### PR TITLE
More apt, less custom

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Exclude everything.
+*
+# We only need the two requirements files.
+!requirements*txt

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 # Don't let qgis grab python's import mechanism (which breaks pytest).
 ENV QGIS_NO_OVERRIDE_IMPORT 1
 
+# User handling to get proper non-root-owned files on linux.
 ARG uid=1000
 ARG gid=1000
 RUN groupadd -g $gid nens && useradd -lm -u $uid -g $gid nens
@@ -25,14 +26,11 @@ RUN apt-get -y update \
         git \
 	strace \
 	valgrind \
-    && apt-get clean \
-    && apt-get purge \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN dbus-uuidgen > /var/lib/dbus/machine-id
 
 RUN echo "deb     https://qgis.org/ubuntu-ltr bionic main" >> /etc/apt/sources.list
-#RUN echo "deb-src https://qgis.org/ubuntu-ltr bionic main" >> /etc/apt/sources.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
 
 RUN apt-get -y update \
@@ -45,9 +43,7 @@ RUN apt-get -y update \
         qgis-provider-grass \
         grass \
         pyqt5-dev-tools \
-    && apt-get clean \
-    && apt-get purge \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
 # Now install the ubuntu packages we need.
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
+	unzip \
+	zip \
         build-essential \
         dbus \
         gdal-bin \

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -26,8 +26,6 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
 # Now install the ubuntu packages we need.
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
-	strace \
-	valgrind \
         build-essential \
         dbus \
         gdal-bin \
@@ -37,38 +35,31 @@ RUN apt-get update \
         pyqt5-dev-tools \
         python-dev \
         python3-dev \
+        python3-h5netcdf \
+        python3-h5py \
         python3-pip \
+        python3-pyqtgraph \
         python3-qgis \
+        python3-sqlalchemy \
         qgis \
         qgis-provider-grass \
+        strace \
+        valgrind \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Seems to be a message bus used by Qt?
 RUN dbus-uuidgen > /var/lib/dbus/machine-id
 
-RUN pip3 install --upgrade pip
-RUN pip3 install setuptools
-
+# Install some python libraries (partially already installed through apt)
 ADD requirements.txt .
 ADD requirements-dev.txt .
-RUN pip3 install -r requirements.txt -U
-RUN pip3 install -r requirements-dev.txt -U
-
-# Remove once netcdf4 is completely removed.
-ENV USE_SETUPCFG=0
-ENV HDF5_INCDIR=/usr/include/hdf5/serial
-ENV HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/serial
-RUN pip install netCDF4
-
-# Make sure the h5py is compiled with the same HDF5 version of QGIS.
-RUN pip3 uninstall h5py -y
-ENV HDF5_DIR /usr/lib/x86_64-linux-gnu/hdf5/serial/
-RUN pip3 install --no-binary=h5py h5py
+RUN pip3 install -U pip setuptools
+RUN pip3 install -r requirements.txt -r requirements-dev.txt
 
 # Add the qgis-core plugins (like 'db_manager') and our own plugin dir to the
-PYTHONPATH. This is needed for pytest and so to find the code. (Qgis finds it
-just fine without this PYTHONPATH, of course).
+# PYTHONPATH. This is needed for pytest and so to find the code. (Qgis finds it
+# just fine without this PYTHONPATH, of course).
 ENV PYTHONPATH /home/nens/.local/share/QGIS/QGIS3/profiles/default/python/plugins:/usr/share/qgis/python/plugins
 
 # Default command if nothing is specified.

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -13,12 +13,28 @@ ARG uid=1000
 ARG gid=1000
 RUN groupadd -g $gid nens && useradd -lm -u $uid -g $gid nens
 
-RUN apt-get -y update \
+# Set up ubuntu for the qgis repository
+RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         dirmngr \
         gpg-agent \
         software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+RUN echo "deb https://qgis.org/ubuntu-ltr bionic main" >> /etc/apt/sources.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
+
+# Now install the ubuntu packages we need.
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends \
+        python3-dev \
+        python3-pip \
+        gdal-bin \
         wget \
+        qgis \
+        python3-qgis \
+        qgis-provider-grass \
+        grass \
+        pyqt5-dev-tools \
         dbus \
         libhdf5-serial-dev \
         python-dev \
