### PR TITLE
[DONE] sinks_sources waterbalans use only _cum

### DIFF
--- a/water_balance/config/waterbalance/sum_configs.py
+++ b/water_balance/config/waterbalance/sum_configs.py
@@ -157,7 +157,7 @@ serie_settings = [
             'order': 7.2,
             'def_fill_color': '204,255,51' + fill_transp,
             'def_pen_color': '204,255,51' + pen_transp,
-            'series': ['q_sss_in', 'q_sss_out'],
+            'series': ['q_sss'],
         }]
     }, {
         'name': 'show main flow',
@@ -242,7 +242,7 @@ serie_settings = [
             'order': 7.2,
             'def_fill_color': '204,255,51' + fill_transp,
             'def_pen_color': '204,255,51' + pen_transp,
-            'series': ['q_sss_in', 'q_sss_out'],
+            'series': ['q_sss'],
         }]
     }
 ]

--- a/water_balance/config/waterbalance/sum_configs.py
+++ b/water_balance/config/waterbalance/sum_configs.py
@@ -152,7 +152,7 @@ serie_settings = [
             'def_pen_color': '50,130,136' + pen_transp,
             'series': ['inflow'],
         }, {
-            'name': 'Surface sources and sinks',
+            'name': 'surface sources and sinks',
             'default_method': 'net',
             'order': 7.2,
             'def_fill_color': '204,255,51' + fill_transp,
@@ -237,7 +237,7 @@ serie_settings = [
             'def_pen_color': '221,160,221' + pen_transp,
             'series': ['leak'],
         }, {
-            'name': 'Surface sources and sinks',
+            'name': 'surface sources and sinks',
             'default_method': 'net',
             'order': 7.2,
             'def_fill_color': '204,255,51' + fill_transp,

--- a/water_balance/tools/waterbalance.py
+++ b/water_balance/tools/waterbalance.py
@@ -740,7 +740,7 @@ class WaterBalanceCalculation(object):
             ('rain', '_cum', np_1d_node, 27, 1),
             ('intercepted_volume', '_current', np_2d_node, 34, -1),
             ('q_sss', '_cum', np_2d_node, 35, 1),
-            ('q_sss', '_cum', np_2d_node, 36, 1),
+
         ]:
 
             if node.size > 0:

--- a/water_balance/views/waterbalance_widget.py
+++ b/water_balance/views/waterbalance_widget.py
@@ -75,8 +75,7 @@ INPUT_SERIES = [
     ('2d__1d_2d_exch_in', 32, '2d', '1d2d'),
     ('2d__1d_2d_exch_out', 33, '2d', '1d2d'),
     ('intercepted_volume', 34, '2d', '2d'),
-    ('q_sss_in', 35, '2d', '2d'),
-    ('q_sss_out', 36, '2d', '2d'),
+    ('q_sss', 35, '2d', '2d'),
 ]
 
 
@@ -638,8 +637,8 @@ class WaterBalanceWidget(QDockWidget):
             'type': '2d',
         }, {
             'label_name': 'Surface sources and sinks',
-            'in': ['q_sss_in'],
-            'out': ['q_sss_out'],
+            'in': ['q_sss'],
+            'out': ['q_sss'],
             'type': '2d',
         }
     ]

--- a/water_balance/views/waterbalance_widget.py
+++ b/water_balance/views/waterbalance_widget.py
@@ -636,7 +636,7 @@ class WaterBalanceWidget(QDockWidget):
             'out': ['intercepted_volume'],
             'type': '2d',
         }, {
-            'label_name': 'Surface sources and sinks',
+            'label_name': 'surface sources and sinks',
             'in': ['q_sss'],
             'out': ['q_sss'],
             'type': '2d',
@@ -974,6 +974,7 @@ class WaterBalanceWidget(QDockWidget):
             'interception': ['2d'],
             'constant infiltration': ['2d'],
             'external (rain and laterals)': ['1d', '2d'],
+            'surface sources and sinks': ['2d'],
         }
 
         # more hackery to fix keys defined in both 'show main flow' and


### PR DESCRIPTION
after giving the q_sss waterbalance some thought I concluded that it is better use only _cum instead of both _cum_negative and _cum_positive

This has two advantages:
- user only has to add q_sss_cum to v2_aggregation_settings table
- 3Di simulation is faster with less aggregation variables

Both the waterbalance Graph and BarChart work fine!

