### PR TITLE
Refactored netcdf datasource

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,14 @@ threedi-qgis-plugin changelog
 0.7.2 (unreleased)
 ------------------
 
+- Refactored timeseries methods of NetcdfDataSource.
+
 - Add Layer Manager, which loads the model and result layers.
 
 - Add map animator for showing results on the map (first version, work in progress).
 
 - Made the parameter config variable for the Graph and Map animator tools. Add
- parameters so almost all results from netCDF and result netCDF can be displayed.
+  parameters so almost all results from netCDF and result netCDF can be displayed.
 
 - Optimizations in getting the time array from netCDF.
 
@@ -29,7 +31,7 @@ threedi-qgis-plugin changelog
 
 - Updated NetcdfDataSource so that it keeps some netCDF attributes in memory.
 
-- Stores selected model and results in Qgs project file (*.qgs).
+- Stores selected model and results in Qgs project file (\*.qgs).
 
 - Cache generated model layers in spatialite.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ threedi-qgis-plugin changelog
 0.7.2 (unreleased)
 ------------------
 
-- Refactored timeseries methods of NetcdfDataSource.
+- Refactored timeseries methods of NetcdfDataSource, more consistent
+  ``get_values_of`` methods.
+
+- Made ``get_timeseries`` only accept one netCDF variable name.
 
 - Add Layer Manager, which loads the model and result layers.
 

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -612,7 +612,7 @@ class NetcdfDataSource(object):
         n_object_type = normalized_object_type(object_type)
 
         # Derive the netcdf id
-        netcdf_ids = range(len(object_ids))  # copy the list
+        netcdf_ids = range(len(object_ids))  # init a list
         for i, obj_id in enumerate(object_ids):
             netcdf_ids[i] = self.obj_to_netcdf_id(obj_id, n_object_type)
         # netcdf_id = self.obj_to_netcdf_id(object_id, n_object_type)

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -158,6 +158,7 @@ layer_qh_type_mapping = dict([(a[0], a[2]) for a in layer_information])
 PUMPLIKE_OBJECTS = ['pumpstation', 'pumpline']
 
 
+# TODO: use this for pumps still? Currently unused.
 def get_variable(object_type=None, parameter=None):
     """Get datasource variable names.
 

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -392,13 +392,13 @@ class NetcdfDataSource(object):
     @cached_property
     def available_subgrid_map_vars(self):
         return self.get_available_variables(
-            only_subgrid_map=True)['subgrid_map']
+            only_subgrid_map=True)
 
     @cached_property
     def available_aggregation_vars(self):
         try:
             _vars = self.get_available_variables(
-                only_aggregation=True)['aggregation']
+                only_aggregation=True)
         except IndexError:
             # If we're here it means no agg. netCDF was found. Fail without
             # error, but do log it.
@@ -443,15 +443,15 @@ class NetcdfDataSource(object):
             a dict with entries for subgrid_map and aggregation vars
         """
         do_all = not any([only_subgrid_map, only_aggregation])
-        result = dict()
+        available_vars = []
 
         if do_all or only_subgrid_map:
             possible_subgrid_map_vars = [v for v, _, _ in
                                          SUBGRID_MAP_VARIABLES]
             subgrid_map_vars = self.ds.variables.keys()
             available_subgrid_map_vars = [v for v in possible_subgrid_map_vars
-                                              if v in set(subgrid_map_vars)]
-            result['subgrid_map'] = list(available_subgrid_map_vars)
+                                          if v in subgrid_map_vars]
+            available_vars += available_subgrid_map_vars
         if do_all or only_aggregation:
             possible_agg_vars = [product_and_concat([v]) for v, _, _ in
                                  AGGREGATION_VARIABLES]
@@ -459,10 +459,10 @@ class NetcdfDataSource(object):
             possible_agg_vars = [item for sublist in possible_agg_vars for
                                  item in sublist]
             agg_vars = self.ds_aggregation.variables.keys()
-            available_agg_vars = set(
-                possible_agg_vars).intersection(set(agg_vars))
-            result['aggregation'] = list(available_agg_vars)
-        return result
+            available_agg_vars = [v for v in possible_agg_vars if v in
+                                  agg_vars]
+            available_vars += available_agg_vars
+        return available_vars
 
     def get_object(self, object_type, object_id):
         pass

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -137,54 +137,8 @@ layer_information = [
 
 ]
 
