### PR TITLE
Disable stats prompt if there are already csv files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ threedi-qgis-plugin changelog
 0.16 (unreleased)
 -----------------
 
+- Disable the "Calculate statistics?" prompt if there are already csv files
+  available.
+
 - Enable PEP8 check in build process; fix remaining PEP8 errors.
 
 - Move icons to ``icons`` folder.

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -388,10 +388,14 @@ class NetcdfDataSource(BaseDataSource):
         from netCDF4 import Dataset
 
         # Load aggregation netcdf
-        aggregation_netcdf_file = find_aggregation_netcdf(self.file_path)
-        log("Opening aggregation netcdf: %s" % aggregation_netcdf_file)
-        return Dataset(aggregation_netcdf_file, mode='r',
-                       format='NETCDF4')
+        try:
+            aggregation_netcdf_file = find_aggregation_netcdf(self.file_path)
+        except IndexError:
+            return None
+        else:
+            log("Opening aggregation netcdf: %s" % aggregation_netcdf_file)
+            return Dataset(aggregation_netcdf_file, mode='r',
+                           format='NETCDF4')
 
     @cached_property
     def channel_mapping(self):

--- a/datasource/netcdf_groundwater.py
+++ b/datasource/netcdf_groundwater.py
@@ -191,3 +191,7 @@ class NetcdfDataSourceGroundwater(BaseDataSource):
             self._ga = GridH5Admin(f)
 
         return self._ga
+
+    @property
+    def ds_aggregation(self):
+        raise IndexError("TODO")

--- a/datasource/netcdf_groundwater.py
+++ b/datasource/netcdf_groundwater.py
@@ -134,7 +134,9 @@ class NetcdfDataSourceGroundwater(BaseDataSource):
         var_1d = self.PREFIX_1D + variable
 
         if index is not None:
-            # a new array is created, thus safe
+            # in the groundwater version, the node index starts from 1 instead
+            # of 0.
+            # Note: a new array is created, e.g., index doesn't get modified
             index = index - 1
 
             # hacky object_type checking mechanism, sinds we don't have

--- a/datasource/netcdf_groundwater.py
+++ b/datasource/netcdf_groundwater.py
@@ -196,7 +196,4 @@ class NetcdfDataSourceGroundwater(BaseDataSource):
 
     @property
     def ds_aggregation(self):
-        # TODO: indexerror is raised because in the old datasource it's also
-        # raised when no ds_aggregation can be found, but we need something
-        # better...
-        raise IndexError("TODO")
+        return None

--- a/datasource/netcdf_groundwater.py
+++ b/datasource/netcdf_groundwater.py
@@ -194,4 +194,7 @@ class NetcdfDataSourceGroundwater(BaseDataSource):
 
     @property
     def ds_aggregation(self):
+        # TODO: indexerror is raised because in the old datasource it's also
+        # raised when no ds_aggregation can be found, but we need something
+        # better...
         raise IndexError("TODO")

--- a/stats/ncstats.py
+++ b/stats/ncstats.py
@@ -45,7 +45,7 @@ class NcStats(object):
         if datasource:
             self.datasource = datasource
         elif not ds and netcdf_file_path:
-            self.datasource = NetcdfDataSource(netcdf_file_path)
+            raise NotImplementedError('DEPRECATED')
         elif ds:
             # TODO: needs fixing
             raise NotImplementedError('TODO')
@@ -204,7 +204,9 @@ class NcStatsAgg(NcStats):
 
     def __init__(self, *args, **kwargs):
         super(NcStatsAgg, self).__init__(*args, **kwargs)
-        self.ds_agg = self.datasource.ds_aggregation
+
+        if self.datasource.ds_aggregation is None:
+            raise ValueError("No aggration netcdf available in data source.")
 
         # Construct a dict with thing we actually have in the loaded netcdf,
         # and store netcdf arrays in memory.
@@ -213,7 +215,7 @@ class NcStatsAgg(NcStats):
                   self.AVAILABLE_STRUCTURE_PARAMETERS +
                   self.AVAILABLE_PUMP_PARAMETERS):
             try:
-                copied_array = self.ds_agg.variables[p][:]
+                copied_array = self.datasource.ds_aggregation.variables[p][:]
                 self.variables[p] = copied_array
             except KeyError:
                 continue

