### PR TITLE
[DONE] Bump geoalchemy from 0.5 to 0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # git+https://github.com/nens/geoalchemy2.git#egg=geoalchemy2
-GeoAlchemy2==0.5.0
+GeoAlchemy2==0.6.1
 SQLAlchemy==1.1.0b3
 pyqtgraph
 git+https://github.com/lizardsystem/lizard-connector.git@0.6#egg=lizard_connector

--- a/sql_models/model_schematisation.py
+++ b/sql_models/model_schematisation.py
@@ -94,7 +94,6 @@ class ConnectionNode(Base):
             srid=4326,
             spatial_index=True,
             management=True,
-            use_st_prefix=False,
         ),
         nullable=False,
     )
@@ -105,7 +104,6 @@ class ConnectionNode(Base):
             srid=4326,
             spatial_index=False,
             management=True,
-            use_st_prefix=False,
         ),
         nullable=True,
     )

--- a/test/test_spatialalchemy.py
+++ b/test/test_spatialalchemy.py
@@ -29,8 +29,7 @@ class GeoTable(Base):
             geometry_type="POINT",
             srid=4326,
             management=True,
-            spatial_index=True,
-            use_st_prefix=False,
+            spatial_index=True
         )
     )
 

--- a/threedi_statistics/sql_models/statistics.py
+++ b/threedi_statistics/sql_models/statistics.py
@@ -38,7 +38,6 @@ class Flowline(Base):
             srid=4326,
             spatial_index=True,
             management=True,
-            use_st_prefix=False,
         ),
         nullable=False,
     )
@@ -159,7 +158,6 @@ class Node(Base):
             srid=4326,
             spatial_index=True,
             management=True,
-            use_st_prefix=False,
         ),
         nullable=False,
     )
@@ -213,7 +211,6 @@ class Pumpline(Base):
             srid=4326,
             spatial_index=True,
             management=True,
-            use_st_prefix=False,
         ),
         nullable=False,
     )


### PR DESCRIPTION
Bumped geoalchemy2 from 0.5 to 0.6.1 as it is needed for the model-checker.

Models no longer need the `use_st_prefix` parameter. Previously this was used to differentiate between spatialite functions (which don't have an 'ST_' prefix) and postgis functions (which have an 'ST_' prefix).