-# Map a generic parameter to the netCDF variable name. Because the parameters
-# we've chosen are almost always analogous to the real netCDF variable names
-# (e.g. 's1', 'vol', 'q') only exceptional cases are listed here, which in
-# practise means only mapping q to q_pump for pumps.
-PARAMETER_TO_VARIABLE = {
-    'pumpstation': {
-        'q': 'q_pump',
-        'q_pump': 'q_pump',
-        },
-    'pumpline': {
-        'q': 'q_pump',
-        'q_pump': 'q_pump',
-        },
-    }
-
 layer_object_type_mapping = dict([(a[0], a[1]) for a in layer_information])
 layer_qh_type_mapping = dict([(a[0], a[2]) for a in layer_information])
-
-PUMPLIKE_OBJECTS = ['pumpstation', 'pumpline']
-
-
-# TODO: use this for pumps still? Currently unused.
-def get_variable(object_type=None, parameter=None):
-    """Get datasource variable names.
-
-    Note: basically returns the parameters unaltered, except for pumps.
-    For pumps it does additionaly checks if it's a agg var.
-    """
-    # See if there is a mapping, else use to the original parameter
-    try:
-        param_map = PARAMETER_TO_VARIABLE[object_type]
-    except KeyError:
-        return parameter
-    else:
-        # We know there is a mapping, now test if it is a agg var.
-        splitted = parameter.rsplit('_', 1)
-        if splitted[0] in AGGREGATION_OPTIONS:
-            # It's an agg method, now check if the variable is supported.
-            # E.g. 'u1_avg' is not supported by pumps, so we then raise an
-            # exception.
-            if splitted[1] in param_map.keys():
-                return parameter
-            else:
-                raise ValueError("Unsupported combination %s - %s " % (
-                    object_type, parameter))
-        else:
-            raise ValueError("Unsupported combination %s - %s " % (
-                object_type, parameter))
 
 
 def normalized_object_type(current_layer_name):
@@ -656,13 +610,13 @@ class NetcdfDataSource(object):
         # Convert row array to regular array.
         return vals[:, 0]
 
-    def get_values_by_timestamp(self, variable, timestamp_idx):
+    def get_values_by_timestep_nr(self, variable, timestep_nr):
         """Horizontal slice over the element indices, i.e., get all values for
         all nodes or flowlines for a specific timestamp.
 
         Args:
             variable: the netCDF variable name
-            timestamp_idx: timestamp index
+            timestep_nr: the timestep index
         """
         if variable in self.available_subgrid_map_vars:
             ds = self.ds
@@ -671,4 +625,4 @@ class NetcdfDataSource(object):
         else:
             # todo: warning
             return
-        return ds.variables[variable][timestamp_idx, :]
+        return ds.variables[variable][timestep_nr, :]

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -572,17 +572,25 @@ class NetcdfDataSource(object):
 
         # Get values
         if variable in self.available_subgrid_map_vars:
-            vals = self.ds.variables[variable][:, netcdf_id]
+            ds = self.ds
             timestamps = self.timestamps
         elif variable in self.available_aggregation_vars:
-            vals = self.ds_aggregation.variables[variable][:, netcdf_id]
+            ds = self.ds_aggregation
             timestamps = self.get_agg_var_timestamps(variable)
         else:
             raise ValueError("Invalid variable: %s" % variable)
 
+        try:
+            vals = ds.variables[variable][:, netcdf_id]
+        except KeyError:
+            log("Variable not in netCDF: %s" % variable)
+            raise
+        except IndexError:
+            log("Id %s not found for %s" % (netcdf_id, variable))
+            raise
+
         # Zip timeseries together in (n,2) array
-        result = np.vstack((timestamps, vals)).T
-        return result
+        return np.vstack((timestamps, vals)).T
 
     def get_timeseries_values(self, object_type, object_id, parameter,
                               caching=True):

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -656,15 +656,19 @@ class NetcdfDataSource(object):
         # Convert row array to regular array.
         return vals[:, 0]
 
-    def get_values_by_timestamp(self, parameter, timestamp):
+    def get_values_by_timestamp(self, variable, timestamp_idx):
         """Horizontal slice over the element indices, i.e., get all values for
         all nodes or flowlines for a specific timestamp.
+
+        Args:
+            variable: the netCDF variable name
+            timestamp_idx: timestamp index
         """
