### PR TITLE
[DONE] Richard resultselection filter bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ ThreeDiToolBox changelog
 
 - Add v2_culvert to layer_tree_manager
 
+- ResultSelectionWidget now correctly downloads the selected result.
+
 
 1.6 (2018-11-28)
 ----------------

--- a/threedi_result_selection.py
+++ b/threedi_result_selection.py
@@ -184,12 +184,14 @@ class ThreeDiResultSelection(QObject):
             'results-3di', 'aggregate-results-3di', 'grid-admin',
         ]
         selection_model = self.dialog.downloadResultTableView.selectionModel()
-        indexes = selection_model.selectedIndexes()
-        if len(indexes) != 1:
+        proxy_indexes = selection_model.selectedIndexes()
+        if len(proxy_indexes) != 1:
             pop_up_info("Please select one result.")
             return
-        row = indexes[0].row()
-        item = self.download_result_model.rows[row]
+        proxy_selection_index = proxy_indexes[0]
+        selection_index = self.dialog.download_proxy_model.mapToSource(
+            proxy_selection_index)
+        item = self.download_result_model.rows[selection_index.row()]
         to_download = [
             r for r in item.results.value if
             r['result_type']['code'] in result_type_codes_download]

--- a/views/result_selection.py
+++ b/views/result_selection.py
@@ -118,12 +118,12 @@ class ThreeDiResultSelectionWidget(QWidget, FORM_CLASS):
         self.ts_datasource.set_column_sizes_on_view(self.resultTableView)
 
         self.download_result_model = download_result_model
-        download_proxy_model = QSortFilterProxyModel()
-        download_proxy_model.setSourceModel(download_result_model)
-        download_proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
+        self.download_proxy_model = QSortFilterProxyModel()
+        self.download_proxy_model.setSourceModel(download_result_model)
+        self.download_proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self.filterLineEdit.textChanged.connect(
-            download_proxy_model.setFilterFixedString)
-        self.downloadResultTableView.setModel(download_proxy_model)
+            self.download_proxy_model.setFilterFixedString)
+        self.downloadResultTableView.setModel(self.download_proxy_model)
 
         self.toggle_login_interface()
 


### PR DESCRIPTION
The proxy model (used for filtering/sorting) did not automatically map
selection indexes. This has to be manually applied via the function
mapToSource/mapSelectionToSource. For more details see
http://doc.qt.io/qt-5/qsortfilterproxymodel.html and
http://doc.qt.io/qt-5/qsortfilterproxymodel.html#mapToSource.
This is now done.