--- a/stats/utils.py
+++ b/stats/utils.py
@@ -174,7 +174,7 @@ def generate_manhole_stats(nds, result_dir, layer, layer_id_name,
     if layer_name == 'nodes':
         try:
             ncstats = NcStatsAgg(datasource=nds)
-        except IndexError:
+        except ValueError:
             log.error('No aggregation netcdf available for statistics')
             ncstats = NcStats(datasource=nds)
 
@@ -182,7 +182,7 @@ def generate_manhole_stats(nds, result_dir, layer, layer_id_name,
         # It's a v2 spatialite layer
         try:
             ncstats = NcStatsAgg(datasource=nds)
-        except IndexError:
+        except ValueError:
             log.error('No aggregation netcdf available for statistics')
             ncstats = NcStats(datasource=nds)
     else:
@@ -274,14 +274,14 @@ def generate_structure_stats(nds, result_dir, layer, layer_id_name,
         # the layer type
         try:
             ncstats = NcStatsAgg(datasource=nds)
-        except IndexError:
+        except ValueError:
             log.error('No aggregation netcdf available for statistics')
             ncstats = NcStats(datasource=nds)
     else:
         # It's a view
         try:
             ncstats = NcStatsAgg(datasource=nds)
-        except IndexError:
+        except ValueError:
             log.error('No aggregation netcdf available for statistics')
             ncstats = NcStats(datasource=nds)
 
@@ -350,7 +350,7 @@ def generate_pump_stats(nds, result_dir, layer, layer_id_name,
         # the layer type
         try:
             ncstats = NcStatsAgg(datasource=nds)
-        except IndexError:
+        except ValueError:
             ncstats = NcStats(datasource=nds)
     else:
         # It's a view

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -349,8 +349,7 @@ class LayerTreeManager(object):
         result_dirs = [
             os.path.dirname(self.model.rows[row_nr].file_path.value)
             for row_nr in range(start_row, stop_row + 1)]
-        csv_filepaths = get_csv_layer_cache_files(*result_dirs)
-        no_existing_csv_files = len(csv_filepaths) == 0
+        no_existing_csv_files = bool(get_csv_layer_cache_files(*result_dirs))
 
         # only bother with a prompt if there are no csv files at all. If there
         # are files we assume we can load them

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -9,6 +9,7 @@ from ..stats.utils import (
     generate_structure_stats,
     generate_manhole_stats,
     generate_pump_stats,
+    get_csv_layer_cache_files,
     get_structure_layer_id_name,
     get_manhole_layer_id_name,
     get_pump_layer_id_name,
@@ -345,11 +346,19 @@ class LayerTreeManager(object):
         return layers
 
     def add_statistic_layers(self, result_row_nr, start_row, stop_row):
+        result_dirs = [
+            os.path.dirname(self.model.rows[row_nr].file_path.value)
+            for row_nr in range(start_row, stop_row + 1)]
+        csv_filepaths = get_csv_layer_cache_files(*result_dirs)
+        no_existing_csv_files = len(csv_filepaths) == 0
 
-        if not pop_up_question('Do you want to calculate statistics (in this '
-                               'version it can still take forever with large '
-                               'netcdf files)?',
-                               'Calculate statistics?',):
+        # only bother with a prompt if there are no csv files at all. If there
+        # are files we assume we can load them
+        if no_existing_csv_files and not pop_up_question(
+                'Do you want to calculate statistics (in this '
+                'version it can still take forever with large '
+                'netcdf files)?',
+                'Calculate statistics?'):
             return
 
         for row_nr in range(start_row, stop_row + 1):

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -349,11 +349,11 @@ class LayerTreeManager(object):
         result_dirs = [
             os.path.dirname(self.model.rows[row_nr].file_path.value)
             for row_nr in range(start_row, stop_row + 1)]
-        no_existing_csv_files = bool(get_csv_layer_cache_files(*result_dirs))
+        csv_files_exist = bool(get_csv_layer_cache_files(*result_dirs))
 
         # only bother with a prompt if there are no csv files at all. If there
         # are files we assume we can load them
-        if no_existing_csv_files and not pop_up_question(
+        if not csv_files_exist and not pop_up_question(
                 'Do you want to calculate statistics (in this '
                 'version it can still take forever with large '
                 'netcdf files)?',


### PR DESCRIPTION
The current behavior is that a prompt is shown at all times. With this PR the prompt won't be shown if the plugin detects that there are already stats csv files in the result directory, which we assume have been generated previously.

This does mean that the statistics layer will always be loaded when they are detected, whereas previously you can choose not to load them even when they are generated by clicking 'no' in the prompt.