-        if parameter in self.available_subgrid_map_vars:
+        if variable in self.available_subgrid_map_vars:
             ds = self.ds
-        elif parameter in self.available_aggregation_vars:
+        elif variable in self.available_aggregation_vars:
             ds = self.ds_aggregation
         else:
             # todo: warning
             return
-        return ds.variables[parameter][timestamp, :]
+        return ds.variables[variable][timestamp_idx, :]

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -646,8 +646,7 @@ class NetcdfDataSource(object):
             raise
         return vals
 
-    def get_values_by_id(self, variable, object_type, object_id,
-                         caching=True):
+    def get_values_by_id(self, variable, object_type, object_id, caching=True):
         """Convenience method to get a regular array if only one ID is needed.
         """
         vals = self.get_values_by_ids(variable=variable,

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -607,23 +607,17 @@ class NetcdfDataSource(object):
 
     # TODO: doesn't work with agg vars yet?
     def get_timeseries_values(self, object_type, object_id, parameters,
-                              source='default', caching=True):
+                              caching=True):
         """Get a list of time series from netcdf; only the values.
 
         Note: you can have multiple parameters, all result values are put
         into a dict under the corresponding key of the parameter. If a
         parameter is unknown it will be skipped.
 
-        Note 2: source defines the netcdf file source we should get our data
-        from, because the NetcdfDataSource can contain the default netcdf
-        but also an aggregation netcdf.
-
         Args:
             object_type: e.g. 'v2_weir'
             object_id: spatialite id
             parameters: a list of params, e.g.: ['q', 'q_pump']
-            source: the netcdf source type, i.e., 'default' (subgrid_map.nc)
-                or 'aggregation' (flow_aggregate.nc)
             caching: if True, keep netcdf array in memory
 
         Important note: using True instead of False as a default for the
@@ -677,16 +671,15 @@ class NetcdfDataSource(object):
             timeseries_vals[v] = vals
         return timeseries_vals
 
-    def get_values_timestamp(self, parameter, timestamp,
-                              source='default'):
-
-        v = parameter
-        if v in self.available_subgrid_map_vars:
+    def get_values_by_timestamp(self, parameter, timestamp):
+        """Horizontal slice over the element indices, i.e., get all values for
+        all nodes or flowlines for a specific timestamp.
+        """
+        if parameter in self.available_subgrid_map_vars:
             ds = self.ds
-        elif v in self.available_aggregation_vars:
+        elif parameter in self.available_aggregation_vars:
             ds = self.ds_aggregation
         else:
             # todo: warning
             return
-
-        return ds.variables[v][timestamp, :]
+        return ds.variables[parameter][timestamp, :]

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -576,7 +576,7 @@ class NetcdfDataSource(object):
             timestamps = self.timestamps
         elif variable in self.available_aggregation_vars:
             vals = self.ds_aggregation.variables[variable][:, netcdf_id]
-            timestamps = self.get_agg_var_timestamps(v)
+            timestamps = self.get_agg_var_timestamps(variable)
         else:
             raise ValueError("Invalid variable: %s" % variable)
 

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -607,7 +607,7 @@ class NetcdfDataSource(object):
         'caching' kwarg makes this method much faster. Branch prediction?
 
         Returns:
-            a dict of arrays of values
+            a 1d array
         """
         # Normalize the name
         n_object_type = normalized_object_type(object_type)

--- a/models/graph.py
+++ b/models/graph.py
@@ -52,7 +52,7 @@ def select_default_color(item_field):
         return colors.values()[0]
 
     # predefined colors are all used, return random color
-    return (randint(0,256), randint(0,256), randint(0,256))
+    return (randint(0, 256), randint(0, 256), randint(0, 256))
 
 
 class LocationTimeseriesModel(BaseModel):
@@ -92,17 +92,16 @@ class LocationTimeseriesModel(BaseModel):
             result_key = str(self.model.datasource.rows[result_ds_nr])
             if not str(parameters) in self._plots:
                 self._plots[str(parameters)] = {}
-            if not result_key in self._plots[str(parameters)]:
+            if result_key not in self._plots[str(parameters)]:
                 ts_table = self.timeseries_table(parameters=parameters,
                                                  result_ds_nr=result_ds_nr)
