### PR TITLE
Madeleine fix no table control

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ threedi-qgis-plugin changelog
 0.14 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix adding new table control to empty v2_control_table.
 
 
 0.13 (2017-10-23)

--- a/threedi_schema_edits/controlled_structures.py
+++ b/threedi_schema_edits/controlled_structures.py
@@ -194,9 +194,10 @@ class ControlledStructures(object):
         # In this case, max_id_control_table is set to 0 to prevent
         # TypeErrors when adding 1 to create new_id_control_table.
         attribute_name = "MAX(id)"
-        max_id_control_table = int(self.get_attributes(
-            table_name, attribute_name)[0])
-        if not max_id_control_table:
+        try:
+            max_id_control_table = int(self.get_attributes(
+                table_name, attribute_name)[0])
+        except ValueError:
             max_id_control_table = 0
         new_id_control_table = max_id_control_table + 1
         # Insert the variables in the v2_control_table


### PR DESCRIPTION
Fix adding new table control to empty v2_control_table.

Creating a new table control with an empty v2_control_table no longer gives an error.