### PR TITLE
[Done] coverage part two

### DIFF
--- a/models/base.py
+++ b/models/base.py
@@ -177,15 +177,15 @@ class BaseModel(QAbstractTableModel):
         item = self.rows[index.row()]
 
         if role == Qt.DisplayRole:
-            if item[index.column()].field_type == VALUE_FIELD:
+            if item[index.column()].field.field_type == VALUE_FIELD:
                 return item[index.column()].value
         elif role == Qt.BackgroundRole:
-            if item[index.column()].field_type == COLOR_FIELD:
+            if item[index.column()].field.field_type == COLOR_FIELD:
                 return item[index.column()].qvalue
         elif role == Qt.TextAlignmentRole:
             return Qt.AlignVCenter
         elif role == Qt.CheckStateRole:
-            if item[index.column()].field_type == CHECKBOX_FIELD:
+            if item[index.column()].field.field_type == CHECKBOX_FIELD:
                 return item[index.column()].qvalue
             else:
                 return None
@@ -226,7 +226,7 @@ class BaseModel(QAbstractTableModel):
     def flags(self, index):
 
         flags = Qt.ItemIsEnabled | Qt.ItemIsSelectable
-        if self.columns[index.column()].field_type == CHECKBOX_FIELD:
+        if self.columns[index.column()].field.field_type == CHECKBOX_FIELD:
             flags |= Qt.ItemIsUserCheckable | Qt.ItemIsEditable
 
         return flags

--- a/models/base.py
+++ b/models/base.py
@@ -49,7 +49,7 @@ class BaseModelItem(object):
     def get_fields(self, show_only=False):
 
         if show_only:
-            return [(name, cl) for name, cl in self._fields if cl.show]
+            return [(name, column_field) for name, column_field in self._fields if column_field.show]
         else:
             return self._fields
 