-                pattern = self.model.datasource.rows[result_ds_nr].\
-                                                    pattern.value
+                pattern = self.model.datasource.rows[
+                    result_ds_nr].pattern.value
                 pen = pg.mkPen(color=self.color.qvalue,
                                width=2,
                                style=pattern)
-
                 self._plots[str(parameters)][result_key] = \
-                        pg.PlotDataItem(ts_table, pen=pen)
+                    pg.PlotDataItem(ts_table, pen=pen)
 
             return self._plots[str(parameters)][result_key]
 
@@ -113,19 +112,18 @@ class LocationTimeseriesModel(BaseModel):
             :param parameters:
             :param result_ds_nr:
             :return: numpy array with timestamp, values
-
-            NOTE: all timeseries of the different parameters will be lumped
-            together. However, at the moment, nowhere in the code is this
-            function called with more than 1 parameter.
             """
             float_data = []
-            for param, timeseries in self.model.datasource.rows[result_ds_nr]\
-                    .datasource().get_timeseries(
-                        self.object_type.value, self.object_id.value,
-                        parameters).items():
-                for t, v in timeseries:
-                    # value data may come back as 'NULL' string; convert
-                    # it to None or else convert it to float
-                    v = None if v == 'NULL' else float(v)
-                    float_data.append((float(t), v))
+            timeseries = self.model.datasource.rows[result_ds_nr]\
+                .datasource().get_timeseries(
+                    self.object_type.value,
+                    self.object_id.value,
+                    parameters)
+
+            for t, v in timeseries:
+                # value data may come back as 'NULL' string; convert
+                # it to None or else convert it to float
+                v = None if v == 'NULL' else float(v)
+                float_data.append((float(t), v))
+
             return np.array(float_data, dtype=float)

--- a/stats/ncstats.py
+++ b/stats/ncstats.py
@@ -68,7 +68,7 @@ class NcStats(object):
         can be negative, so the absolute values are used.
         """
         q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['q'])['q']
+            structure_type, obj_id, 'q')
         q_slice = np.absolute(q_slice)
         # calc total vol thru structure
         vols = self.timesteps * q_slice[0:-1]
@@ -77,7 +77,7 @@ class NcStats(object):
     def tot_vol_positive(self, structure_type, obj_id):
         """Total volume through structure, counting only positive q's."""
         q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['q'])['q']
+            structure_type, obj_id, 'q')
         # mask negative values
         ma_q_slice = np.ma.masked_where(q_slice < 0, q_slice)
         # calc total vol thru structure
@@ -87,7 +87,7 @@ class NcStats(object):
     def tot_vol_negative(self, structure_type, obj_id):
         """Total volume through structure, counting only negative q's."""
         q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['q'])['q']
+            structure_type, obj_id, 'q')
         # mask positive values
         ma_q_slice = np.ma.masked_where(q_slice > 0, q_slice)
         # calc total vol thru structure
@@ -98,7 +98,7 @@ class NcStats(object):
         """Maximum value of a q timeseries; can be negative.
         """
         q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['q'])['q']
+            structure_type, obj_id, 'q')
         _min = q_slice.min()
         _max = q_slice.max()
         # return highest absolute value, while retaining the sign of the number
@@ -108,7 +108,7 @@ class NcStats(object):
         """The time at maximum value of a q timeseries
         """
         q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['q'])['q']
+            structure_type, obj_id, 'q')
         _min = q_slice.min()
         _max = q_slice.max()
         # return highest absolute value, while retaining the sign of the number
@@ -119,7 +119,7 @@ class NcStats(object):
     def s1_max(self, structure_type, obj_id):
         """Maximum value of a s1 timeseries."""
         s1_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['s1'])['s1']
+            structure_type, obj_id, 's1')
         return s1_slice.max()
 
     def q_cumulative_duration(self, structure_type, obj_id, threshold=None):
@@ -129,7 +129,7 @@ class NcStats(object):
             # TODO: q values can be vary small, maybe add a threshold??
             raise NotImplementedError()
         q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['q'])['q']
+            structure_type, obj_id, 'q')
 
         # normalize nonzero qs to 1, so it becomes a binary representation
         # of q, which we can simply multiply with the timesteps
