### PR TITLE
removed auto add fields

### DIFF
--- a/sql_models/model_schematisation.py
+++ b/sql_models/model_schematisation.py
@@ -76,8 +76,7 @@ class ConnectionNode(Base):
                                  nullable=True)
 
     # extra fields:
-    code = Column(String(100), default='', nullable=False)
-    _basin_code = Column(String(4), nullable=True)
+    code = Column(String(100), default='', nullable=True)
 
     manhole = relationship("Manhole",
                            uselist=False,

--- a/utils/import_sufhyd.py
+++ b/utils/import_sufhyd.py
@@ -88,7 +88,7 @@ class Importer(object):
             main function for performing all import tasks
         """
 
-        self.db.create_and_check_fields()
+        # self.db.create_and_check_fields()
 
         if self.file_type == 'sufhyd':
             data = self.load_sufhyd_data()
@@ -301,7 +301,6 @@ class Importer(object):
                     data['manholes'].append({
                         'code': bound_code,
                         'display_name': bound_code,
-                        '_basin_code': '',
                         'width': 1.0,
                         'length': 1.0,
                         'shape': Constants.MANHOLE_SHAPE_SQUARE,
@@ -401,8 +400,7 @@ class Importer(object):
                             srid)
             con_list.append(ConnectionNode(code=manhole['code'],
                             storage_area=manhole['storage_area'],
-                            the_geom="srid={0};{1}".format(srid, wkt),
-                            _basin_code=manhole['_basin_code']))
+                            the_geom="srid={0};{1}".format(srid, wkt)))
 
         session.bulk_save_objects(con_list)
         session.commit()
@@ -435,7 +433,6 @@ class Importer(object):
         man_list = []
         for manhole in data['manholes']:
             del manhole['geom']
-            del manhole['_basin_code']
             del manhole['storage_area']
 
             manhole['connection_node_id'] = con_dict[manhole['code']]

--- a/utils/importer/sufhyd.py
+++ b/utils/importer/sufhyd.py
@@ -283,7 +283,6 @@ class SufhydReader(object):
         manhole = {
             'code': code,
             'display_name': code,
-            '_basin_code': get_value(knp.ide_geb),
             'geom': point(multiply(knp.knp_xco, 0.001),
                           multiply(knp.knp_yco, 0.001),
                           28992),


### PR DESCRIPTION
Automatically adding fields is not needed anymore, the code fields are now in the model. To prevent conflicts with the django migration and make error messages for older database more specific, this function has turned off.  

for sufhyd import
- removed adding missing fields automatically (required fields like code
are now standard);
- removed additional field '_basin_code'