@@ -84,17 +84,15 @@ class BaseModel(QAbstractTableModel):
         # create item class
         self._fields = sorted(
             [
-                (name, cl)
-                for name, cl in inspect.getmembers(
+                (name, column_field)
+                for name, column_field in inspect.getmembers(
                     self.Fields, lambda a: not (inspect.isroutine(a))
                 )
                 if not name.startswith("__") and not name.startswith("_")
             ],
-            key=lambda cl: cl[1]._nr,
+            key=lambda item: item[1]._nr,  # Sort on column_field number
         )
-
-        self.columns = [cl for name, cl in self._fields]
-
+        self.columns = [column_field for name, column_field in self._fields]
         self.item_class = type(
             self.class_name + "Item",
             (self._base_model_item_class, self.Fields),

--- a/models/base.py
+++ b/models/base.py
@@ -1,10 +1,10 @@
-from .base_fields import CHECKBOX_FIELD
-from .base_fields import COLOR_FIELD
-from .base_fields import VALUE_FIELD
 from qgis.PyQt.QtCore import QAbstractTableModel
 from qgis.PyQt.QtCore import QModelIndex
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtCore import Qt
+from ThreeDiToolbox.models.base_fields import CHECKBOX_FIELD
+from ThreeDiToolbox.models.base_fields import COLOR_FIELD
+from ThreeDiToolbox.models.base_fields import VALUE_FIELD
 
 import inspect
 import logging

--- a/models/base.py
+++ b/models/base.py
@@ -13,7 +13,23 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class BaseModelItem(object):
+class BaseModelRow(object):
+    """Row inside a BaseModel.
+
+    TODO: please, remove this horrible stuff. We have a feature freeze now, so
+    I can only do some minimal renaming to clear it up a bit.
+    [reinout, 2019-06-24]
+
+    - Nothing subclasses this BaseModelRow.
+
+    - BaseModelRow is dynamically generated with ``type()`` in BaseModel, but
+      that makes no sense if there's just one class.
+
+    - BaseModelRow calls BaseModel all the time. As a class, you should keep
+      your fingers out of another class.
+
+    """
+
     def __init__(self, model=None, **kwargs):
 
         self.model = model
@@ -27,7 +43,7 @@ class BaseModelItem(object):
                 value = kwargs[field_name]
 
             setattr(
-                self, field_name, field_class.create_row_field(item=self, value=value)
+                self, field_name, field_class.create_row_field(row=self, value=value)
             )
 
         # for function_name, function in self._functions:
@@ -49,7 +65,11 @@ class BaseModelItem(object):
     def get_fields(self, show_only=False):
 
         if show_only:
-            return [(name, column_field) for name, column_field in self._fields if column_field.show]
+            return [
+                (name, column_field)
+                for name, column_field in self._fields
+                if column_field.show
+            ]
         else:
             return self._fields
 
@@ -61,7 +81,7 @@ class BaseModel(QAbstractTableModel):
     declaration and storage of settings and values in ModelItems, ItemFields
     and Fields"""
 
-    _base_model_item_class = BaseModelItem
+    _base_model_item_class = BaseModelRow
     class_name = "BaseModel"
 
     def __init__(self, ts_datasources=None, initial_data=[], parent=None):
@@ -93,8 +113,9 @@ class BaseModel(QAbstractTableModel):
             key=lambda item: item[1]._nr,  # Sort on column_field number
         )
         self.columns = [column_field for name, column_field in self._fields]
+
         self.item_class = type(
-            self.class_name + "Item",
+            self.class_name + "Row",
             (self._base_model_item_class, self.Fields),
             {"_fields": self._fields},
         )

--- a/models/base_fields.py
+++ b/models/base_fields.py
@@ -17,24 +17,25 @@ def get_field_nr():
 
 
 class RowFieldValue(object):
-    """Class holding the value for a column/field for a certain item.
+    """Class holding the value for a column/field for a certain row.
 
     The field is the BaseField instance (so: really a column).
 
     The value is mapped to something QT-friendly.
 
-    The "item" is probably a table.
+    The "row" is a BaseModelRow instance.
 
     """
-    def __init__(self, item, field, value=None):
+
+    def __init__(self, row, field, value=None):
         """Initialization.
 
-        :param item: ModelItem to which this ItemField belongs
+        :param row: BaseModelRow to which this ItemField belongs
         :param field: ModelField
         :param value: Initial value
 
         """
-        self.item = item
+        self.row = row
         self.field = field
         self._value = None
 
@@ -56,8 +57,8 @@ class RowFieldValue(object):
     def value(self, value):
         """Set new value, possibly after some adjustments, and return it.
 
-        :param value: value to be set for field item
-        :return: new value of field item
+        :param value: value to be set for field row
+        :return: new value of field row
         """
         if self.field_type == CHECKBOX_FIELD:
             if type(value) == bool:
@@ -87,11 +88,11 @@ class RowFieldValue(object):
             return
         self._value = value
         if signal:
-            if self.item.model:
-                index = self.item.model.index(
-                    self.item.get_row_nr(), self.field.column_nr
+            if self.row.model:
+                index = self.row.model.index(
+                    self.row.get_row_nr(), self.field.column_nr
                 )
-                self.item.model.dataChanged.emit(index, index)
+                self.row.model.dataChanged.emit(index, index)
 
     @property
     def qvalue(self):
@@ -112,12 +113,12 @@ class RowFieldValue(object):
             return self._value
 
     def __getattr__(self, prop_name):
-        """Return property of related field, directly from this item field.
+        """Return property of related field, directly from this row field.
 
         :param prop_name: property name
         :return: value of related Field property
 
-        # TODO: check if it is used. I see item_field.item.model.rows() and
+        # TODO: check if it is used. I see item_field.row.model.rows() and
         so.... Everyone seems to dive into its internals anyway...
 
         """
@@ -134,6 +135,7 @@ class BaseField(object):
     RowFieldValue, which is basically a row's value for this column.
 
     """
+
     field_type = None
 
     def __init__(
@@ -165,21 +167,24 @@ class BaseField(object):
         self.model = model
         self.column_nr = column_nr
 
-    def create_row_field(self, item, value=None):
-        return RowFieldValue(item, field=self, value=value)
+    def create_row_field(self, row, value=None):
+        return RowFieldValue(row, field=self, value=value)
 
 
 class ValueField(BaseField):
     """Field implementation for Values, which (for now) can be everything
     which can be showed in plain text (string, int, float)"""
+
     field_type = VALUE_FIELD
 
 
 class ColorField(BaseField):
     """Field implementation for Colors."""
+
     field_type = COLOR_FIELD
 
 
 class CheckboxField(BaseField):
     """Field implementation for booleans with checkboxes"""
+
     field_type = CHECKBOX_FIELD

--- a/models/base_fields.py
+++ b/models/base_fields.py
@@ -118,17 +118,13 @@ class RowFieldValue(object):
         :param prop_name: property name
         :return: value of related Field property
 
-        # TODO: check if it is used. I see item_field.row.model.rows() and
-        so.... Everyone seems to dive into its internals anyway...
-
-        One old use case that I removed is ``self.field_type``, which is now
-        explicitly ``self.field.field_type``...
+        It is used to grab things like default_value, column_width,
+        column_name from the BaseField. See
+        ``tool_graph/test_graph_model.py``, the
+        ``item.active.default_value``call.
 
         """
         if hasattr(self.field, prop_name):
-            logger.warn(
-                "To fix: indirect property access from RowFieldValue to Basefield."
-            )
             return getattr(self.field, prop_name)
         else:
             raise AttributeError

--- a/models/base_fields.py
+++ b/models/base_fields.py
@@ -73,19 +73,17 @@ class BaseItemField(object):
         :param value: new value
         :param signal: bool, send dataChanged event through model on value
                        change
-        :return: value changed
         """
         if value == self._value:
-            return False
-        else:
-            self._value = value
-            if signal:
-                if self.item.model:
-                    index = self.item.model.index(
-                        self.item.get_row_nr(), self.field.column_nr
-                    )
-                    self.item.model.dataChanged.emit(index, index)
-            return True
+            # No need to set it and fire a signal and so.
+            return
+        self._value = value
+        if signal:
+            if self.item.model:
+                index = self.item.model.index(
+                    self.item.get_row_nr(), self.field.column_nr
+                )
+                self.item.model.dataChanged.emit(index, index)
 
     @property
     def qvalue(self):

--- a/models/base_fields.py
+++ b/models/base_fields.py
@@ -60,7 +60,7 @@ class RowFieldValue(object):
         :param value: value to be set for field row
         :return: new value of field row
         """
-        if self.field_type == CHECKBOX_FIELD:
+        if self.field.field_type == CHECKBOX_FIELD:
             if type(value) == bool:
                 self._set_value(value)
             elif value == Qt.Checked:
@@ -101,12 +101,12 @@ class RowFieldValue(object):
         :return: current value, adjusted for qt.
 
         """
-        if self.field_type == CHECKBOX_FIELD:
+        if self.field.field_type == CHECKBOX_FIELD:
             if self.value:
                 return Qt.Checked
             else:
                 return Qt.Unchecked
-        elif self.field_type == COLOR_FIELD:
+        elif self.field.field_type == COLOR_FIELD:
             if self.value is not None:
                 return QColor(*self.value)
         else:
@@ -121,8 +121,14 @@ class RowFieldValue(object):
         # TODO: check if it is used. I see item_field.row.model.rows() and
         so.... Everyone seems to dive into its internals anyway...
 
+        One old use case that I removed is ``self.field_type``, which is now
+        explicitly ``self.field.field_type``...
+
         """
         if hasattr(self.field, prop_name):
+            logger.warn(
+                "To fix: indirect property access from RowFieldValue to Basefield."
+            )
             return getattr(self.field, prop_name)
         else:
             raise AttributeError

--- a/models/base_fields.py
+++ b/models/base_fields.py
@@ -17,14 +17,15 @@ def get_field_nr():
 
 
 class BaseItemField(object):
-    """base class for each field in a row containing the value"""
+    """Base class for each field in a row containing a value."""
 
     def __init__(self, item, field, value=None):
-        """
-        initialization
+        """Initialization.
+
         :param item: ModelItem to which this ItemField belongs
         :param field: ModelField
         :param value: Initial value
+
         """
         self.item = item
         self.field = field
@@ -41,16 +42,13 @@ class BaseItemField(object):
 
     @property
     def value(self):
-        """
-        get current value
-        :return: current value
-        """
+        """Return current value."""
         return self._value
 
     @value.setter
     def value(self, value):
-        """
-        set new value
+        """Set new value, possibly after some adjustments, and return it.
+
         :param value: value to be set for field item
         :return: new value of field item
         """
@@ -67,12 +65,15 @@ class BaseItemField(object):
         return self._value
 
     def _set_value(self, value, signal=True):
-        """
-        private function for setting value, including sending a signal if
+        """Set value (if changed) and fire a signal.
+
+        Private function for setting value, including sending a signal if
         value changed
+
         :param value: new value
         :param signal: bool, send dataChanged event through model on value
                        change
+
         """
         if value == self._value:
             # No need to set it and fire a signal and so.
@@ -87,9 +88,10 @@ class BaseItemField(object):
 
     @property
     def qvalue(self):
-        """
-        get current value in a Qt object
-        :return: current value
+        """Return current value as a Qt object
+
+        :return: current value, adjusted for qt.
+
         """
         if self.field_type == CHECKBOX_FIELD:
             if self.value:
@@ -103,8 +105,8 @@ class BaseItemField(object):
             return self._value
 
     def __getattr__(self, prop_name):
-        """
-        get properties of related field, directly on item field
+        """Return property of related field, directly from this item field.
+
         :param prop_name: property name
         :return: value of related Field property
         """

--- a/models/base_fields.py
+++ b/models/base_fields.py
@@ -16,9 +16,16 @@ def get_field_nr():
     return field_nr
 
 
-class BaseItemField(object):
-    """Base class for each field in a row containing a value."""
+class RowFieldValue(object):
+    """Class holding the value for a column/field for a certain item.
 
+    The field is the BaseField instance (so: really a column).
+
+    The value is mapped to something QT-friendly.
+
+    The "item" is probably a table.
+
+    """
     def __init__(self, item, field, value=None):
         """Initialization.
 
@@ -121,6 +128,12 @@ class BaseItemField(object):
 
 
 class BaseField(object):
+    """Configuration for a column: what kind of field are we?
+
+    Important is the ``.create_row_field()`` method that creates a
+    RowFieldValue, which is basically a row's value for this column.
+
+    """
     field_type = None
 
     def __init__(
@@ -153,7 +166,7 @@ class BaseField(object):
         self.column_nr = column_nr
 
     def create_row_field(self, item, value=None):
-        return BaseItemField(item, field=self, value=value)
+        return RowFieldValue(item, field=self, value=value)
 
 
 class ValueField(BaseField):

--- a/models/base_fields.py
+++ b/models/base_fields.py
@@ -109,6 +109,10 @@ class BaseItemField(object):
 
         :param prop_name: property name
         :return: value of related Field property
+
+        # TODO: check if it is used. I see item_field.item.model.rows() and
+        so.... Everyone seems to dive into its internals anyway...
+
         """
         if hasattr(self.field, prop_name):
             return getattr(self.field, prop_name)
@@ -117,6 +121,8 @@ class BaseItemField(object):
 
 
 class BaseField(object):
+    field_type = None
+
     def __init__(
         self,
         name=None,
@@ -140,7 +146,6 @@ class BaseField(object):
         self.model = None
 
     def contribute_to_class(self, name, model, column_nr):
-
         self.name = name
         if self.column_name is None:
             self.column_name = name
@@ -148,32 +153,20 @@ class BaseField(object):
         self.column_nr = column_nr
 
     def create_row_field(self, item, value=None):
-
         return BaseItemField(item, field=self, value=value)
 
 
 class ValueField(BaseField):
     """Field implementation for Values, which (for now) can be everything
     which can be showed in plain text (string, int, float)"""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.field_type = VALUE_FIELD
+    field_type = VALUE_FIELD
 
 
 class ColorField(BaseField):
     """Field implementation for Colors."""
-
-    def __init__(self, *args, **kwargs):
-        """same as BaseField. Color values are a list of three color values
-        in the range of 0-256. For example (68, 55, 204)"""
-        super().__init__(*args, **kwargs)
-        self.field_type = COLOR_FIELD
+    field_type = COLOR_FIELD
 
 
 class CheckboxField(BaseField):
     """Field implementation for booleans with checkboxes"""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.field_type = CHECKBOX_FIELD
+    field_type = CHECKBOX_FIELD

--- a/models/tests.py
+++ b/models/tests.py
@@ -1,5 +1,5 @@
-from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QColor
 from ThreeDiToolbox.models import base_fields
 
 import mock

--- a/models/tests.py
+++ b/models/tests.py
@@ -1,0 +1,53 @@
+from qgis.PyQt.QtGui import QColor
+from qgis.PyQt.QtCore import Qt
+from ThreeDiToolbox.models import base_fields
+
+import mock
+
+
+def test_row_field_value_set_value():
+    row = mock.Mock()
+    field = mock.Mock()
+    row_field_value = base_fields.RowFieldValue(row, field, 42)
+    # For coverage, test that setting a value to the current value doesn't
+    # fire any signals.
+    row_field_value._set_value(42)
+    assert not row_field_value.row.model.dataChanged.emit.called
+
+
+def test_row_field_value_qvalue1():
+    row = mock.Mock()
+    field = mock.Mock()
+    row_field_value = base_fields.RowFieldValue(row, field, 42)
+    # Not a specific special field, so we just return the value.
+    assert row_field_value.qvalue == 42
+
+
+def test_row_field_value_qvalue2():
+    row = mock.Mock()
+    field = mock.Mock()
+    # For checkbox fields, we want the proper QT version of true/false.
+    field.field_type = base_fields.CHECKBOX_FIELD
+    row_field_value = base_fields.RowFieldValue(row, field, True)
+    assert row_field_value.qvalue == Qt.Checked
+    row_field_value = base_fields.RowFieldValue(row, field, False)
+    assert row_field_value.qvalue == Qt.Unchecked
+
+
+def test_row_field_value_qvalue3():
+    row = mock.Mock()
+    field = mock.Mock()
+    # Color fields should return a qt color.
+    field.field_type = base_fields.COLOR_FIELD
+    row_field_value = base_fields.RowFieldValue(row, field, [42, 42, 42])
+    assert isinstance(row_field_value.qvalue, QColor)
+
+
+def test_row_field_value_qvalue4():
+    row = mock.Mock()
+    field = mock.Mock()
+    field.field_type = base_fields.COLOR_FIELD
+    # Special case: don't return a color if the value is None.
+    row_field_value = base_fields.RowFieldValue(row, field, None)
+    row_field_value._value = None  # Otherwise default_value() gives us a Mock :-)
+    assert row_field_value.qvalue is None

--- a/tool_graph/graph_model.py
+++ b/tool_graph/graph_model.py
@@ -47,7 +47,7 @@ def select_default_color(item_field):
     :return: tuple with the 3 color bands (values between 0-256)
     """
 
-    model = item_field.item.model
+    model = item_field.row.model
     colors = OrderedDict([(str(color), color) for color in COLOR_LIST])
 
     for item in model.rows:

--- a/tool_result_selection/models.py
+++ b/tool_result_selection/models.py
@@ -34,7 +34,7 @@ def get_line_pattern(item_field):
         Qt.DashDotDotLine,
     ]
 
-    already_used_patterns = [item.pattern.value for item in item_field.item.model.rows]
+    already_used_patterns = [item.pattern.value for item in item_field.row.model.rows]
 
     for style in available_styles:
         if style not in already_used_patterns:

--- a/tool_water_balance/models/wb_item.py
+++ b/tool_water_balance/models/wb_item.py
@@ -42,7 +42,7 @@ def select_default_color(item_field):
     :return: tuple with the 3 color bands (values between 0-256)
     """
 
-    model = item_field.item.model
+    model = item_field.row.model
     colors = OrderedDict([(str(color), color) for color in COLOR_LIST])
 
     for item in model.rows:


### PR DESCRIPTION
Mostly I looked at improving the coverage for `models/` a bit.
In the end, I mostly added docstrings, trying to figure out what was happening.

I also did a bit of renaming, which is mostly only internal to this `models/*` directory. So the rename is much more "documentation" than it is "refactoring", which makes it OK for during the feature freeze.

The renaming was necessary as I just could not make sense of "item" and "model" and "field" and so.