@@ -144,7 +144,7 @@ class NcStats(object):
         This means, count the timesteps where s1 - surface level > 0.
         """
         s1_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['s1'])['s1']
+            structure_type, obj_id, 's1')
 
         water_op_straat = s1_slice - surface_level
 
@@ -159,7 +159,7 @@ class NcStats(object):
         """q at last timeSTAMP (!= timestep)
         """
         q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, ['q'])['q']
+            structure_type, obj_id, 'q')
         return q_slice[-1]
 
     def get_value_from_parameter(

--- a/stats/ncstats.py
+++ b/stats/ncstats.py
@@ -67,8 +67,8 @@ class NcStats(object):
         element is another option, but not implemented here). Also note that q
         can be negative, so the absolute values are used.
         """
-        q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 'q')
+        q_slice = self.datasource.get_values_by_id(
+            'q', structure_type, object_id=obj_id)
         q_slice = np.absolute(q_slice)
         # calc total vol thru structure
         vols = self.timesteps * q_slice[0:-1]
@@ -76,8 +76,8 @@ class NcStats(object):
 
     def tot_vol_positive(self, structure_type, obj_id):
         """Total volume through structure, counting only positive q's."""
-        q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 'q')
+        q_slice = self.datasource.get_values_by_id(
+            'q', structure_type, object_id=obj_id)
         # mask negative values
         ma_q_slice = np.ma.masked_where(q_slice < 0, q_slice)
         # calc total vol thru structure
@@ -86,8 +86,8 @@ class NcStats(object):
 
     def tot_vol_negative(self, structure_type, obj_id):
         """Total volume through structure, counting only negative q's."""
-        q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 'q')
+        q_slice = self.datasource.get_values_by_id(
+            'q', structure_type, object_id=obj_id)
         # mask positive values
         ma_q_slice = np.ma.masked_where(q_slice > 0, q_slice)
         # calc total vol thru structure
@@ -97,8 +97,8 @@ class NcStats(object):
     def q_max(self, structure_type, obj_id):
         """Maximum value of a q timeseries; can be negative.
         """
-        q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 'q')
+        q_slice = self.datasource.get_values_by_id(
+            'q', structure_type, object_id=obj_id)
         _min = q_slice.min()
         _max = q_slice.max()
         # return highest absolute value, while retaining the sign of the number
@@ -107,8 +107,8 @@ class NcStats(object):
     def time_q_max(self, structure_type, obj_id):
         """The time at maximum value of a q timeseries
         """
-        q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 'q')
+        q_slice = self.datasource.get_values_by_id(
+            'q', structure_type, object_id=obj_id)
         _min = q_slice.min()
         _max = q_slice.max()
         # return highest absolute value, while retaining the sign of the number
@@ -118,8 +118,8 @@ class NcStats(object):
 
     def s1_max(self, structure_type, obj_id):
         """Maximum value of a s1 timeseries."""
-        s1_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 's1')
+        s1_slice = self.datasource.get_values_by_id(
+            's1', structure_type, object_id=obj_id)
         return s1_slice.max()
 
     def q_cumulative_duration(self, structure_type, obj_id, threshold=None):
@@ -128,8 +128,8 @@ class NcStats(object):
         if threshold:
             # TODO: q values can be vary small, maybe add a threshold??
             raise NotImplementedError()
-        q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 'q')
+        q_slice = self.datasource.get_values_by_id(
+            'q', structure_type, object_id=obj_id)
 
         # normalize nonzero qs to 1, so it becomes a binary representation
         # of q, which we can simply multiply with the timesteps
