### PR TITLE
Renier detect h5file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ threedi-qgis-plugin changelog
 - Add h5py 2.7.0 to ``external`` libs for Windows. The files were acquired
   by installing h5py using OSGeo4W on Windows 7, and copying the installed
   files to the ``external`` folder.
+- Add detection method to determine whether .h5 or id_mappping.json is present
+  (this determines if the netcdf is old (no groundwater) or new (groundwater)
 
 
 0.15 (2018-02-07)

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -168,7 +168,7 @@ def find_h5_file(netcdf_file_path):
     this order is also the searching order):
 
     1) . (in the same dir as the netcdf)
-    2) ../input_generated
+    2) ../preprocessed
 
     relative to the netcdf file and that it starts with 'h5_file'.
 

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -5,7 +5,7 @@ import json
 import os
 
 from netCDF4 import Dataset
-import numpy as np
+import numpy as nupy
 
 from ..utils.user_messages import log
 from ..utils import cached_property
@@ -151,6 +151,37 @@ def find_id_mapping_file(netcdf_file_path):
         IndexError if nothing is found
     """
     pattern = 'id_mapping*'
+    inpdir = os.path.join(os.path.dirname(netcdf_file_path),
+                          '..', 'input_generated')
+    resultdir = os.path.dirname(netcdf_file_path)
+
+    from_inpdir = glob.glob(os.path.join(inpdir, pattern))
+    from_resultdir = glob.glob(os.path.join(resultdir, pattern))
+
+    inpfiles = from_resultdir + from_inpdir
+    return inpfiles[0]
+
+def find_h5_file(netcdf_file_path):
+    """An ad-hoc way to get the h5_file.
+
+    We assume the h5_file file is in on of the following locations (note:
+    this order is also the searching order):
+
+    1) . (in the same dir as the netcdf)
+    2) ../input_generated
+
+    relative to the netcdf file and that it starts with 'h5_file'.
+
+    Args:
+        netcdf_file_path: path to the result netcdf
+
+    Returns:
+        h5_file path
+
+    Raises:
+        IndexError if nothing is found
+    """
+    pattern = '*.h5'
     inpdir = os.path.join(os.path.dirname(netcdf_file_path),
                           '..', 'input_generated')
     resultdir = os.path.dirname(netcdf_file_path)

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -5,7 +5,7 @@ import json
 import os
 
 from netCDF4 import Dataset
-import numpy as nupy
+import numpy as np
 
 from ..utils.user_messages import log
 from ..utils import cached_property

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -170,7 +170,7 @@ def find_h5_file(netcdf_file_path):
     1) . (in the same dir as the netcdf)
     2) ../preprocessed
 
-    relative to the netcdf file and that it starts with 'h5_file'.
+    relative to the netcdf file and has extension '.h5'
 
     Args:
         netcdf_file_path: path to the result netcdf

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -183,7 +183,7 @@ def find_h5_file(netcdf_file_path):
     """
     pattern = '*.h5'
     inpdir = os.path.join(os.path.dirname(netcdf_file_path),
-                          '..', 'input_generated')
+                          '..', 'preprocessed')
     resultdir = os.path.dirname(netcdf_file_path)
 
     from_inpdir = glob.glob(os.path.join(inpdir, pattern))

--- a/views/result_selection.py
+++ b/views/result_selection.py
@@ -213,7 +213,7 @@ class ThreeDiResultSelectionWidget(QWidget, FORM_CLASS):
             }]
             self.ts_datasource.insertRows(items)
             settings.setValue('last_used_datasource_path',
-                                  os.path.dirname(filename))
+                              os.path.dirname(filename))
             return True
         return False
 

--- a/views/result_selection.py
+++ b/views/result_selection.py
@@ -201,7 +201,8 @@ class ThreeDiResultSelectionWidget(QWidget, FORM_CLASS):
                     find_h5_file(filename)
                 except IndexError:
                     pop_up_info("No id mapping or .h5 file found, we tried the following "
-                                "locations: [., ../input_generated]. Please add "
+                                "locations: id_mapping in [., ../input_generated] and"
+                                "h5_file in [., ../preprocessed]. Please add "
                                 "this file to the correct location and try again.",
                                 title='Error')
                     return False


### PR DESCRIPTION
Create method to detect if gridadmin.h5 file is present
**Uitgangspunt:** 
detecteren of het een nieuwe of oude NetCDF is gebeurt obv code en niet door de gebruiker zelf, want
gebruiker kan het niet afleiden aan naam vd NetCDF / extensie oid);
en/of die gebruiker weet het vaak niet meer wanneer (met welke 3di rekenkern) de simulatie is gemaakt;
en/of gebruiker A simuleert, vervolgens gaat gebruiker B met de resultaten aan de haal (miscommunicatie etc)

**Stappenplan detectie methode:**
1: Check of er een gridadmin.h5 file aanwezig is
Deze .h5 file staat normaliter in /preprocessed. Check in folder waar de .ini staat (en alle subfolders). Waarom? als de 3di resultaten uit Lizard worden gedownload kan de .h5 file ook in een andere folder staan
2a: CASE NEW NetCDF
indien .h5 file aanwezig: wat is de rekenkern versie? Dit versienummer printen we in Qgis/log als plugin de resultaten inlaadt (print "3di calculationcore version = xxx. Your model(results) are generated with a 3di calculation core that is suitable for groundwater calculations")
2b: CASE OLD NetCDF
indien .h5 file niet aanwezig is in /input_generated (of ergens anders: zie verhaal hierboven 'via Lizard downloaden'), dan is er sprake van een "oude" NetCDF