### PR TITLE
Madeleine delete measuring stations, measuring groups, rules and control groups from database

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ threedi-qgis-plugin changelog
 0.14 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Removing measuring stations in the 'Measuring station' tab also removes them from the database.
 
 
 0.13 (2017-10-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ threedi-qgis-plugin changelog
 0.14 (unreleased)
 -----------------
 
+- Make it possible to delete measuring group from the database and from view with the 'Delete button'.
+
 - Removing measuring stations in the 'Measuring station' tab also removes them from the database.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ threedi-qgis-plugin changelog
 0.14 (unreleased)
 -----------------
 
+- Also make it possible to delete control groups from the database and from view with the 'Delete button' in the 'Control group' tab.
+
 - Also make it possible to delete rule from the database and from view with the 'Delete button' in the 'Rule' tab.
 
 - Make it possible to delete measuring group from the database and from view with the 'Delete button in the 'Measuring group' tab.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ threedi-qgis-plugin changelog
 0.14 (unreleased)
 -----------------
 
-- Make it possible to delete measuring group from the database and from view with the 'Delete button'.
+- Also make it possible to delete rule from the database and from view with the 'Delete button' in the 'Rule' tab.
+
+- Make it possible to delete measuring group from the database and from view with the 'Delete button in the 'Measuring group' tab.
 
 - Removing measuring stations in the 'Measuring station' tab also removes them from the database.
 

--- a/commands/Tools/Step 3 - Modify schematisation/control_structures.py
+++ b/commands/Tools/Step 3 - Modify schematisation/control_structures.py
@@ -356,6 +356,22 @@ class CustomCommand(CustomCommandBase):
         tablewidget = self.dockwidget_controlled_structures\
             .tablewidget_measuring_point
         row_number = tablewidget.currentRow()
+        # Get id of measuring point
+        measuring_point_id = tablewidget.item(row_number, 0).text()
+        # Remove measuring point from database
+        db_key = self.dockwidget_controlled_structures\
+            .combobox_input_model.currentText()  # name of database
+        db = get_database_properties(db_key)
+        control_structure = ControlledStructures(
+            flavor=db["db_entry"]['db_type'])
+        control_structure.start_sqalchemy_engine(db["db_settings"])
+        table_name = "v2_control_measure_map"
+        where = " WHERE id = '{}'".format(str(measuring_point_id))
+        control_structure.delete_from_database(
+            table_name=table_name, where=where)
+        # Update measuring point ids
+        self.update_measuring_point_ids(control_structure)
+        # Remove measuring point from dockwidget
         # Don't remove the first row.
         dont_remove = 0
         if row_number != dont_remove:

--- a/threedi_schema_edits/controlled_structures.py
+++ b/threedi_schema_edits/controlled_structures.py
@@ -245,3 +245,31 @@ class ControlledStructures(object):
             msg = "An unknown exception occured: {}".format(e)
             messagebar_message(
                 "Error", msg, level=QgsMessageBar.CRITICAL, duration=5)
+
+    def delete_from_database(self, table_name, where=""):
+        """
+        Function to delete data from a table (table_name).
+
+        Args
+            (str) table_name: The table name of a spatialite or postgres
+                              database
+            (str) where: A where clause for the delete statement.
+        """
+        try:
+            with self.engine.connect() as con:
+                con.execute(
+                    '''DELETE FROM {table}{where};'''.format(
+                        table=table_name, where=where)
+                )
+        except OperationalError as e:
+            msg = str(e)
+            messagebar_message(
+                "Error", msg, level=QgsMessageBar.CRITICAL, duration=5)
+        except ProgrammingError as e:
+            msg = str(e)
+            messagebar_message(
+                "Error", msg, level=QgsMessageBar.CRITICAL, duration=5)
+        except Exception as e:
+            msg = "An unknown exception occured: {}".format(e)
+            messagebar_message(
+                "Error", msg, level=QgsMessageBar.CRITICAL, duration=5)

--- a/ui/control_structures_dockwidget.ui
+++ b/ui/control_structures_dockwidget.ui
@@ -670,7 +670,7 @@
         <x>20</x>
         <y>140</y>
         <width>761</width>
-        <height>361</height>
+        <height>321</height>
        </rect>
       </property>
       <property name="autoFillBackground">
@@ -686,6 +686,29 @@
        <bool>true</bool>
       </property>
      </widget>
+     <widget class="QPushButton" name="pushbutton_control_delete">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>470</y>
+        <width>99</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Delete</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="combobox_input_control_delete">
+      <property name="geometry">
+       <rect>
+        <x>140</x>
+        <y>470</y>
+        <width>201</width>
+        <height>27</height>
+       </rect>
+      </property>
+     </widget>
      <zorder>tab_control_view</zorder>
      <zorder>pushbutton_input_control_new</zorder>
      <zorder>pusbutton_input_control_view</zorder>
@@ -694,6 +717,8 @@
      <zorder>label_input_control_view</zorder>
      <zorder>pushbutton_control_close_all</zorder>
      <zorder>label_input_control_clear</zorder>
+     <zorder>pushbutton_control_delete</zorder>
+     <zorder>combobox_input_control_delete</zorder>
     </widget>
     <widget class="QWidget" name="tab_help">
      <attribute name="title">

--- a/ui/control_structures_dockwidget.ui
+++ b/ui/control_structures_dockwidget.ui
@@ -336,7 +336,7 @@
         <x>20</x>
         <y>140</y>
         <width>761</width>
-        <height>361</height>
+        <height>321</height>
        </rect>
       </property>
       <property name="autoFillBackground">
@@ -350,6 +350,29 @@
       </property>
       <property name="movable">
        <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="pushbutton_input_measuring_group_delete">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>470</y>
+        <width>99</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Delete</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="combobox_input_measuring_group_delete">
+      <property name="geometry">
+       <rect>
+        <x>140</x>
+        <y>470</y>
+        <width>201</width>
+        <height>27</height>
+       </rect>
       </property>
      </widget>
     </widget>

--- a/ui/control_structures_dockwidget.ui
+++ b/ui/control_structures_dockwidget.ui
@@ -375,6 +375,19 @@
        </rect>
       </property>
      </widget>
+     <widget class="QLabel" name="label_input_measuring_group_delete">
+      <property name="geometry">
+       <rect>
+        <x>360</x>
+        <y>470</y>
+        <width>371</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Delete a measuring group from the database.</string>
+      </property>
+     </widget>
     </widget>
     <widget class="QWidget" name="tab_rule">
      <attribute name="title">
@@ -558,6 +571,19 @@
        </property>
       </item>
      </widget>
+     <widget class="QLabel" name="label_input_rule_delete">
+      <property name="geometry">
+       <rect>
+        <x>360</x>
+        <y>470</y>
+        <width>371</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Delete a rule from the database.</string>
+      </property>
+     </widget>
      <zorder>tab_table_control_view</zorder>
      <zorder>pushbutton_input_rule_new</zorder>
      <zorder>combobox_input_rule_type_2</zorder>
@@ -571,6 +597,7 @@
      <zorder>pushbutton_input_rule_delete</zorder>
      <zorder>combobox_input_rule_delete</zorder>
      <zorder>combobox_input_rule_type_delete</zorder>
+     <zorder>label_input_rule_delete</zorder>
     </widget>
     <widget class="QWidget" name="tab_control">
      <attribute name="title">
@@ -709,6 +736,19 @@
        </rect>
       </property>
      </widget>
+     <widget class="QLabel" name="label_input_control_group_delete">
+      <property name="geometry">
+       <rect>
+        <x>360</x>
+        <y>470</y>
+        <width>371</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Delete a control group from the database.</string>
+      </property>
+     </widget>
      <zorder>tab_control_view</zorder>
      <zorder>pushbutton_input_control_new</zorder>
      <zorder>pusbutton_input_control_view</zorder>
@@ -719,6 +759,7 @@
      <zorder>label_input_control_clear</zorder>
      <zorder>pushbutton_control_delete</zorder>
      <zorder>combobox_input_control_delete</zorder>
+     <zorder>label_input_control_group_delete</zorder>
     </widget>
     <widget class="QWidget" name="tab_help">
      <attribute name="title">

--- a/ui/control_structures_dockwidget.ui
+++ b/ui/control_structures_dockwidget.ui
@@ -479,7 +479,7 @@
         <x>20</x>
         <y>140</y>
         <width>761</width>
-        <height>361</height>
+        <height>321</height>
        </rect>
       </property>
       <property name="autoFillBackground">
@@ -520,6 +520,44 @@
        </rect>
       </property>
      </widget>
+     <widget class="QPushButton" name="pushbutton_input_rule_delete">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>470</y>
+        <width>99</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Delete</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="combobox_input_rule_delete">
+      <property name="geometry">
+       <rect>
+        <x>280</x>
+        <y>470</y>
+        <width>61</width>
+        <height>27</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="combobox_input_rule_type_delete">
+      <property name="geometry">
+       <rect>
+        <x>140</x>
+        <y>470</y>
+        <width>121</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <item>
+       <property name="text">
+        <string>table_control</string>
+       </property>
+      </item>
+     </widget>
      <zorder>tab_table_control_view</zorder>
      <zorder>pushbutton_input_rule_new</zorder>
      <zorder>combobox_input_rule_type_2</zorder>
@@ -530,6 +568,9 @@
      <zorder>label_input_rule_clear</zorder>
      <zorder>combobox_input_rule_type_view</zorder>
      <zorder>combobox_input_rule_view</zorder>
+     <zorder>pushbutton_input_rule_delete</zorder>
+     <zorder>combobox_input_rule_delete</zorder>
+     <zorder>combobox_input_rule_type_delete</zorder>
     </widget>
     <widget class="QWidget" name="tab_control">
      <attribute name="title">

--- a/views/control_structures_create_control_group_dialog.py
+++ b/views/control_structures_create_control_group_dialog.py
@@ -257,7 +257,7 @@ class CreateControlGroupDialogWidget(QDialog, FORM_CLASS):
             self.textedit_input_control_description.toPlainText()))
 
         control_group_table = QTableWidget(tab)
