### PR TITLE
Fixed dependency installation on windows 7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,13 @@ ThreeDiToolBox changelog
 1.12 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fixed dependency installation on windows 7.
 
 
 1.11.1 (2019-06-17)
 -------------------
 
-- Nothing changed yet.
+- Release fix.
 
 
 1.11 (2019-06-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,15 +7,13 @@ ThreeDiToolBox changelog
 
 - Fixed dependency installation on windows 7.
 
+- Added developer documentation.
+
+- Modelchecker user interface improvements.
+
 
 1.11.1 (2019-06-17)
 -------------------
-
-- Release fix.
-
-
-1.11 (2019-06-17)
------------------
 
 - Made automated tests on travis-ci.org run much faster (from 8 down to 3
   minutes).

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -52,6 +52,12 @@ def test_install_dependencies(tmpdir):
     assert installed_directory.exists()
 
 
+def test_install_dependencies_with_error(tmpdir):
+    wrong_dependencies = [missing_dependency]
+    with pytest.raises(RuntimeError):
+        dependencies._install_dependencies(wrong_dependencies, target_dir=tmpdir)
+
+
 def test_generate_constraints_txt(tmpdir):
     target_dir = Path(tmpdir)
     dependencies.generate_constraints_txt(target_dir=target_dir)


### PR DESCRIPTION
I copied some `subprocess.Popen()` code from buildout, so I'm pretty sure that's robust.