### PR TITLE
Fix int32 IDs, add more logging, fix leakage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ threedi-qgis-plugin changelog
 
 0.16 (unreleased)
 -----------------
+
+- Fix leakage name.
+
+- Implement ``get_timeseries`` for pumplines using the newest threedigrid.
+
+- Fix SetFID error caused by int32.
+
 - try to show more often the object_name in graph widget (instead of 'N/A')
 
 - use gridadmin has_pumpstations in functions get_or_create_pumpline_layer and

--- a/datasource/netcdf.py
+++ b/datasource/netcdf.py
@@ -47,7 +47,7 @@ RAIN_INTENSITY = NcVar('rain', 'rain intensity', 'm3/s')
 WET_SURFACE_AREA = NcVar('su', 'wet surface area', 'm2')
 INFILTRATION = NcVar('infiltration_rate', 'infiltration rate', 'm3/s')
 WET_CROSS_SECTION_AREA = NcVar('au', 'wet cross section area', 'm2')
-LEAKAGE_RATE = NcVar('Mesh2D_leak', 'leakage rate', 'm3/s')
+LEAKAGE_RATE = NcVar('leak', 'leakage rate', 'm3/s')
 
 _Q_TYPES = [
     DISCHARGE,

--- a/datasource/netcdf_groundwater.py
+++ b/datasource/netcdf_groundwater.py
@@ -168,51 +168,13 @@ class NetcdfDataSourceGroundwater(BaseDataSource):
                     content_pk=object_id).timeseries(indexes=slice(None))
             # e.g. gr.nodes.connectionnodes.filter(content_pk=1).timeseries(
             #   indexes=slice(None)).vol
-            filter_timeseries_ncvar = getattr(
-                filter_timeseries, nc_variable)
+            filter_timeseries_ncvar = getattr(filter_timeseries, nc_variable)
             # this could return multiple timeseries, since a v2_channel can
             # be splitted up in multiple flowlines. For now, we pick first:
             pick_only_first_of_element = 0
             vals = filter_timeseries_ncvar[:, pick_only_first_of_element]
-
         elif model_instance == 'pumps':
-            # one example for v2_pumpstation =
-            # gr.pumps.filter(id=3).timeseries(indexes=slice(
-                # None)).Mesh1D_q_pump
-            # gr.pumps.timeseries(indexes=slice(None))
-            gr_model_instance_subset = \
-                gr_model_instance.timeseries(indexes=slice(None))
-
-            # tijdelijke hack omdat threedigrid indexerrors geeft op pumps
-            # normaalgesproken zou dit werken:
-            # gr.pumps.filter(id=1).timeseries(indexes=slice(None)).q_pump
-            # echter, dit geeft nu een: "IndexError: boolean index did not
-            # match indexed array along dimension 1; dimension is 20 but
-            # corresponding boolean dimension is 19"
-
-            # ter achtergrond info:
-            # v2_bergermeer heeft 18 v2_pumpstations
-            # v2_bergermeer heeft 19 pumplines (export functie is goed!)
-
-            # vanwege indexerror daarom tijdelijke hack:
-            # dit werkt: gr.pumps.q_pump[:,1:].shape --> (10, 19)
-            # echter dit werkt niet: gr.pumps.filter(id=1).q_pump[:,1:]
-            # dus de id array moeten we ook gaan slicen
-            # ff nieuwe array bouwen (v2_bergermeer id = {1, 2, .., 18, 19}
-            id_array = gr_model_instance_subset.id
-            # dan kunnen we vervolgens bijv doen:
-            # gr.pumps.timeseries(indexes=slice(None)).q_pump
-            subset_ncvar = getattr(gr_model_instance_subset, nc_variable)
-
-            # gr.pumps.timeseries(indexes=slice(None)).q_pump[:, 1:][:,
-            # id_array == 3]
-            ncvar_filter = subset_ncvar[:, 1:][:, id_array == object_id]
-            # flatten numpyarray
-            vals = ncvar_filter.flatten()
-            # Todo:
-            # wait for Jelle/Lars to fix this IndexError in threedigrid,
-            # so that we can do the normal way (maybe also using content_pk
-            # instead of id?
+            raise NotImplementedError("TODO")
         else:
             raise ValueError('object_type not available')
         return vals
@@ -234,52 +196,13 @@ class NetcdfDataSourceGroundwater(BaseDataSource):
         # gr.nodes / gr.lines / gr.pumps
         gr_model_instance = getattr(gridadmin_result, model_instance)
 