-        control_group_table.setGeometry(10, 100, 741, 251)
+        control_group_table.setGeometry(10, 100, 741, 181)
         control_group_table.insertColumn(0)
         control_group_table.setHorizontalHeaderItem(
             0, QTableWidgetItem("measuring_group_id"))

--- a/views/control_structures_create_measuring_group.py
+++ b/views/control_structures_create_measuring_group.py
@@ -224,7 +224,7 @@ class CreateMeasuringGroupDialogWidget(QDialog, FORM_CLASS):
         tab.setLayout(layout)
 
         table_measuring_group = QtGui.QTableWidget(tab)
-        table_measuring_group.setGeometry(10, 10, 741, 306)
+        table_measuring_group.setGeometry(10, 10, 741, 266)
         table_measuring_group.insertColumn(0)
         table_measuring_group.setHorizontalHeaderItem(
             0, QTableWidgetItem("table"))

--- a/views/control_structures_create_table_control_dialog.py
+++ b/views/control_structures_create_table_control_dialog.py
@@ -312,7 +312,7 @@ class CreateTableControlDialogWidget(QDialog, FORM_CLASS):
             self.combobox_input_action_type.currentText()))
 
         table_control_table = QTableWidget(tab)
-        table_control_table.setGeometry(10, 100, 741, 221)
+        table_control_table.setGeometry(10, 100, 741, 181)
         table_control_table.insertColumn(0)
         table_control_table.setHorizontalHeaderItem(
             0, QTableWidgetItem("measuring_value"))


### PR DESCRIPTION
It is now possible to delete
* Measuring stations
* Measuring groups
* Rules
* Control groups

from the database when clicking the Delete button on these tabs.