@@ -143,8 +143,8 @@ class NcStats(object):
 
         This means, count the timesteps where s1 - surface level > 0.
         """
-        s1_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 's1')
+        s1_slice = self.datasource.get_values_by_id(
+            's1', structure_type, object_id=obj_id)
 
         water_op_straat = s1_slice - surface_level
 
@@ -158,8 +158,8 @@ class NcStats(object):
     def q_end(self, structure_type, obj_id):
         """q at last timeSTAMP (!= timestep)
         """
-        q_slice = self.datasource.get_timeseries_values(
-            structure_type, obj_id, 'q')
+        q_slice = self.datasource.get_values_by_id(
+            'q', structure_type, object_id=obj_id)
         return q_slice[-1]
 
     def get_value_from_parameter(

--- a/test/test_datasources.py
+++ b/test/test_datasources.py
@@ -11,7 +11,7 @@ from qgis.core import (
     QgsVectorLayer, QgsFeature, QgsPoint, QgsField, QgsGeometry)
 from PyQt4.QtCore import QVariant
 
-from ThreeDiToolbox.datasource.netcdf import NetcdfDataSource, get_variables
+from ThreeDiToolbox.datasource.netcdf import NetcdfDataSource
 try:
     from ThreeDiToolbox.datasource.spatialite import Spatialite
 except ImportError:
@@ -27,24 +27,6 @@ spatialite_datasource_path = os.path.join(
 netcdf_datasource_path = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     'data', 'testmodel', 'results', 'subgrid_map.nc')
-
-
-class TestParameters(unittest.TestCase):
-    """Test functions that convert parameters to variable names in the
-    datasource."""
-
-    def test_get_variables(self):
-        vars = get_variables(object_type='pipe', parameters=['q'])
-        self.assertEqual(vars, ['q'])
-
-    def test_get_variables2(self):
-        """Get both u variable names for backwards compatability."""
-        vars = get_variables('pipe', ['u1'])
-        self.assertEqual(vars, ['u1'])
-
-    def test_get_variables3(self):
-        vars = get_variables('pumpstation', ['q'])
-        self.assertEqual(vars, ['q_pump'])
 
 
 @unittest.skipIf(not os.path.exists(netcdf_datasource_path),

--- a/views/graph.py
+++ b/views/graph.py
@@ -6,7 +6,6 @@ from PyQt4.QtGui import (
     QSizePolicy, QPushButton, QSpacerItem, QApplication, QTabWidget,
     QDockWidget, QComboBox, QMessageBox)
 
-import pyqtgraph as pg
 from qgis.core import (QgsDataSourceURI, QgsFeatureRequest, QGis,
                        QgsCoordinateTransform, QgsCoordinateReferenceSystem)
 from qgis.gui import (QgsVertexMarker, QgsRubberBand)
@@ -24,13 +23,13 @@ from ..datasource.netcdf import (
 
 # GraphDockWidget labels related parameters.
 parameter_config = {
-    'q': [{'name': 'Debiet', 'unit': 'm3/s', 'parameters': ['q']},
-          {'name': 'Snelheid', 'unit': 'm/s', 'parameters': ['u1']},
-          {'name': 'Debiet interflow', 'unit': 'm3/s', 'parameters': ['qp']},
-          {'name': 'Snelheid interflow', 'unit': 'm/s', 'parameters': ['up1']}
+    'q': [{'name': 'Debiet', 'unit': 'm3/s', 'parameters': 'q'},
+          {'name': 'Snelheid', 'unit': 'm/s', 'parameters': 'u1'},
+          {'name': 'Debiet interflow', 'unit': 'm3/s', 'parameters': 'qp'},
+          {'name': 'Snelheid interflow', 'unit': 'm/s', 'parameters': 'up1'}
           ],
-    'h': [{'name': 'Waterstand', 'unit': 'mNAP', 'parameters': ['s1']},
-          {'name': 'Volume', 'unit': 'm3', 'parameters': ['vol']}
+    'h': [{'name': 'Waterstand', 'unit': 'mNAP', 'parameters': 's1'},
+          {'name': 'Volume', 'unit': 'm3', 'parameters': 'vol'}
           ]
 }
 
@@ -58,7 +57,7 @@ def generate_parameter_config(subgrid_map_vars, agg_vars):
     for varname in subgrid_map_vars:
         varinfo = subgrid_map_vars_mapping[varname]
         d = {'name': varinfo[0].capitalize(), 'unit': varinfo[1],
-             'parameters': [varname]}
+             'parameters': varname}
         if varname in Q_TYPES:
             config['q'].append(d)
         elif varname in H_TYPES:
@@ -76,7 +75,7 @@ def generate_parameter_config(subgrid_map_vars, agg_vars):
             unit = varinfo[1]
 
         d = {'name': '%s %s' % (agg_method.capitalize(), varinfo[0]),
-             'unit': unit, 'parameters': [aggvarname]}
+             'unit': unit, 'parameters': aggvarname}
         if _varname in Q_TYPES:
             config['q'].append(d)
         elif _varname in H_TYPES:

--- a/views/graph.py
+++ b/views/graph.py
@@ -21,19 +21,6 @@ from ..datasource.netcdf import (
     CUMULATIVE_AGGREGATION_UNITS)
 
 
-# GraphDockWidget labels related parameters.
-parameter_config = {
-    'q': [{'name': 'Debiet', 'unit': 'm3/s', 'parameters': 'q'},
-          {'name': 'Snelheid', 'unit': 'm/s', 'parameters': 'u1'},
-          {'name': 'Debiet interflow', 'unit': 'm3/s', 'parameters': 'qp'},
-          {'name': 'Snelheid interflow', 'unit': 'm/s', 'parameters': 'up1'}
-          ],
-    'h': [{'name': 'Waterstand', 'unit': 'mNAP', 'parameters': 's1'},
-          {'name': 'Volume', 'unit': 'm3', 'parameters': 'vol'}
-          ]
-}
-
-
 def generate_parameter_config(subgrid_map_vars, agg_vars):
     """Dynamically create the parameter config.
 