-        if model_instance in ['nodes', 'lines']:
-            # gr.nodes.filter(id=100).timeseries(indexes=slice(None))
-            filter_timeseries = gr_model_instance.filter(
-                id=object_id).timeseries(indexes=slice(None))
-            # gr.nodes.filter(id=100).timeseries(indexes=slice(None)).vol
-            filter_timeseries_ncvar = getattr(filter_timeseries, nc_variable)
-            # flatten numpyarray
-            vals = filter_timeseries_ncvar.flatten()
-        elif model_instance == 'pumps':
-            # gr.pumps.timeseries(indexes=slice(None))
-            timeseries = gr_model_instance.timeseries(
-                indexes=slice(None))
-
-            # tijdelijke hack omdat threedigrid indexerrors geeft op pumps
-            # --------------------------------------------------
-            # normaalgesproken zou dit werken:
-            # gr.pumps.filter(id=1).timeseries(indexes=slice(None)).q_pump
-            # echter, dit geeft nu een: "IndexError: boolean index did not
-            # match indexed array along dimension 1; dimension is 20 but
-            # corresponding boolean dimension is 19"
-
-            # ter achtergrond info:
-            # v2_bergermeer heeft 18 v2_pumpstations
-            # v2_bergermeer heeft 19 pumplines (export functie is goed!)
-
-            # vanwege indexerror daarom tijdelijke hack:
-            # dit werkt: gr.pumps.q_pump[:,1:].shape --> (10, 19)
-            # echter dit werkt niet: gr.pumps.filter(id=1).q_pump[:,1:]
-            # dus de id array moeten we ook gaan slicen
-            # ff nieuwe array bouwen
-            # id_array = gr.pumps.id # --> is id 1 tm 19
-            id_array = gr_model_instance.id
-            # dan kunnen we vervolgens bijv doen:
-            # gr.pumps.timeseries(indexes=slice(None)).q_pump
-            timeseries_ncvar = getattr(timeseries, nc_variable)
-            # gr.pumps.timeseries(indexes=slice(None)).q_pump[:, 1:][:,
-            # id_array == 3]
-            filter = timeseries_ncvar[:, 1:][:, id_array == object_id]
-            # flatten numpyarray
-            vals = filter.flatten()
-            # Todo:
-            # wait for Jelle/Lars to fix this IndexError in threedigrid,
-            # so that we can do the normal way (maybe also using content_pk
-            # instead of id?
-        else:
-            raise ValueError('object_type not available')
+        # gr.nodes.filter(id=100).timeseries(indexes=slice(None))
+        filter_timeseries = gr_model_instance.filter(
+            id=object_id).timeseries(indexes=slice(None))
+        # gr.nodes.filter(id=100).timeseries(indexes=slice(None)).vol
+        filter_timeseries_ncvar = getattr(filter_timeseries, nc_variable)
+        # flatten numpyarray
+        vals = filter_timeseries_ncvar.flatten()
         return vals
 
     def get_timeseries(

--- a/models/graph.py
+++ b/models/graph.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
+import logging
 from random import randint
 
 from .base import BaseModel
@@ -7,6 +8,9 @@ from .base_fields import ValueField, ColorField, CheckboxField
 
 import numpy as np
 import pyqtgraph as pg
+
+
+logger = logging.getLogger(__name__)
 
 
 COLOR_LIST = [
@@ -127,7 +131,7 @@ class LocationTimeseriesModel(BaseModel):
                 if absolute:
                     timeseries = np.abs(timeseries)
             except (KeyError, IndexError, ValueError, AttributeError):
+                logger.exception("Error getting timeseries table")
                 # Return an empty array so that the graph won't crash.
-                # The exceptions are already logged by the nc datasource.
                 timeseries = EMPTY_TIMESERIES
             return timeseries

--- a/models/graph.py
+++ b/models/graph.py
@@ -131,6 +131,8 @@ class LocationTimeseriesModel(BaseModel):
                 if absolute:
                     timeseries = np.abs(timeseries)
             except (KeyError, IndexError, ValueError, AttributeError):
+                # TODO: we're catching way too many errors here, maybe we need
+                # a custom type
                 logger.exception("Error getting timeseries table")
                 # Return an empty array so that the graph won't crash.
                 timeseries = EMPTY_TIMESERIES

--- a/utils/gridadmin.py
+++ b/utils/gridadmin.py
@@ -23,8 +23,12 @@ def get_spatial_reference(epsg_code):
     return spatial_ref
 
 
-def _fix_fid_for_SetFID(fid):
-    """SetFID can't handle numpy.int64, which the h5 data sometimes returns"""
+def _temp_fix_fid_for_SetFID(fid):
+    """SetFID can't handle numpy.int64, which the h5 data sometimes returns
+
+    Note: shouldn't be needed anymore in newer results because it's converted
+    back to int32. Ask Martijn.
+    """
     return int(fid)
 
 
@@ -139,7 +143,7 @@ class QgisNodesOgrExporter(BaseOgrExporter):
                     feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                fid = _fix_fid_for_SetFID(node_data['id'][i])
+                fid = _temp_fix_fid_for_SetFID(node_data['id'][i])
                 feature.SetFID(fid)
             layer.CreateFeature(feature)
             feature.Destroy()
@@ -337,7 +341,7 @@ class QgisLinesOgrExporter(BaseOgrExporter):
                     feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                fid = _fix_fid_for_SetFID(line_data['id'][i])
+                fid = _temp_fix_fid_for_SetFID(line_data['id'][i])
                 feature.SetFID(fid)
 
             layer.CreateFeature(feature)
@@ -428,7 +432,7 @@ class QgisPumpsOgrExporter(BaseOgrExporter):
                 feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                fid = _fix_fid_for_SetFID(pump_data['id'][i])
+                fid = _temp_fix_fid_for_SetFID(pump_data['id'][i])
                 feature.SetFID(fid)
 
             layer.CreateFeature(feature)

--- a/utils/gridadmin.py
+++ b/utils/gridadmin.py
@@ -23,12 +23,8 @@ def get_spatial_reference(epsg_code):
     return spatial_ref
 
 
-def _temp_fix_fid_for_SetFID(fid):
-    """SetFID can't handle numpy.int64, which the h5 data sometimes returns
-
-    Note: shouldn't be needed anymore in newer results because it's converted
-    back to int32. Ask Martijn.
-    """
+def _fix_fid_for_SetFID(fid):
+    """SetFID can't handle numpy.int32, which the h5 data sometimes returns"""
     return int(fid)
 
 
@@ -143,7 +139,7 @@ class QgisNodesOgrExporter(BaseOgrExporter):
                     feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                fid = _temp_fix_fid_for_SetFID(node_data['id'][i])
+                fid = _fix_fid_for_SetFID(node_data['id'][i])
                 feature.SetFID(fid)
             layer.CreateFeature(feature)
             feature.Destroy()
@@ -341,7 +337,7 @@ class QgisLinesOgrExporter(BaseOgrExporter):
                     feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                fid = _temp_fix_fid_for_SetFID(line_data['id'][i])
+                fid = _fix_fid_for_SetFID(line_data['id'][i])
                 feature.SetFID(fid)
 
             layer.CreateFeature(feature)
@@ -432,7 +428,7 @@ class QgisPumpsOgrExporter(BaseOgrExporter):
                 feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                fid = _temp_fix_fid_for_SetFID(pump_data['id'][i])
+                fid = _fix_fid_for_SetFID(pump_data['id'][i])
                 feature.SetFID(fid)
 
             layer.CreateFeature(feature)

--- a/utils/gridadmin.py
+++ b/utils/gridadmin.py
@@ -23,6 +23,11 @@ def get_spatial_reference(epsg_code):
     return spatial_ref
 
 
+def _fix_fid_for_SetFID(fid):
+    """SetFID can't handle numpy.int64, which the h5 data sometimes returns"""
+    return int(fid)
+
+
 class QgisNodesOgrExporter(BaseOgrExporter):
     """
     Exports to ogr formats. You need to set the driver explicitly
@@ -134,7 +139,8 @@ class QgisNodesOgrExporter(BaseOgrExporter):
                     feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                feature.SetFID(node_data['id'][i])
+                fid = _fix_fid_for_SetFID(node_data['id'][i])
+                feature.SetFID(fid)
             layer.CreateFeature(feature)
             feature.Destroy()
         layer.CommitTransaction()
@@ -331,7 +337,8 @@ class QgisLinesOgrExporter(BaseOgrExporter):
                     feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                feature.SetFID(line_data['id'][i])
+                fid = _fix_fid_for_SetFID(line_data['id'][i])
+                feature.SetFID(fid)
 
             layer.CreateFeature(feature)
             feature.Destroy()
@@ -421,7 +428,8 @@ class QgisPumpsOgrExporter(BaseOgrExporter):
                 feature.SetField(str(field_name), value)
                 # explicitly set feature id to the 'id' field of the gridadmin
                 # data, because graph tool uses the feature id.
-                feature.SetFID(pump_data['id'][i])
+                fid = _fix_fid_for_SetFID(pump_data['id'][i])
+                feature.SetFID(fid)
 
             layer.CreateFeature(feature)
             feature.Destroy()


### PR DESCRIPTION
- Fix SetFID error due to int32
- Add logging
- Fix ``get_timeseries`` for the newest threedigrid (pumplines)
- Remove the ``get_timeseries`` implementation for v2_pumpstation_view because it doesn't work yet: threedigrid doesn't support indexing using the ``pump_id``. This needs to be made first.