### PR TITLE
Removed QgsLayerTreeGroup.destroyed

### DIFF
--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -57,6 +57,7 @@ class LayerTreeManager(object):
         self._model_layergroup = None
         self._model_layergroup_connected = False
 
+        # The 4 variables below seem to be never used anywhere
         self.result_layergroups = []
         self.results_layers = []
 
@@ -84,19 +85,23 @@ class LayerTreeManager(object):
     @model_layergroup.setter
     def model_layergroup(self, value):
         if self._model_layergroup_connected:
-            self._model_layergroup.destroyed.disconnect(
-                self._on_delete_model_layergroup)
+            # What is QgsLayerTreeGroup.destroyed???
+            # No information anywhere on the internet
+            # Not on the Qgis api documentation 2.18 and 3.4
+
+            # self._model_layergroup.destroyed.disconnect(
+            #     self._on_delete_model_layergroup)
             self._model_layergroup_connected = False
         self._model_layergroup = value
         if isinstance(value, QgsLayerTreeNode):
-            self._model_layergroup.destroyed.connect(
-                self._on_delete_model_layergroup)
+            # self._model_layergroup.destroyed.connect(
+            #     self._on_delete_model_layergroup)
             self._model_layergroup_connected = True
 
     def _on_delete_model_layergroup(self):
         if self._model_layergroup_connected:
-            self._model_layergroup.destroyed.disconnect(
-                self._on_delete_model_layergroup)
+            # self._model_layergroup.destroyed.disconnect(
+            #     self._on_delete_model_layergroup)
             self._model_layergroup_connected = False
         self._model_layergroup = None
 


### PR DESCRIPTION
In the changed file I commented out the variable which caused the bug: `self._model_layergroup.destroyed`
Inspecting this variable in Qgis2 shows that this is a `PyQt4.QtCore.pyqtBoundSignal`. This explains why Qgis3 is crashing because Qgis3 uses Qt5 (and not Qt4 anymore). However, it is still not clear to me what is done here and why. Can we just remove it? @larsclaussen @martijn-siemerink 