--- a/views/map_animator.py
+++ b/views/map_animator.py
@@ -199,7 +199,7 @@ class MapAnimator(QWidget):
 
         result = self.root_tool.timeslider_widget.active_datasource
 
-        timestamp_nr = self.root_tool.timeslider_widget.value()
+        timestep_nr = self.root_tool.timeslider_widget.value()
 
         ds = result.datasource()
 
@@ -209,9 +209,9 @@ class MapAnimator(QWidget):
 
             provider = layer.dataProvider()
 
-            values = ds.get_values_by_timestamp(parameter[0], timestamp_nr)
+            values = ds.get_values_by_timestep_nr(parameter, timestep_nr)
             if stat == 'diff':
-                values = values - ds.get_values_by_timestamp(parameter[0], 0)
+                values = values - ds.get_values_by_timestep_nr(parameter, 0)
             elif stat == 'abs':
                 values = np.fabs(values)
 

--- a/views/map_animator.py
+++ b/views/map_animator.py
@@ -209,9 +209,9 @@ class MapAnimator(QWidget):
 
             provider = layer.dataProvider()
 
-            values = ds.get_values_timestamp(parameter[0], timestamp_nr)
+            values = ds.get_values_by_timestamp(parameter[0], timestamp_nr)
             if stat == 'diff':
-                values = values - ds.get_values_timestamp(parameter[0], 0)
+                values = values - ds.get_values_by_timestamp(parameter[0], 0)
             elif stat == 'abs':
                 values = np.fabs(values)
 

--- a/views/sideview.py
+++ b/views/sideview.py
@@ -627,12 +627,12 @@ class SideViewPlotWidget(pg.PlotWidget):
                     if python_value(node['idx']) is not None:
                         ts = ds.get_timeseries('nodes',
                                                int(node['nr']),
-                                               ['s1'])
+                                               's1')
                     else:
                         ts = ds.get_timeseries('v2_connection_nodes',
                                                node['id'],
-                                               ['s1'])
-                    node['timeseries'] = ts['s1']
+                                               's1')
+                    node['timeseries'] = ts
                 except KeyError:
                     node['timeseries'] = None
 

--- a/views/sideview.py
+++ b/views/sideview.py
@@ -618,20 +618,16 @@ class SideViewPlotWidget(pg.PlotWidget):
             self.sideview_nodes = []
 
     def update_water_level_cache(self):
-
         ds_item = self.time_slider.get_current_ts_datasource_item()
         if ds_item:
             ds = ds_item.datasource()
             for node in self.sideview_nodes:
                 try:
                     if python_value(node['idx']) is not None:
-                        ts = ds.get_timeseries('nodes',
-                                               int(node['nr']),
-                                               's1')
+                        ts = ds.get_timeseries('nodes', int(node['nr']), 's1')
                     else:
                         ts = ds.get_timeseries('v2_connection_nodes',
-                                               node['id'],
-                                               's1')
+                                               node['id'], 's1')
                     node['timeseries'] = ts
                 except KeyError:
                     node['timeseries'] = None
@@ -639,7 +635,7 @@ class SideViewPlotWidget(pg.PlotWidget):
             self.draw_waterlevel_line()
 
         else:
-             # reset water level line
+            # reset water level line
             ts_table = np.array(np.array([(0.0, np.nan)]), dtype=float)
             self.water_level_plot.setData(ts_table)
 


### PR DESCRIPTION
Made things more consistent in NetcdfDataSource. The following methods are now available:

```
+ get_values_by_ids (a list of ids)
+ get_values_by_id (convenience method if you want just one id)
+ get_values_by_timestep_nr (by timestep index)
```

Furthermore, `get_timeseries` now only accepts one variable and not a list of variables anymore.