@@ -28,22 +44,8 @@ RUN apt-get -y update \
 	valgrind \
     && rm -rf /var/lib/apt/lists/*
 
+# Seems to be a message bus used by Qt?
 RUN dbus-uuidgen > /var/lib/dbus/machine-id
-
-RUN echo "deb     https://qgis.org/ubuntu-ltr bionic main" >> /etc/apt/sources.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
-
-RUN apt-get -y update \
-    && apt-get -y install --no-install-recommends \
-        python3-dev \
-        python3-pip \
-        gdal-bin \
-        qgis \
-        python3-qgis \
-        qgis-provider-grass \
-        grass \
-        pyqt5-dev-tools \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -26,22 +26,22 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
 # Now install the ubuntu packages we need.
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
-        python3-dev \
-        python3-pip \
-        gdal-bin \
-        wget \
-        qgis \
-        python3-qgis \
-        qgis-provider-grass \
-        grass \
-        pyqt5-dev-tools \
-        dbus \
-        libhdf5-serial-dev \
-        python-dev \
-        build-essential \
-        git \
 	strace \
 	valgrind \
+        build-essential \
+        dbus \
+        gdal-bin \
+        git \
+        grass \
+        libhdf5-serial-dev \
+        pyqt5-dev-tools \
+        python-dev \
+        python3-dev \
+        python3-pip \
+        python3-qgis \
+        qgis \
+        qgis-provider-grass \
+        wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Seems to be a message bus used by Qt?
@@ -66,7 +66,9 @@ RUN pip3 uninstall h5py -y
 ENV HDF5_DIR /usr/lib/x86_64-linux-gnu/hdf5/serial/
 RUN pip3 install --no-binary=h5py h5py
 
-# Add the qgis-core plugins (like 'db_manager') and our own plugin dir to the PYTHONPATH.
+# Add the qgis-core plugins (like 'db_manager') and our own plugin dir to the
+PYTHONPATH. This is needed for pytest and so to find the code. (Qgis finds it
+just fine without this PYTHONPATH, of course).
 ENV PYTHONPATH /home/nens/.local/share/QGIS/QGIS3/profiles/default/python/plugins:/usr/share/qgis/python/plugins
 
 # Default command if nothing is specified.

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -2,8 +2,11 @@ FROM ubuntu:bionic
 MAINTAINER Richard Boon <richard.boon@nelen-schuurmans.nl>
 # Inspired by https://hub.docker.com/r/timcera/qgis-desktop-ubuntu/~/dockerfile/
 
+# Debian docker config settings.
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
+# Don't let qgis grab python's import mechanism (which breaks pytest).
+ENV QGIS_NO_OVERRIDE_IMPORT 1
 
 ENV TZ Europe/Amsterdam
 
@@ -74,8 +77,6 @@ RUN pip3 install --no-binary=h5py h5py
 
 # Add the qgis-core plugins (like 'db_manager') and our own plugin dir to the PYTHONPATH.
 ENV PYTHONPATH /home/nens/.local/share/QGIS/QGIS3/profiles/default/python/plugins:/usr/share/qgis/python/plugins
-# Don't let qgis grab python's import mechanism (which breaks pytest).
-ENV QGIS_NO_OVERRIDE_IMPORT 1
 
 # Default command if nothing is specified.
 CMD ["/usr/bin/qgis"]

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -8,16 +8,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 # Don't let qgis grab python's import mechanism (which breaks pytest).
 ENV QGIS_NO_OVERRIDE_IMPORT 1
 
-ENV TZ Europe/Amsterdam
-
 ARG uid=1000
 ARG gid=1000
 RUN groupadd -g $gid nens && useradd -lm -u $uid -g $gid nens
 
-RUN echo $TZ > /etc/timezone \
-    && apt-get -y update \
+RUN apt-get -y update \
     && apt-get -y install --no-install-recommends \
-        tzdata \
         dirmngr \
         gpg-agent \
         software-properties-common \
@@ -29,9 +25,6 @@ RUN echo $TZ > /etc/timezone \
         git \
 	strace \
 	valgrind \
-    && rm /etc/localtime \
-    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
-    && dpkg-reconfigure -f noninteractive tzdata \
     && apt-get clean \
     && apt-get purge \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -16,7 +16,6 @@ RUN echo $TZ > /etc/timezone \
     && apt-get -y install --no-install-recommends \
         tzdata \
         dirmngr \
-        apt-transport-https \
         gpg-agent \
         software-properties-common \
         wget \

--- a/Docker/qgis3.4.5/Dockerfile
+++ b/Docker/qgis3.4.5/Dockerfile
@@ -45,8 +45,6 @@ RUN apt-get update \
         python3-sqlalchemy \
         qgis \
         qgis-provider-grass \
-        strace \
-        valgrind \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-# test deps
+# Dependencies for development and tests.
 mock
 pytest
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,10 +8,3 @@ pycodestyle
 flake8
 docstr-coverage >= 1.0.4
 coveralls
-
-# misc required deps that are not included with QGIS on linux
-# numpy and cython may be needed for building netCDF4 (see netcdf4-python)
-numpy
-cython
-
-future

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-# git+https://github.com/nens/geoalchemy2.git#egg=geoalchemy2
-GeoAlchemy2==0.6.1
-SQLAlchemy==1.1.0b3
+GeoAlchemy2 >=0.6.2
+SQLAlchemy >=1.1.11, <=1.2
 pyqtgraph
 git+https://github.com/lizardsystem/lizard-connector.git@0.6#egg=lizard_connector
-threedigrid==1.0.10
+threedigrid ==1.0.10
+future

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,12 @@
 # The maximum versions are one minor version higher.
 SQLAlchemy >=1.1.11, <1.2
 future
-gdal >=2.2.3, < 2.3
 numpy >= 1.13.3, <1.14
 pyqtgraph >=0.10.0
+
+# Gdal is commented out, it is notoriously hard to install and fails to find
+# the installed python3-gdal package.
+# gdal >=2.2.3, < 2.3
 
 # Geoalchemy2 is at 0.4.2 in ubuntu 18.04, we need a newer one.
 GeoAlchemy2 >=0.6.2, <0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,14 @@
-GeoAlchemy2 >=0.6.2
-SQLAlchemy >=1.1.11, <=1.2
-pyqtgraph
+# The minimum versions here are the versions provided by ubuntu 18.04.
+# The maximum versions are one minor version higher.
+SQLAlchemy >=1.1.11, <1.2
+future
+gdal >=2.2.3, < 2.3
+numpy >= 1.13.3, <1.14
+pyqtgraph >=0.10.0
+
+# Geoalchemy2 is at 0.4.2 in ubuntu 18.04, we need a newer one.
+GeoAlchemy2 >=0.6.2, <0.7
+
+# Our own custom packages.
 git+https://github.com/lizardsystem/lizard-connector.git@0.6#egg=lizard_connector
 threedigrid ==1.0.10
-future

--- a/threedi_statistics/utils/statistics_database.py
+++ b/threedi_statistics/utils/statistics_database.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import os
 
-import ogr
+from osgeo import ogr
 from ThreeDiToolbox.utils.threedi_database import ThreediDatabase
 from ..sql_models.statistics import Base
 

--- a/utils/import_sufhyd.py
+++ b/utils/import_sufhyd.py
@@ -4,8 +4,8 @@
 from builtins import str
 from builtins import range
 from builtins import object
-import ogr
-import osr
+from osgeo import ogr
+from osgeo import osr
 import logging
 import datetime
 from collections import OrderedDict

--- a/utils/sqlalchemy_add_columns.py
+++ b/utils/sqlalchemy_add_columns.py
@@ -80,8 +80,8 @@ def create_and_upgrade(engine, metadata):
                         % (model_table.name, model_column.name)
                     )
 
-                model_col_spec = re.sub("[(][\d ,]+[)]", "", model_col_spec)
-                db_col_spec = re.sub("[(][\d ,]+[)]", "", db_col_spec)
+                model_col_spec = re.sub(r"[(][\d ,]+[)]", "", model_col_spec)
+                db_col_spec = re.sub(r"[(][\d ,]+[)]", "", db_col_spec)
                 db_col_spec = db_col_spec.replace("DECIMAL", "NUMERIC")
                 db_col_spec = db_col_spec.replace("TINYINT", "BOOL")
 

--- a/utils/threedi_database.py
+++ b/utils/threedi_database.py
@@ -2,7 +2,7 @@ from builtins import object
 import os
 import copy
 
-import ogr
+from osgeo import ogr
 import collections
 from qgis.PyQt.QtCore import QSettings
 from sqlalchemy.orm import sessionmaker

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -87,7 +87,7 @@ def parse_db_source_info(source_info):
     if not source_info[:6] == "dbname":
         return
     layer_info = source_info.replace("'", '"')
-    raw_dict = dict(re.findall('(\S+)="?(.*?)"? ', layer_info))
+    raw_dict = dict(re.findall(r'(\S+)="?(.*?)"? ', layer_info))
     info_dict["database"] = raw_dict.get("dbname", "")
     info_dict["username"] = raw_dict.get("user", "")
     info_dict["password"] = raw_dict.get("password", "")


### PR DESCRIPTION
Replaced the compile-from-source for netcdf and h5py. Also sqlalchemy.
As it is, only geoalchemy2 cannot be used from ubuntu as it seems a bit too old.
I relaxed the requirement specs in requirements.txt a bit for this (and upgraded some to a newer version).