### PR TITLE
Bugfix relpath

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ threedi-qgis-plugin changelog
 0.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Bugfix relative path exception.
 
 
 0.8.1 (2016-09-13)

--- a/utils/qprojects.py
+++ b/utils/qprojects.py
@@ -253,6 +253,6 @@ class ProjectStateMixin(object):
                         value = self._get_relative_path(value)
                     except ValueError:
                         # Empty file path, not sure about this solution...
-                        value = value
+                        pass
 
             QgsProject.instance().writeEntry(name, key, value)

--- a/utils/qprojects.py
+++ b/utils/qprojects.py
@@ -250,9 +250,9 @@ class ProjectStateMixin(object):
                     # relative path under original key
                     QgsProject.instance().writeEntry(name, 'abs_' + key, value)
                     try:
-                        _value = self._get_relative_path(value)
+                        value = self._get_relative_path(value)
                     except ValueError:
                         # Empty file path, not sure about this solution...
-                        _value = value
+                        value = value
 
-            QgsProject.instance().writeEntry(name, key, _value)
+            QgsProject.instance().writeEntry(name, key, value)

--- a/utils/qprojects.py
+++ b/utils/qprojects.py
@@ -149,7 +149,7 @@ class ProjectStateMixin(object):
     def _get_relative_path(self, file_path):
         proj = QgsProject.instance()
         home = proj.homePath()
-        if len(str(home)) > 0 and len(str(file_path)) > 0:
+        if len(str(home)) > 0:
             rel_path = os.path.relpath(file_path, home)
         else:
             rel_path = file_path
@@ -239,9 +239,7 @@ class ProjectStateMixin(object):
         else:
             value = value_list[0]
 
-
         name = self.get_tool_state_name(tool_name)
-
 
         if type(value) == float:
             QgsProject.instance().writeEntryDouble(name, key, value)
@@ -251,6 +249,10 @@ class ProjectStateMixin(object):
                     # type is file, store absolute path under extra key and
                     # relative path under original key
                     QgsProject.instance().writeEntry(name, 'abs_' + key, value)
-                    value = self._get_relative_path(value)
+                    try:
+                        _value = self._get_relative_path(value)
+                    except ValueError:
+                        # Empty file path, not sure about this solution...
+                        _value = value
 
-            QgsProject.instance().writeEntry(name, key, value)
+            QgsProject.instance().writeEntry(name, key, _value)

--- a/utils/qprojects.py
+++ b/utils/qprojects.py
@@ -149,7 +149,7 @@ class ProjectStateMixin(object):
     def _get_relative_path(self, file_path):
         proj = QgsProject.instance()
         home = proj.homePath()
-        if len(str(home)) > 0:
+        if len(str(home)) > 0 and len(str(file_path)) > 0:
             rel_path = os.path.relpath(file_path, home)
         else:
             rel_path = file_path


### PR DESCRIPTION
If `file_path` is empty it gives a ValueError. This PR does a check on this, but I'm not completely sure if this is correct.

This issue: https://github.com/nens/threedi-qgis-plugin/issues/77
