### PR TITLE
bugfix use index in get_values_by_timestep_nr  of NetcdfDataSource

### DIFF
--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -609,7 +609,7 @@ class NetcdfDataSource(object):
         else:
             # todo: warning
             return
-        if index:
+        if index is not None:
             return ds.variables[variable][timestamp_idx, index]
         else:
             return ds.variables[variable][timestamp_idx, :]


### PR DESCRIPTION
NetcdfDataSource returns an error when using the index in the function get_values_by_timestep_nr. 
The index is an numpy array, which returns an error when forced to bool (try: (bool(index) - this doesn't work because numpy would like to evaluate all elements).
Check 'is None' works fine.