### PR TITLE
Ivar qml

### DIFF
--- a/layer_styles/custom_widgets/mywidget.py
+++ b/layer_styles/custom_widgets/mywidget.py
@@ -1,0 +1,54 @@
+# https://github.com/elpaso/qgis-formawarevaluerelationwidget/blob/master/FormAwareValueRelationWidget.py
+# https://gis.stackexchange.com/questions/202371/how-to-format-qgis-field-names-on-editor-form
+
+
+from qgis.gui import QgsEditorWidgetWrapper
+from qgis.gui import QgsEditorWidgetFactory
+from qgis.gui import QgsEditorConfigWidget
+from qgis.PyQt.QtWidgets import QWidget
+
+
+class MyCustomWidget(QgsEditorWidgetWrapper):
+    def __init__(self, vl, fieldIdx, editor, parent):
+        super().__init__(vl, fieldIdx, editor, parent)
+        self.key_index = -1
+        self.value_index = -1
+        self.context = None
+        self.expression = None
+        # Re-create the cache if the layer is modified
+        self.mLayer.layerModified.connect(self.createCache)
+        self.completer_list = None  # Caches completer elements
+        self.completer = None  # Store compler instance
+        self.editor = editor
+
+    # def createWidget(self, parent):
+    #     return super().create()
+
+
+class MyQgsEditorConfigWidget(QgsEditorConfigWidget):
+
+    def __init__(self, vl, fieldIdx, parent):
+        super(MyQgsEditorConfigWidget, self).__init__(vl, fieldIdx, parent)
+
+
+class MyCustomWidgetFactory(QgsEditorWidgetFactory):
+
+    def __init__(self, name):
+        super(MyCustomWidgetFactory, self).__init__(name)
+        self.wrapper = None
+        self.dlg = None
+
+    def configWidget(self, vl, fieldIdx, parent):
+        print("MY CUSTOM CONFIGWIDGET FUNCTION")
+        self.dlg = MyQgsEditorConfigWidget(vl, fieldIdx, parent)
+        return self.dlg
+
+    def create(self, vl, fieldIdx, editor, parent):
+        # QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent
+        self.wrapper = MyCustomWidget(vl, fieldIdx, editor, parent)
+        return self.wrapper
+
+
+if __name__ == '__main__':
+    config_widget = MyQgsEditorConfigWidget()
+    print('done')

--- a/layer_styles/schematisation/v2_1d_boundary_conditions.qml
+++ b/layer_styles/schematisation/v2_1d_boundary_conditions.qml
@@ -1,80 +1,21 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="-4.65661e-10" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
-    <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
-        <layer enabled="1" pass="0" locked="0" class="SimpleMarker">
-          <prop k="angle" v="225"/>
-          <prop k="color" v="51,160,44,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="arrow"/>
-          <prop k="offset" v="0,3"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="area"/>
-          <prop k="size" v="5"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-    </symbols>
-    <rotation/>
-    <sizescale/>
-  </renderer-v2>
   <customproperties>
+    <property key="dualview/previewExpressions" value="id"/>
     <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="-4.65661e-10" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
-      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
-    </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
-    <properties>
-      <Option type="Map">
-        <Option type="QString" value="" name="name"/>
-        <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
-      </Option>
-    </properties>
-  </DiagramLayerSettings>
   <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
   <fieldConfiguration>
-    <field name="ROWID">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
     <field name="id">
       <editWidget type="TextEdit">
         <config>
@@ -95,6 +36,28 @@
         </config>
       </editWidget>
     </field>
+    <field name="boundary_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: Waterlevel"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="2: Velocity"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="3" name="3: Discharge"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="5" name="5: Sommerfeld"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
     <field name="timeseries">
       <editWidget type="TextEdit">
         <config>
@@ -107,29 +70,29 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="ROWID" index="0" name=""/>
-    <alias field="id" index="1" name=""/>
-    <alias field="connection_node_id" index="2" name=""/>
+    <alias field="id" index="0" name=""/>
+    <alias field="connection_node_id" index="1" name=""/>
+    <alias field="boundary_type" index="2" name=""/>
     <alias field="timeseries" index="3" name=""/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
     <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
     <default expression="" applyOnUpdate="0" field="connection_node_id"/>
+    <default expression="" applyOnUpdate="0" field="boundary_type"/>
     <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="id" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
     <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="boundary_type" exp_strength="0"/>
     <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="ROWID" exp=""/>
     <constraint desc="" field="id" exp=""/>
     <constraint desc="" field="connection_node_id" exp=""/>
+    <constraint desc="" field="boundary_type" exp=""/>
     <constraint desc="" field="timeseries" exp=""/>
   </constraintExpressions>
   <expressionfields/>
@@ -138,9 +101,9 @@
   </attributeactions>
   <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
-      <column width="-1" hidden="0" type="field" name="ROWID"/>
       <column width="-1" hidden="0" type="field" name="id"/>
       <column width="-1" hidden="0" type="field" name="connection_node_id"/>
+      <column width="-1" hidden="0" type="field" name="boundary_type"/>
       <column width="-1" hidden="0" type="field" name="timeseries"/>
       <column width="-1" hidden="1" type="actions"/>
     </columns>
@@ -149,10 +112,10 @@
     <rowstyles/>
     <fieldstyles/>
   </conditionalstyles>
-  <editform tolerant="1">.</editform>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath>.</editforminitfilepath>
+  <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -164,7 +127,7 @@ Enter the name of the function in the "Python Init function"
 field.
 An example follows:
 """
-from PyQt4.QtGui import QWidget
+from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
@@ -174,25 +137,26 @@ def my_form_open(dialog, layer, feature):
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
     <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="1" name="id" showLabel="1"/>
-      <attributeEditorField index="2" name="connection_node_id" showLabel="1"/>
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="connection_node_id" showLabel="1"/>
+      <attributeEditorField index="2" name="boundary_type" showLabel="1"/>
       <attributeEditorField index="3" name="timeseries" showLabel="1"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="ROWID"/>
+    <field editable="1" name="boundary_type"/>
     <field editable="1" name="connection_node_id"/>
     <field editable="1" name="id"/>
     <field editable="1" name="timeseries"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="boundary_type"/>
     <field labelOnTop="0" name="connection_node_id"/>
     <field labelOnTop="0" name="id"/>
     <field labelOnTop="0" name="timeseries"/>
   </labelOnTop>
   <widgets/>
-  <previewExpression>ROWID</previewExpression>
-  <mapTip>display_name</mapTip>
-  <layerGeometryType>0</layerGeometryType>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_1d_boundary_conditions.qml
+++ b/layer_styles/schematisation/v2_1d_boundary_conditions.qml
@@ -1,13 +1,13 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property key="dualview/previewExpressions" value="id"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="id" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
@@ -20,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -30,8 +30,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -42,16 +42,16 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1" name="1: Waterlevel"/>
+                <Option value="1" type="QString" name="1: waterlevel"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="2: Velocity"/>
+                <Option value="2" type="QString" name="2: velocity"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="3" name="3: Discharge"/>
+                <Option value="3" type="QString" name="3: discharge"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="5" name="5: Sommerfeld"/>
+                <Option value="5" type="QString" name="5: sommerfeld"/>
               </Option>
             </Option>
           </Option>
@@ -62,18 +62,18 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="true" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="id" index="0" name=""/>
-    <alias field="connection_node_id" index="1" name=""/>
-    <alias field="boundary_type" index="2" name=""/>
-    <alias field="timeseries" index="3" name=""/>
+    <alias name="" field="id" index="0"/>
+    <alias name="" field="connection_node_id" index="1"/>
+    <alias name="" field="boundary_type" index="2"/>
+    <alias name="" field="timeseries" index="3"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
@@ -84,28 +84,28 @@
     <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="boundary_type" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="boundary_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="timeseries"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="id" exp=""/>
-    <constraint desc="" field="connection_node_id" exp=""/>
-    <constraint desc="" field="boundary_type" exp=""/>
-    <constraint desc="" field="timeseries" exp=""/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="connection_node_id"/>
+    <constraint exp="" desc="" field="boundary_type"/>
+    <constraint exp="" desc="" field="timeseries"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
-      <column width="-1" hidden="0" type="field" name="boundary_type"/>
-      <column width="-1" hidden="0" type="field" name="timeseries"/>
-      <column width="-1" hidden="1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_id"/>
+      <column width="-1" type="field" hidden="0" name="boundary_type"/>
+      <column width="-1" type="field" hidden="0" name="timeseries"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -136,18 +136,18 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="0" name="id" showLabel="1"/>
-      <attributeEditorField index="1" name="connection_node_id" showLabel="1"/>
-      <attributeEditorField index="2" name="boundary_type" showLabel="1"/>
-      <attributeEditorField index="3" name="timeseries" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+      <attributeEditorField showLabel="1" name="id" index="0"/>
+      <attributeEditorField showLabel="1" name="connection_node_id" index="1"/>
+      <attributeEditorField showLabel="1" name="boundary_type" index="2"/>
+      <attributeEditorField showLabel="1" name="timeseries" index="3"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="boundary_type"/>
-    <field editable="1" name="connection_node_id"/>
-    <field editable="1" name="id"/>
-    <field editable="1" name="timeseries"/>
+    <field name="boundary_type" editable="1"/>
+    <field name="connection_node_id" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="timeseries" editable="1"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="boundary_type"/>

--- a/layer_styles/schematisation/v2_1d_boundary_conditions.qml
+++ b/layer_styles/schematisation/v2_1d_boundary_conditions.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -11,7 +11,7 @@
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -20,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -30,8 +30,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -40,18 +40,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: waterlevel"/>
+                <Option value="1" name="1: waterlevel" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: velocity"/>
+                <Option value="2" name="2: velocity" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: discharge"/>
+                <Option value="3" name="3: discharge" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: sommerfeld"/>
+                <Option value="5" name="5: sommerfeld" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -62,32 +62,32 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="true" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="id" index="0"/>
-    <alias name="" field="connection_node_id" index="1"/>
-    <alias name="" field="boundary_type" index="2"/>
-    <alias name="" field="timeseries" index="3"/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="connection_node_id"/>
+    <alias index="2" name="" field="boundary_type"/>
+    <alias index="3" name="" field="timeseries"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
-    <default expression="" applyOnUpdate="0" field="boundary_type"/>
-    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="" field="connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="boundary_type"/>
+    <default applyOnUpdate="0" expression="" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="boundary_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="timeseries"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="2" field="connection_node_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="boundary_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timeseries" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" desc="" field="id"/>
@@ -99,13 +99,13 @@
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="id"/>
-      <column width="-1" type="field" hidden="0" name="connection_node_id"/>
-      <column width="-1" type="field" hidden="0" name="boundary_type"/>
-      <column width="-1" type="field" hidden="0" name="timeseries"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_id" type="field"/>
+      <column width="-1" hidden="0" name="boundary_type" type="field"/>
+      <column width="-1" hidden="0" name="timeseries" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -136,18 +136,18 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-      <attributeEditorField showLabel="1" name="id" index="0"/>
-      <attributeEditorField showLabel="1" name="connection_node_id" index="1"/>
-      <attributeEditorField showLabel="1" name="boundary_type" index="2"/>
-      <attributeEditorField showLabel="1" name="timeseries" index="3"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="0" name="id"/>
+      <attributeEditorField showLabel="1" index="1" name="connection_node_id"/>
+      <attributeEditorField showLabel="1" index="2" name="boundary_type"/>
+      <attributeEditorField showLabel="1" index="3" name="timeseries"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="boundary_type" editable="1"/>
-    <field name="connection_node_id" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="timeseries" editable="1"/>
+    <field editable="1" name="boundary_type"/>
+    <field editable="1" name="connection_node_id"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="boundary_type"/>

--- a/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
+++ b/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="-4.65661e-10" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="0" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
-        <layer enabled="1" pass="0" locked="0" class="SimpleMarker">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="0">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="170,0,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -29,9 +29,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -41,25 +41,25 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="-4.65661e-10" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -79,8 +79,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -89,8 +89,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -101,16 +101,16 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1" name="1: Waterlevel"/>
+                <Option value="1" type="QString" name="1: waterlevel"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="2: Velocity"/>
+                <Option value="2" type="QString" name="2: velocity"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="3" name="3: Discharge"/>
+                <Option value="3" type="QString" name="3: discharge"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="5" name="5: Sommerfeld"/>
+                <Option value="5" type="QString" name="5: sommerfeld"/>
               </Option>
             </Option>
           </Option>
@@ -121,19 +121,19 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="true" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="ROWID" index="0" name=""/>
-    <alias field="id" index="1" name=""/>
-    <alias field="connection_node_id" index="2" name=""/>
-    <alias field="boundary_type" index="3" name=""/>
-    <alias field="timeseries" index="4" name=""/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="" field="id" index="1"/>
+    <alias name="" field="connection_node_id" index="2"/>
+    <alias name="" field="boundary_type" index="3"/>
+    <alias name="" field="timeseries" index="4"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
@@ -145,31 +145,31 @@
     <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="boundary_type" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="boundary_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="timeseries"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="ROWID" exp=""/>
-    <constraint desc="" field="id" exp=""/>
-    <constraint desc="" field="connection_node_id" exp=""/>
-    <constraint desc="" field="boundary_type" exp=""/>
-    <constraint desc="" field="timeseries" exp=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="connection_node_id"/>
+    <constraint exp="" desc="" field="boundary_type"/>
+    <constraint exp="" desc="" field="timeseries"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column width="-1" hidden="0" type="field" name="ROWID"/>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
-      <column width="-1" hidden="0" type="field" name="boundary_type"/>
-      <column width="-1" hidden="0" type="field" name="timeseries"/>
-      <column width="-1" hidden="1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_id"/>
+      <column width="-1" type="field" hidden="0" name="boundary_type"/>
+      <column width="-1" type="field" hidden="0" name="timeseries"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -200,19 +200,19 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="1" name="id" showLabel="1"/>
-      <attributeEditorField index="2" name="connection_node_id" showLabel="1"/>
-      <attributeEditorField index="3" name="boundary_type" showLabel="1"/>
-      <attributeEditorField index="4" name="timeseries" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+      <attributeEditorField showLabel="1" name="id" index="1"/>
+      <attributeEditorField showLabel="1" name="connection_node_id" index="2"/>
+      <attributeEditorField showLabel="1" name="boundary_type" index="3"/>
+      <attributeEditorField showLabel="1" name="timeseries" index="4"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="ROWID"/>
-    <field editable="1" name="boundary_type"/>
-    <field editable="1" name="connection_node_id"/>
-    <field editable="1" name="id"/>
-    <field editable="1" name="timeseries"/>
+    <field name="ROWID" editable="1"/>
+    <field name="boundary_type" editable="1"/>
+    <field name="connection_node_id" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="timeseries" editable="1"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="ROWID"/>

--- a/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
+++ b/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
@@ -1,37 +1,37 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="0" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis version="3.4.5-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" minScale="1e+08" labelsEnabled="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" readOnly="0" simplifyMaxScale="1" simplifyAlgorithm="0" maxScale="-4.65661e-10">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="0">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="170,0,255,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="square"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="area"/>
-          <prop k="size" v="2"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol alpha="1" name="0" force_rhr="0" type="marker" clip_to_extent="1">
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="170,0,255,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="square" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="area" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -41,25 +41,25 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property value="0" key="embeddedWidgets/count"/>
+    <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" penAlpha="255" width="15" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" rotationOffset="270" barWidth="5" sizeType="MM" backgroundColor="#ffffff" diagramOrientation="Up" maxScaleDenominator="1e+08" enabled="0" lineSizeType="MM" backgroundAlpha="255" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" opacity="1" height="15" minimumSize="0">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+      <attribute color="#000000" field="" label=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="0" zIndex="0">
+  <DiagramLayerSettings placement="0" linePlacementFlags="2" obstacle="0" dist="0" showAll="1" priority="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -79,8 +79,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -89,8 +89,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -99,18 +99,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: waterlevel"/>
+                <Option value="1" name="1: waterlevel" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: velocity"/>
+                <Option value="2" name="2: velocity" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: discharge"/>
+                <Option value="3" name="3: discharge" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: sommerfeld"/>
+                <Option value="5" name="5: sommerfeld" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -121,55 +121,55 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="true" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="ROWID" index="0"/>
-    <alias name="" field="id" index="1"/>
-    <alias name="" field="connection_node_id" index="2"/>
-    <alias name="" field="boundary_type" index="3"/>
-    <alias name="" field="timeseries" index="4"/>
+    <alias field="ROWID" name="" index="0"/>
+    <alias field="id" name="" index="1"/>
+    <alias field="connection_node_id" name="" index="2"/>
+    <alias field="boundary_type" name="" index="3"/>
+    <alias field="timeseries" name="" index="4"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
-    <default expression="" applyOnUpdate="0" field="boundary_type"/>
-    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+    <default field="ROWID" expression="" applyOnUpdate="0"/>
+    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+    <default field="connection_node_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))" applyOnUpdate="0"/>
+    <default field="boundary_type" expression="" applyOnUpdate="0"/>
+    <default field="timeseries" expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="boundary_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="timeseries"/>
+    <constraint unique_strength="0" exp_strength="0" field="ROWID" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="id" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="connection_node_id" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="boundary_type" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="timeseries" notnull_strength="2" constraints="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="id"/>
-    <constraint exp="" desc="" field="connection_node_id"/>
-    <constraint exp="" desc="" field="boundary_type"/>
-    <constraint exp="" desc="" field="timeseries"/>
+    <constraint field="ROWID" desc="" exp=""/>
+    <constraint field="id" desc="" exp=""/>
+    <constraint field="connection_node_id" desc="" exp=""/>
+    <constraint field="boundary_type" desc="" exp=""/>
+    <constraint field="timeseries" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
   <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column width="-1" type="field" hidden="0" name="ROWID"/>
-      <column width="-1" type="field" hidden="0" name="id"/>
-      <column width="-1" type="field" hidden="0" name="connection_node_id"/>
-      <column width="-1" type="field" hidden="0" name="boundary_type"/>
-      <column width="-1" type="field" hidden="0" name="timeseries"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column hidden="0" name="ROWID" type="field" width="-1"/>
+      <column hidden="0" name="id" type="field" width="-1"/>
+      <column hidden="0" name="connection_node_id" type="field" width="-1"/>
+      <column hidden="0" name="boundary_type" type="field" width="-1"/>
+      <column hidden="0" name="timeseries" type="field" width="-1"/>
+      <column hidden="1" type="actions" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -200,7 +200,7 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+    <attributeEditorContainer showLabel="1" name="General" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0" columnCount="1">
       <attributeEditorField showLabel="1" name="id" index="1"/>
       <attributeEditorField showLabel="1" name="connection_node_id" index="2"/>
       <attributeEditorField showLabel="1" name="boundary_type" index="3"/>
@@ -210,16 +210,16 @@ def my_form_open(dialog, layer, feature):
   <editable>
     <field name="ROWID" editable="1"/>
     <field name="boundary_type" editable="1"/>
-    <field name="connection_node_id" editable="1"/>
+    <field name="connection_node_id" editable="0"/>
     <field name="id" editable="1"/>
     <field name="timeseries" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ROWID"/>
-    <field labelOnTop="0" name="boundary_type"/>
-    <field labelOnTop="0" name="connection_node_id"/>
-    <field labelOnTop="0" name="id"/>
-    <field labelOnTop="0" name="timeseries"/>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="boundary_type" labelOnTop="0"/>
+    <field name="connection_node_id" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="timeseries" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
+++ b/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
@@ -1,226 +1,182 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.4-Essen" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="ROWID">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="connection_node_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="boundary_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="timeseries">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="-4.65661e-10" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="marker" name="0">
-        <layer pass="0" class="SimpleMarker" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="170,0,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="name" v="rectangle"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="square"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="scale_method" v="area"/>
           <prop k="size" v="2"/>
-          <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="size_unit" v="MM"/>
           <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="0"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>ROWID</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="-4.65661e-10">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="-4.65661e-10" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="boundary_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: Waterlevel"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="2: Velocity"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="3" name="3: Discharge"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="5" name="5: Sommerfeld"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="timeseries">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="ROWID" index="0" name=""/>
+    <alias field="id" index="1" name=""/>
+    <alias field="connection_node_id" index="2" name=""/>
+    <alias field="boundary_type" index="3" name=""/>
+    <alias field="timeseries" index="4" name=""/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform></editform>
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
+    <default expression="" applyOnUpdate="0" field="boundary_type"/>
+    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="boundary_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="ROWID" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="connection_node_id" exp=""/>
+    <constraint desc="" field="boundary_type" exp=""/>
+    <constraint desc="" field="timeseries" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="ROWID"/>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
+      <column width="-1" hidden="0" type="field" name="boundary_type"/>
+      <column width="-1" hidden="0" type="field" name="timeseries"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -242,11 +198,31 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="1" name="id" showLabel="1"/>
+      <attributeEditorField index="2" name="connection_node_id" showLabel="1"/>
+      <attributeEditorField index="3" name="boundary_type" showLabel="1"/>
+      <attributeEditorField index="4" name="timeseries" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="ROWID"/>
+    <field editable="1" name="boundary_type"/>
+    <field editable="1" name="connection_node_id"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="boundary_type"/>
+    <field labelOnTop="0" name="connection_node_id"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="timeseries"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>ROWID</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
+++ b/layer_styles/schematisation/v2_1d_boundary_conditions_view.qml
@@ -1,32 +1,32 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.4.5-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" minScale="1e+08" labelsEnabled="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" readOnly="0" simplifyMaxScale="1" simplifyAlgorithm="0" maxScale="-4.65661e-10">
+<qgis maxScale="-4.65661e-10" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol alpha="1" name="0" force_rhr="0" type="marker" clip_to_extent="1">
-        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
-          <prop v="0" k="angle"/>
-          <prop v="170,0,255,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="square" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="area" k="scale_method"/>
-          <prop v="2" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+      <symbol clip_to_extent="1" alpha="1" name="0" type="marker" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="170,0,255,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="square"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="2"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" name="name" type="QString"/>
@@ -41,20 +41,20 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" penAlpha="255" width="15" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" rotationOffset="270" barWidth="5" sizeType="MM" backgroundColor="#ffffff" diagramOrientation="Up" maxScaleDenominator="1e+08" enabled="0" lineSizeType="MM" backgroundAlpha="255" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" opacity="1" height="15" minimumSize="0">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="-4.65661e-10" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" field="" label=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" linePlacementFlags="2" obstacle="0" dist="0" showAll="1" priority="0" zIndex="0">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="0" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
         <Option value="" name="name" type="QString"/>
@@ -63,7 +63,7 @@
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -129,47 +129,47 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="ROWID" name="" index="0"/>
-    <alias field="id" name="" index="1"/>
-    <alias field="connection_node_id" name="" index="2"/>
-    <alias field="boundary_type" name="" index="3"/>
-    <alias field="timeseries" name="" index="4"/>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="" field="id"/>
+    <alias index="2" name="" field="connection_node_id"/>
+    <alias index="3" name="" field="boundary_type"/>
+    <alias index="4" name="" field="timeseries"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="ROWID" expression="" applyOnUpdate="0"/>
-    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
-    <default field="connection_node_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))" applyOnUpdate="0"/>
-    <default field="boundary_type" expression="" applyOnUpdate="0"/>
-    <default field="timeseries" expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))" field="connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="boundary_type"/>
+    <default applyOnUpdate="0" expression="" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" exp_strength="0" field="ROWID" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="id" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="connection_node_id" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="boundary_type" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="timeseries" notnull_strength="2" constraints="1"/>
+    <constraint exp_strength="0" notnull_strength="0" field="ROWID" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="connection_node_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="boundary_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timeseries" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="ROWID" desc="" exp=""/>
-    <constraint field="id" desc="" exp=""/>
-    <constraint field="connection_node_id" desc="" exp=""/>
-    <constraint field="boundary_type" desc="" exp=""/>
-    <constraint field="timeseries" desc="" exp=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="connection_node_id"/>
+    <constraint exp="" desc="" field="boundary_type"/>
+    <constraint exp="" desc="" field="timeseries"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column hidden="0" name="ROWID" type="field" width="-1"/>
-      <column hidden="0" name="id" type="field" width="-1"/>
-      <column hidden="0" name="connection_node_id" type="field" width="-1"/>
-      <column hidden="0" name="boundary_type" type="field" width="-1"/>
-      <column hidden="0" name="timeseries" type="field" width="-1"/>
-      <column hidden="1" type="actions" width="-1"/>
+      <column width="-1" hidden="0" name="ROWID" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_id" type="field"/>
+      <column width="-1" hidden="0" name="boundary_type" type="field"/>
+      <column width="-1" hidden="0" name="timeseries" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -200,26 +200,26 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="General" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0" columnCount="1">
-      <attributeEditorField showLabel="1" name="id" index="1"/>
-      <attributeEditorField showLabel="1" name="connection_node_id" index="2"/>
-      <attributeEditorField showLabel="1" name="boundary_type" index="3"/>
-      <attributeEditorField showLabel="1" name="timeseries" index="4"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="1" name="id"/>
+      <attributeEditorField showLabel="1" index="2" name="connection_node_id"/>
+      <attributeEditorField showLabel="1" index="3" name="boundary_type"/>
+      <attributeEditorField showLabel="1" index="4" name="timeseries"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="ROWID" editable="1"/>
-    <field name="boundary_type" editable="1"/>
-    <field name="connection_node_id" editable="0"/>
-    <field name="id" editable="1"/>
-    <field name="timeseries" editable="1"/>
+    <field editable="1" name="ROWID"/>
+    <field editable="1" name="boundary_type"/>
+    <field editable="0" name="connection_node_id"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="boundary_type" labelOnTop="0"/>
-    <field name="connection_node_id" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="timeseries" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="boundary_type"/>
+    <field labelOnTop="0" name="connection_node_id"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="timeseries"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_1d_lateral.qml
+++ b/layer_styles/schematisation/v2_1d_lateral.qml
@@ -1,17 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property key="dualview/previewExpressions" value="id"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="id" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -20,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -30,8 +30,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -40,44 +40,44 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="true" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="id" index="0" name=""/>
-    <alias field="connection_node_id" index="1" name=""/>
-    <alias field="timeseries" index="2" name=""/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="connection_node_id"/>
+    <alias index="2" name="" field="timeseries"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
-    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="" field="connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="2" field="connection_node_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timeseries" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="id" exp=""/>
-    <constraint desc="" field="connection_node_id" exp=""/>
-    <constraint desc="" field="timeseries" exp=""/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="connection_node_id"/>
+    <constraint exp="" desc="" field="timeseries"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
-      <column width="-1" hidden="0" type="field" name="timeseries"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_id" type="field"/>
+      <column width="-1" hidden="0" name="timeseries" type="field"/>
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -109,10 +109,10 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="0" name="id" showLabel="1"/>
-      <attributeEditorField index="1" name="connection_node_id" showLabel="1"/>
-      <attributeEditorField index="2" name="timeseries" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="0" name="id"/>
+      <attributeEditorField showLabel="1" index="1" name="connection_node_id"/>
+      <attributeEditorField showLabel="1" index="2" name="timeseries"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>

--- a/layer_styles/schematisation/v2_1d_lateral.qml
+++ b/layer_styles/schematisation/v2_1d_lateral.qml
@@ -1,61 +1,16 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
-    <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
-        <layer enabled="1" pass="0" locked="0" class="SimpleFill">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="182,70,216,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="94,17,93,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.46"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="dense5"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-    </symbols>
-    <rotation/>
-    <sizescale/>
-  </renderer-v2>
   <customproperties>
+    <property key="dualview/previewExpressions" value="id"/>
     <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>0.6</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
-      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
-    </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
-    <properties>
-      <Option type="Map">
-        <Option type="QString" value="" name="name"/>
-        <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
-      </Option>
-    </properties>
-  </DiagramLayerSettings>
   <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
@@ -71,20 +26,48 @@
         </config>
       </editWidget>
     </field>
+    <field name="connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="timeseries">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
   </fieldConfiguration>
   <aliases>
     <alias field="id" index="0" name=""/>
+    <alias field="connection_node_id" index="1" name=""/>
+    <alias field="timeseries" index="2" name=""/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
     <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
+    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
   </defaults>
   <constraints>
     <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="connection_node_id" exp=""/>
+    <constraint desc="" field="timeseries" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
@@ -93,6 +76,8 @@
   <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
       <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
+      <column width="-1" hidden="0" type="field" name="timeseries"/>
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -100,10 +85,10 @@
     <rowstyles/>
     <fieldstyles/>
   </conditionalstyles>
-  <editform tolerant="1">.</editform>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath>.</editforminitfilepath>
+  <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -126,16 +111,22 @@ def my_form_open(dialog, layer, feature):
   <attributeEditorForm>
     <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
       <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="connection_node_id" showLabel="1"/>
+      <attributeEditorField index="2" name="timeseries" showLabel="1"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
+    <field editable="1" name="connection_node_id"/>
     <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
   </editable>
   <labelOnTop>
+    <field labelOnTop="0" name="connection_node_id"/>
     <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="timeseries"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>id</previewExpression>
-  <mapTip>display_name</mapTip>
-  <layerGeometryType>2</layerGeometryType>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_1d_lateral_view.qml
+++ b/layer_styles/schematisation/v2_1d_lateral_view.qml
@@ -1,32 +1,32 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.4.5-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" minScale="1e+08" labelsEnabled="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" readOnly="0" simplifyMaxScale="1" simplifyAlgorithm="0" maxScale="-4.65661e-10">
+<qgis maxScale="-4.65661e-10" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol alpha="1" name="0" force_rhr="0" type="marker" clip_to_extent="1">
-        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
-          <prop v="225" k="angle"/>
-          <prop v="51,160,44,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="arrow" k="name"/>
-          <prop v="0,3" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="area" k="scale_method"/>
-          <prop v="5" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+      <symbol clip_to_extent="1" alpha="1" name="0" type="marker" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
+          <prop k="angle" v="225"/>
+          <prop k="color" v="51,160,44,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="arrow"/>
+          <prop k="offset" v="0,3"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="5"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" name="name" type="QString"/>
@@ -41,20 +41,20 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" penAlpha="255" width="15" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" rotationOffset="270" barWidth="5" sizeType="MM" backgroundColor="#ffffff" diagramOrientation="Up" maxScaleDenominator="1e+08" enabled="0" lineSizeType="MM" backgroundAlpha="255" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" opacity="1" height="15" minimumSize="0">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="-4.65661e-10" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" field="" label=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" linePlacementFlags="2" obstacle="0" dist="0" showAll="1" priority="0" zIndex="0">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="0" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
         <Option value="" name="name" type="QString"/>
@@ -63,7 +63,7 @@
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -107,42 +107,42 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="ROWID" name="" index="0"/>
-    <alias field="id" name="" index="1"/>
-    <alias field="connection_node_id" name="" index="2"/>
-    <alias field="timeseries" name="" index="3"/>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="" field="id"/>
+    <alias index="2" name="" field="connection_node_id"/>
+    <alias index="3" name="" field="timeseries"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="ROWID" expression="" applyOnUpdate="0"/>
-    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
-    <default field="connection_node_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))" applyOnUpdate="0"/>
-    <default field="timeseries" expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))" field="connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" exp_strength="0" field="ROWID" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="id" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="connection_node_id" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="timeseries" notnull_strength="2" constraints="1"/>
+    <constraint exp_strength="0" notnull_strength="0" field="ROWID" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="connection_node_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timeseries" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="ROWID" desc="" exp=""/>
-    <constraint field="id" desc="" exp=""/>
-    <constraint field="connection_node_id" desc="" exp=""/>
-    <constraint field="timeseries" desc="" exp=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="connection_node_id"/>
+    <constraint exp="" desc="" field="timeseries"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column hidden="0" name="ROWID" type="field" width="-1"/>
-      <column hidden="0" name="id" type="field" width="-1"/>
-      <column hidden="0" name="connection_node_id" type="field" width="-1"/>
-      <column hidden="0" name="timeseries" type="field" width="-1"/>
-      <column hidden="1" type="actions" width="-1"/>
+      <column width="-1" hidden="0" name="ROWID" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_id" type="field"/>
+      <column width="-1" hidden="0" name="timeseries" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -173,23 +173,23 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="General" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0" columnCount="1">
-      <attributeEditorField showLabel="1" name="id" index="1"/>
-      <attributeEditorField showLabel="1" name="connection_node_id" index="2"/>
-      <attributeEditorField showLabel="1" name="timeseries" index="3"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="1" name="id"/>
+      <attributeEditorField showLabel="1" index="2" name="connection_node_id"/>
+      <attributeEditorField showLabel="1" index="3" name="timeseries"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="ROWID" editable="1"/>
-    <field name="connection_node_id" editable="0"/>
-    <field name="id" editable="1"/>
-    <field name="timeseries" editable="1"/>
+    <field editable="1" name="ROWID"/>
+    <field editable="0" name="connection_node_id"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="connection_node_id" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="timeseries" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="connection_node_id"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="timeseries"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_1d_lateral_view.qml
+++ b/layer_styles/schematisation/v2_1d_lateral_view.qml
@@ -1,37 +1,37 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="-4.65661e-10" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis version="3.4.5-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" minScale="1e+08" labelsEnabled="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" readOnly="0" simplifyMaxScale="1" simplifyAlgorithm="0" maxScale="-4.65661e-10">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
+  <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
-        <layer enabled="1" pass="0" locked="0" class="SimpleMarker">
-          <prop k="angle" v="225"/>
-          <prop k="color" v="51,160,44,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="arrow"/>
-          <prop k="offset" v="0,3"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="area"/>
-          <prop k="size" v="5"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol alpha="1" name="0" force_rhr="0" type="marker" clip_to_extent="1">
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <prop v="225" k="angle"/>
+          <prop v="51,160,44,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="arrow" k="name"/>
+          <prop v="0,3" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="area" k="scale_method"/>
+          <prop v="5" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -49,17 +49,17 @@
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
   <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="-4.65661e-10" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" penAlpha="255" width="15" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" rotationOffset="270" barWidth="5" sizeType="MM" backgroundColor="#ffffff" diagramOrientation="Up" maxScaleDenominator="1e+08" enabled="0" lineSizeType="MM" backgroundAlpha="255" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" opacity="1" height="15" minimumSize="0">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
+      <attribute color="#000000" field="" label=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+  <DiagramLayerSettings placement="0" linePlacementFlags="2" obstacle="0" dist="0" showAll="1" priority="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -79,8 +79,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -89,8 +89,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -99,50 +99,50 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="true" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="ROWID" index="0" name=""/>
-    <alias field="id" index="1" name=""/>
-    <alias field="connection_node_id" index="2" name=""/>
-    <alias field="timeseries" index="3" name=""/>
+    <alias field="ROWID" name="" index="0"/>
+    <alias field="id" name="" index="1"/>
+    <alias field="connection_node_id" name="" index="2"/>
+    <alias field="timeseries" name="" index="3"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
-    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+    <default field="ROWID" expression="" applyOnUpdate="0"/>
+    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+    <default field="connection_node_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))" applyOnUpdate="0"/>
+    <default field="timeseries" expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="ROWID" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="id" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="connection_node_id" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="timeseries" notnull_strength="2" constraints="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="ROWID" exp=""/>
-    <constraint desc="" field="id" exp=""/>
-    <constraint desc="" field="connection_node_id" exp=""/>
-    <constraint desc="" field="timeseries" exp=""/>
+    <constraint field="ROWID" desc="" exp=""/>
+    <constraint field="id" desc="" exp=""/>
+    <constraint field="connection_node_id" desc="" exp=""/>
+    <constraint field="timeseries" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column width="-1" hidden="0" type="field" name="ROWID"/>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
-      <column width="-1" hidden="0" type="field" name="timeseries"/>
-      <column width="-1" hidden="1" type="actions"/>
+      <column hidden="0" name="ROWID" type="field" width="-1"/>
+      <column hidden="0" name="id" type="field" width="-1"/>
+      <column hidden="0" name="connection_node_id" type="field" width="-1"/>
+      <column hidden="0" name="timeseries" type="field" width="-1"/>
+      <column hidden="1" type="actions" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -173,23 +173,23 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="1" name="id" showLabel="1"/>
-      <attributeEditorField index="2" name="connection_node_id" showLabel="1"/>
-      <attributeEditorField index="3" name="timeseries" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" name="General" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0" columnCount="1">
+      <attributeEditorField showLabel="1" name="id" index="1"/>
+      <attributeEditorField showLabel="1" name="connection_node_id" index="2"/>
+      <attributeEditorField showLabel="1" name="timeseries" index="3"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="ROWID"/>
-    <field editable="1" name="connection_node_id"/>
-    <field editable="1" name="id"/>
-    <field editable="1" name="timeseries"/>
+    <field name="ROWID" editable="1"/>
+    <field name="connection_node_id" editable="0"/>
+    <field name="id" editable="1"/>
+    <field name="timeseries" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ROWID"/>
-    <field labelOnTop="0" name="connection_node_id"/>
-    <field labelOnTop="0" name="id"/>
-    <field labelOnTop="0" name="timeseries"/>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="connection_node_id" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="timeseries" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_2d_boundary_conditions.qml
+++ b/layer_styles/schematisation/v2_2d_boundary_conditions.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
-        <layer enabled="1" pass="0" locked="0" class="SimpleLine">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,9 +27,9 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -39,26 +39,26 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="dualview/previewExpressions" value="&quot;display_name&quot;"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="&quot;display_name&quot;" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -71,8 +71,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -81,8 +81,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -91,8 +91,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="true" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -103,16 +103,16 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1" name="1: Waterlevel"/>
+                <Option value="1" type="QString" name="1: waterlevel"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="2: Velocity"/>
+                <Option value="2" type="QString" name="2: velocity"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="3" name="3: Discharge"/>
+                <Option value="3" type="QString" name="3: discharge"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="5" name="5: Sommerfeld"/>
+                <Option value="5" type="QString" name="5: sommerfeld"/>
               </Option>
             </Option>
           </Option>
@@ -121,10 +121,10 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="id" index="0" name=""/>
-    <alias field="display_name" index="1" name=""/>
-    <alias field="timeseries" index="2" name=""/>
-    <alias field="boundary_type" index="3" name=""/>
+    <alias name="" field="id" index="0"/>
+    <alias name="" field="display_name" index="1"/>
+    <alias name="" field="timeseries" index="2"/>
+    <alias name="" field="boundary_type" index="3"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
@@ -135,28 +135,28 @@
     <default expression="" applyOnUpdate="0" field="boundary_type"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="display_name" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="boundary_type" exp_strength="0"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="timeseries"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="boundary_type"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="id" exp=""/>
-    <constraint desc="" field="display_name" exp=""/>
-    <constraint desc="" field="timeseries" exp=""/>
-    <constraint desc="" field="boundary_type" exp=""/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="timeseries"/>
+    <constraint exp="" desc="" field="boundary_type"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="display_name"/>
-      <column width="-1" hidden="0" type="field" name="timeseries"/>
-      <column width="-1" hidden="0" type="field" name="boundary_type"/>
-      <column width="-1" hidden="1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" hidden="0" name="display_name"/>
+      <column width="-1" type="field" hidden="0" name="timeseries"/>
+      <column width="-1" type="field" hidden="0" name="boundary_type"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -187,18 +187,18 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="0" name="id" showLabel="1"/>
-      <attributeEditorField index="1" name="display_name" showLabel="1"/>
-      <attributeEditorField index="3" name="boundary_type" showLabel="1"/>
-      <attributeEditorField index="2" name="timeseries" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+      <attributeEditorField showLabel="1" name="id" index="0"/>
+      <attributeEditorField showLabel="1" name="display_name" index="1"/>
+      <attributeEditorField showLabel="1" name="boundary_type" index="3"/>
+      <attributeEditorField showLabel="1" name="timeseries" index="2"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="boundary_type"/>
-    <field editable="1" name="display_name"/>
-    <field editable="1" name="id"/>
-    <field editable="1" name="timeseries"/>
+    <field name="boundary_type" editable="1"/>
+    <field name="display_name" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="timeseries" editable="1"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="boundary_type"/>

--- a/layer_styles/schematisation/v2_2d_boundary_conditions.qml
+++ b/layer_styles/schematisation/v2_2d_boundary_conditions.qml
@@ -1,26 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="timeseries">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="boundary_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -29,214 +20,106 @@
           <prop k="line_width" v="0.66"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
+    <property key="dualview/previewExpressions" value="&quot;display_name&quot;"/>
     <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="128"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="25"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-25"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="4294967295"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="-1" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="2" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="timeseries">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="boundary_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: Waterlevel"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="2: Velocity"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="3" name="3: Discharge"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="5" name="5: Sommerfeld"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
     <alias field="id" index="0" name=""/>
     <alias field="display_name" index="1" name=""/>
@@ -245,8 +128,29 @@
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <defaults>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="display_name"/>
+    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+    <default expression="" applyOnUpdate="0" field="boundary_type"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="display_name" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="boundary_type" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="display_name" exp=""/>
+    <constraint desc="" field="timeseries" exp=""/>
+    <constraint desc="" field="boundary_type" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
       <column width="-1" hidden="0" type="field" name="id"/>
       <column width="-1" hidden="0" type="field" name="display_name"/>
@@ -255,7 +159,11 @@
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform></editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -277,18 +185,29 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="display_name" showLabel="1"/>
+      <attributeEditorField index="3" name="boundary_type" showLabel="1"/>
+      <attributeEditorField index="2" name="timeseries" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="boundary_type"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="boundary_type"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="timeseries"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="id" expression=""/>
-    <default field="display_name" expression=""/>
-    <default field="timeseries" expression=""/>
-    <default field="boundary_type" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_2d_boundary_conditions.qml
+++ b/layer_styles/schematisation/v2_2d_boundary_conditions.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis maxScale="0" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+      <symbol clip_to_extent="1" alpha="1" name="0" type="line" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,9 +27,9 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -48,21 +48,21 @@
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
   <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
       <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="2" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -71,8 +71,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -81,8 +81,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -91,8 +91,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="true" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -101,18 +101,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: waterlevel"/>
+                <Option value="1" name="1: waterlevel" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: velocity"/>
+                <Option value="2" name="2: velocity" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: discharge"/>
+                <Option value="3" name="3: discharge" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: sommerfeld"/>
+                <Option value="5" name="5: sommerfeld" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -121,24 +121,24 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="id" index="0"/>
-    <alias name="" field="display_name" index="1"/>
-    <alias name="" field="timeseries" index="2"/>
-    <alias name="" field="boundary_type" index="3"/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="display_name"/>
+    <alias index="2" name="" field="timeseries"/>
+    <alias index="3" name="" field="boundary_type"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="" applyOnUpdate="0" field="display_name"/>
-    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
-    <default expression="" applyOnUpdate="0" field="boundary_type"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="" field="display_name"/>
+    <default applyOnUpdate="0" expression="" field="timeseries"/>
+    <default applyOnUpdate="0" expression="" field="boundary_type"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="timeseries"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="boundary_type"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="2" field="display_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timeseries" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="boundary_type" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" desc="" field="id"/>
@@ -150,13 +150,13 @@
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="id"/>
-      <column width="-1" type="field" hidden="0" name="display_name"/>
-      <column width="-1" type="field" hidden="0" name="timeseries"/>
-      <column width="-1" type="field" hidden="0" name="boundary_type"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="display_name" type="field"/>
+      <column width="-1" hidden="0" name="timeseries" type="field"/>
+      <column width="-1" hidden="0" name="boundary_type" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -187,18 +187,18 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-      <attributeEditorField showLabel="1" name="id" index="0"/>
-      <attributeEditorField showLabel="1" name="display_name" index="1"/>
-      <attributeEditorField showLabel="1" name="boundary_type" index="3"/>
-      <attributeEditorField showLabel="1" name="timeseries" index="2"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="0" name="id"/>
+      <attributeEditorField showLabel="1" index="1" name="display_name"/>
+      <attributeEditorField showLabel="1" index="3" name="boundary_type"/>
+      <attributeEditorField showLabel="1" index="2" name="timeseries"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="boundary_type" editable="1"/>
-    <field name="display_name" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="timeseries" editable="1"/>
+    <field editable="1" name="boundary_type"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="boundary_type"/>

--- a/layer_styles/schematisation/v2_2d_lateral.qml
+++ b/layer_styles/schematisation/v2_2d_lateral.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis maxScale="0" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
-        <layer enabled="1" pass="0" locked="0" class="SimpleMarker">
+      <symbol clip_to_extent="1" alpha="1" name="0" type="marker" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="180"/>
           <prop k="color" v="113,111,253,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -29,9 +29,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -41,29 +41,29 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="0" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -72,9 +72,9 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="1" name="1: Surface"/>
+                <Option value="1" name="1: Surface" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -85,8 +85,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -95,44 +95,44 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="true" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="type" index="0" name=""/>
-    <alias field="id" index="1" name=""/>
-    <alias field="timeseries" index="2" name=""/>
+    <alias index="0" name="" field="type"/>
+    <alias index="1" name="" field="id"/>
+    <alias index="2" name="" field="timeseries"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="1" applyOnUpdate="0" field="type"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+    <default applyOnUpdate="0" expression="1" field="type"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="" field="timeseries"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="type" exp_strength="0"/>
-    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timeseries" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="type" exp=""/>
-    <constraint desc="" field="id" exp=""/>
-    <constraint desc="" field="timeseries" exp=""/>
+    <constraint exp="" desc="" field="type"/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="timeseries"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" hidden="0" type="field" name="type"/>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="timeseries"/>
+      <column width="-1" hidden="0" name="type" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="timeseries" type="field"/>
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -164,10 +164,10 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="1" name="id" showLabel="1"/>
-      <attributeEditorField index="0" name="type" showLabel="1"/>
-      <attributeEditorField index="2" name="timeseries" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="1" name="id"/>
+      <attributeEditorField showLabel="1" index="0" name="type"/>
+      <attributeEditorField showLabel="1" index="2" name="timeseries"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>

--- a/layer_styles/schematisation/v2_2d_lateral.qml
+++ b/layer_styles/schematisation/v2_2d_lateral.qml
@@ -1,242 +1,107 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="timeseries">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="marker" name="0">
-        <layer pass="0" class="SimpleMarker" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleMarker">
           <prop k="angle" v="180"/>
           <prop k="color" v="113,111,253,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="name" v="arrow"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="scale_method" v="area"/>
           <prop k="size" v="5"/>
-          <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="size_unit" v="MM"/>
           <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
     <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="128"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="25"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-25"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="3"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="6"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>id</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="-1" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: Surface"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="timeseries">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
     <alias field="type" index="0" name=""/>
     <alias field="id" index="1" name=""/>
@@ -244,8 +109,26 @@
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="594149376">
+  <defaults>
+    <default expression="1" applyOnUpdate="0" field="type"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="'0,1&#xd;&#xa;9999,1'" applyOnUpdate="0" field="timeseries"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="type" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timeseries" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="type" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="timeseries" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
       <column width="-1" hidden="0" type="field" name="type"/>
       <column width="-1" hidden="0" type="field" name="id"/>
@@ -253,7 +136,11 @@
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform></editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -275,17 +162,26 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="1" name="id" showLabel="1"/>
+      <attributeEditorField index="0" name="type" showLabel="1"/>
+      <attributeEditorField index="2" name="timeseries" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timeseries"/>
+    <field editable="1" name="type"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="timeseries"/>
+    <field labelOnTop="0" name="type"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="type" expression=""/>
-    <default field="id" expression=""/>
-    <default field="timeseries" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_aggregation_settings.qml
+++ b/layer_styles/schematisation/v2_aggregation_settings.qml
@@ -1,0 +1,264 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="dualview/previewExpressions" value="var_name"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="global_settings_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="timestep">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="var_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aggregation_in_space">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aggregation_method">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="avg" name="average"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="min" name="minimum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="max" name="maximum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="cum" name="cumulative"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="med" name="median"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="cum_negative" name="cumulative negative"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="cum_positive" name="cumulative positive"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="current" name="current"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="flow_variable">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="discharge" name="discharge"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="flow_velocity" name="flow velocity"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="pump_discharge" name="pump discharge"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="rain" name="rain"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="waterlevel" name="waterlevel"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="wet_cross-section" name="wet cross section"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="wet_surface" name="wet surface"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="lateral_discharge" name="lateral discharge"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="volume" name="volume"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="simple_infiltration" name="infiltration"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="leakage" name="leakage"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="interception" name="interception"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="global_settings_id" index="0" name=""/>
+    <alias field="timestep" index="1" name=""/>
+    <alias field="var_name" index="2" name=""/>
+    <alias field="aggregation_in_space" index="3" name=""/>
+    <alias field="aggregation_method" index="4" name=""/>
+    <alias field="flow_variable" index="5" name=""/>
+    <alias field="id" index="6" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="global_settings_id"/>
+    <default expression="" applyOnUpdate="0" field="timestep"/>
+    <default expression="" applyOnUpdate="0" field="var_name"/>
+    <default expression="0" applyOnUpdate="0" field="aggregation_in_space"/>
+    <default expression="" applyOnUpdate="0" field="aggregation_method"/>
+    <default expression="" applyOnUpdate="0" field="flow_variable"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="global_settings_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timestep" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="var_name" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="aggregation_in_space" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="aggregation_method" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="flow_variable" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="global_settings_id" exp=""/>
+    <constraint desc="" field="timestep" exp=""/>
+    <constraint desc="" field="var_name" exp=""/>
+    <constraint desc="" field="aggregation_in_space" exp=""/>
+    <constraint desc="" field="aggregation_method" exp=""/>
+    <constraint desc="" field="flow_variable" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="timestep"/>
+      <column width="-1" hidden="0" type="field" name="var_name"/>
+      <column width="-1" hidden="0" type="field" name="global_settings_id"/>
+      <column width="-1" hidden="0" type="field" name="aggregation_in_space"/>
+      <column width="-1" hidden="0" type="field" name="aggregation_method"/>
+      <column width="-1" hidden="0" type="field" name="flow_variable"/>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="6" name="id" showLabel="1"/>
+      <attributeEditorField index="5" name="flow_variable" showLabel="1"/>
+      <attributeEditorField index="4" name="aggregation_method" showLabel="1"/>
+      <attributeEditorField index="1" name="timestep" showLabel="1"/>
+      <attributeEditorField index="2" name="var_name" showLabel="1"/>
+      <attributeEditorField index="0" name="global_settings_id" showLabel="1"/>
+      <attributeEditorField index="3" name="aggregation_in_space" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="aggregation_in_space"/>
+    <field editable="1" name="aggregation_method"/>
+    <field editable="1" name="flow_variable"/>
+    <field editable="1" name="global_settings_id"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="timestep"/>
+    <field editable="1" name="var_name"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="aggregation_in_space"/>
+    <field labelOnTop="0" name="aggregation_method"/>
+    <field labelOnTop="0" name="flow_variable"/>
+    <field labelOnTop="0" name="global_settings_id"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="timestep"/>
+    <field labelOnTop="0" name="var_name"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>var_name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_aggregation_settings.qml
+++ b/layer_styles/schematisation/v2_aggregation_settings.qml
@@ -1,37 +1,29 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property key="dualview/previewExpressions" value="var_name"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property key="dualview/previewExpressions">
+      <value>var_name</value>
+    </property>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
   <fieldConfiguration>
-    <field name="global_settings_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
     <field name="timestep">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -40,19 +32,26 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="global_settings_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
     <field name="aggregation_in_space">
-      <editWidget type="CheckBox">
+      <editWidget type="Hidden">
         <config>
-          <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
-          </Option>
+          <Option/>
         </config>
       </editWidget>
     </field>
@@ -60,30 +59,30 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="avg" name="average"/>
+                <Option value="avg" name="average" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="min" name="minimum"/>
+                <Option value="min" name="minimum" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="max" name="maximum"/>
+                <Option value="max" name="maximum" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="cum" name="cumulative"/>
+                <Option value="cum" name="cumulative" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="med" name="median"/>
+                <Option value="med" name="median" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="cum_negative" name="cumulative negative"/>
+                <Option value="cum_negative" name="cumulative negative" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="cum_positive" name="cumulative positive"/>
+                <Option value="cum_positive" name="cumulative positive" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="current" name="current"/>
+                <Option value="current" name="current" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -94,42 +93,42 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="discharge" name="discharge"/>
+                <Option value="discharge" name="discharge" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="flow_velocity" name="flow velocity"/>
+                <Option value="flow_velocity" name="flow velocity" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="pump_discharge" name="pump discharge"/>
+                <Option value="pump_discharge" name="pump discharge" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="rain" name="rain"/>
+                <Option value="rain" name="rain" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="waterlevel" name="waterlevel"/>
+                <Option value="waterlevel" name="waterlevel" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="wet_cross-section" name="wet cross section"/>
+                <Option value="wet_cross-section" name="wet cross section" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="wet_surface" name="wet surface"/>
+                <Option value="wet_surface" name="wet surface" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="lateral_discharge" name="lateral discharge"/>
+                <Option value="lateral_discharge" name="lateral discharge" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="volume" name="volume"/>
+                <Option value="volume" name="volume" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="simple_infiltration" name="infiltration"/>
+                <Option value="simple_infiltration" name="infiltration" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="leakage" name="leakage"/>
+                <Option value="leakage" name="leakage" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="interception" name="interception"/>
+                <Option value="interception" name="interception" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -140,64 +139,64 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="global_settings_id" index="0" name=""/>
-    <alias field="timestep" index="1" name=""/>
-    <alias field="var_name" index="2" name=""/>
-    <alias field="aggregation_in_space" index="3" name=""/>
-    <alias field="aggregation_method" index="4" name=""/>
-    <alias field="flow_variable" index="5" name=""/>
-    <alias field="id" index="6" name=""/>
+    <alias index="0" name="" field="timestep"/>
+    <alias index="1" name="" field="var_name"/>
+    <alias index="2" name="" field="global_settings_id"/>
+    <alias index="3" name="" field="aggregation_in_space"/>
+    <alias index="4" name="" field="aggregation_method"/>
+    <alias index="5" name="" field="flow_variable"/>
+    <alias index="6" name="" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="global_settings_id"/>
-    <default expression="" applyOnUpdate="0" field="timestep"/>
-    <default expression="" applyOnUpdate="0" field="var_name"/>
-    <default expression="0" applyOnUpdate="0" field="aggregation_in_space"/>
-    <default expression="" applyOnUpdate="0" field="aggregation_method"/>
-    <default expression="" applyOnUpdate="0" field="flow_variable"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default applyOnUpdate="0" expression="" field="timestep"/>
+    <default applyOnUpdate="0" expression="" field="var_name"/>
+    <default applyOnUpdate="0" expression="" field="global_settings_id"/>
+    <default applyOnUpdate="0" expression="0" field="aggregation_in_space"/>
+    <default applyOnUpdate="0" expression="" field="aggregation_method"/>
+    <default applyOnUpdate="0" expression="" field="flow_variable"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="global_settings_id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="timestep" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="var_name" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="aggregation_in_space" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="aggregation_method" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="flow_variable" exp_strength="0"/>
-    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timestep" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="var_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="global_settings_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="aggregation_in_space" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="aggregation_method" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="flow_variable" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="global_settings_id" exp=""/>
-    <constraint desc="" field="timestep" exp=""/>
-    <constraint desc="" field="var_name" exp=""/>
-    <constraint desc="" field="aggregation_in_space" exp=""/>
-    <constraint desc="" field="aggregation_method" exp=""/>
-    <constraint desc="" field="flow_variable" exp=""/>
-    <constraint desc="" field="id" exp=""/>
+    <constraint exp="" desc="" field="timestep"/>
+    <constraint exp="" desc="" field="var_name"/>
+    <constraint exp="" desc="" field="global_settings_id"/>
+    <constraint exp="" desc="" field="aggregation_in_space"/>
+    <constraint exp="" desc="" field="aggregation_method"/>
+    <constraint exp="" desc="" field="flow_variable"/>
+    <constraint exp="" desc="" field="id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" hidden="0" type="field" name="timestep"/>
-      <column width="-1" hidden="0" type="field" name="var_name"/>
-      <column width="-1" hidden="0" type="field" name="global_settings_id"/>
-      <column width="-1" hidden="0" type="field" name="aggregation_in_space"/>
-      <column width="-1" hidden="0" type="field" name="aggregation_method"/>
-      <column width="-1" hidden="0" type="field" name="flow_variable"/>
-      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="214" hidden="0" name="timestep" type="field"/>
+      <column width="207" hidden="0" name="var_name" type="field"/>
+      <column width="123" hidden="0" name="global_settings_id" type="field"/>
+      <column width="168" hidden="0" name="aggregation_in_space" type="field"/>
+      <column width="-1" hidden="0" name="aggregation_method" type="field"/>
+      <column width="-1" hidden="0" name="flow_variable" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -229,14 +228,13 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="6" name="id" showLabel="1"/>
-      <attributeEditorField index="5" name="flow_variable" showLabel="1"/>
-      <attributeEditorField index="4" name="aggregation_method" showLabel="1"/>
-      <attributeEditorField index="1" name="timestep" showLabel="1"/>
-      <attributeEditorField index="2" name="var_name" showLabel="1"/>
-      <attributeEditorField index="0" name="global_settings_id" showLabel="1"/>
-      <attributeEditorField index="3" name="aggregation_in_space" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="6" name="id"/>
+      <attributeEditorField showLabel="1" index="5" name="flow_variable"/>
+      <attributeEditorField showLabel="1" index="4" name="aggregation_method"/>
+      <attributeEditorField showLabel="1" index="0" name="timestep"/>
+      <attributeEditorField showLabel="1" index="1" name="var_name"/>
+      <attributeEditorField showLabel="1" index="2" name="global_settings_id"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>

--- a/layer_styles/schematisation/v2_channel.qml
+++ b/layer_styles/schematisation/v2_channel.qml
@@ -1,38 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="calculation_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="dist_calc_points">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="connection_node_start_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="connection_node_end_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -41,300 +20,287 @@
           <prop k="line_width" v="0.66"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="MarkerLine" locked="0">
+        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
           <prop k="interval" v="12"/>
-          <prop k="interval_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="placement" v="interval"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="rotate" v="1"/>
-          <symbol alpha="1" clip_to_extent="1" type="marker" name="@0@1">
-            <layer pass="0" class="SimpleMarker" locked="0">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
+            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
               <prop k="angle" v="0"/>
               <prop k="color" v="0,101,210,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
               <prop k="joinstyle" v="bevel"/>
               <prop k="name" v="filled_arrowhead"/>
               <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="outline_color" v="0,0,0,255"/>
               <prop k="outline_style" v="no"/>
               <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="outline_width_unit" v="MM"/>
               <prop k="scale_method" v="area"/>
               <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="size_unit" v="MM"/>
               <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
+    <property value="display_name" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>../../../OSGEO4~1/bin</annotationform>
+  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties" type="Map">
+          <Option name="show" type="Map">
+            <Option name="active" value="true" type="bool"/>
+            <Option name="field" value="id" type="QString"/>
+            <Option name="type" value="2" type="int"/>
+          </Option>
+        </Option>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="calculation_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="100: embedded" value="100" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="101: isolated" value="101" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="102: connected" value="102" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="105: double connected" value="105" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dist_calc_points">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
-    <alias field="id" index="0" name=""/>
-    <alias field="display_name" index="1" name=""/>
-    <alias field="code" index="2" name=""/>
-    <alias field="calculation_type" index="3" name=""/>
-    <alias field="dist_calc_points" index="4" name=""/>
-    <alias field="zoom_category" index="5" name=""/>
-    <alias field="connection_node_start_id" index="6" name=""/>
-    <alias field="connection_node_end_id" index="7" name=""/>
+    <alias name="" index="0" field="id"/>
+    <alias name="" index="1" field="display_name"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="calculation_type"/>
+    <alias name="" index="4" field="dist_calc_points"/>
+    <alias name="" index="5" field="zoom_category"/>
+    <alias name="" index="6" field="connection_node_start_id"/>
+    <alias name="" index="7" field="connection_node_end_id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <defaults>
+    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="code" expression="'new'"/>
+    <default applyOnUpdate="0" field="calculation_type" expression=""/>
+    <default applyOnUpdate="0" field="dist_calc_points" expression=""/>
+    <default applyOnUpdate="0" field="zoom_category" expression="5"/>
+    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
+    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="dist_calc_points" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="calculation_type" desc=""/>
+    <constraint exp="" field="dist_calc_points" desc=""/>
+    <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" field="connection_node_start_id" desc=""/>
+    <constraint exp="" field="connection_node_end_id" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="display_name"/>
-      <column width="-1" hidden="0" type="field" name="code"/>
-      <column width="-1" hidden="0" type="field" name="calculation_type"/>
-      <column width="-1" hidden="0" type="field" name="dist_calc_points"/>
-      <column width="-1" hidden="0" type="field" name="zoom_category"/>
-      <column width="-1" hidden="0" type="field" name="connection_node_start_id"/>
-      <column width="-1" hidden="0" type="field" name="connection_node_end_id"/>
-      <column width="-1" hidden="1" type="actions"/>
+      <column name="id" hidden="0" width="-1" type="field"/>
+      <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="code" hidden="0" width="-1" type="field"/>
+      <column name="calculation_type" hidden="0" width="-1" type="field"/>
+      <column name="dist_calc_points" hidden="0" width="-1" type="field"/>
+      <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform>../../../OSGEO4~1/bin</editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">../../../OSGEO4~1/bin</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>../../../OSGEO4~1/bin</editforminitfilepath>
@@ -356,22 +322,47 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Channel" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="id" index="0" showLabel="1"/>
+        <attributeEditorField name="display_name" index="1" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
+        <attributeEditorField name="calculation_type" index="3" showLabel="1"/>
+        <attributeEditorField name="dist_calc_points" index="4" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="zoom_category" index="5" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="connection_node_start_id" index="6" showLabel="1"/>
+        <attributeEditorField name="connection_node_end_id" index="7" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="calculation_type" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="connection_node_end_id" editable="1"/>
+    <field name="connection_node_start_id" editable="1"/>
+    <field name="display_name" editable="1"/>
+    <field name="dist_calc_points" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="calculation_type" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="connection_node_end_id" labelOnTop="0"/>
+    <field name="connection_node_start_id" labelOnTop="0"/>
+    <field name="display_name" labelOnTop="0"/>
+    <field name="dist_calc_points" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="id" expression=""/>
-    <default field="display_name" expression=""/>
-    <default field="code" expression=""/>
-    <default field="calculation_type" expression=""/>
-    <default field="dist_calc_points" expression=""/>
-    <default field="zoom_category" expression=""/>
-    <default field="connection_node_start_id" expression=""/>
-    <default field="connection_node_end_id" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_channel.qml
+++ b/layer_styles/schematisation/v2_channel.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+<qgis labelsEnabled="0" readOnly="0" simplifyLocal="1" simplifyDrawingTol="1" minScale="1e+08" simplifyDrawingHints="1" simplifyAlgorithm="0" styleCategories="AllStyleCategories" simplifyMaxScale="1" version="3.4.5-Madeira" maxScale="0" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
+  <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol name="0" type="line" alpha="1" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
+        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
           <prop k="interval" v="12"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
+          <symbol name="@0@1" type="marker" alpha="1" clip_to_extent="1" force_rhr="0">
+            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
               <prop k="angle" v="0"/>
               <prop k="color" v="0,101,210,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -98,27 +98,27 @@
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
   <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+    <DiagramCategory minimumSize="0" opacity="1" penWidth="0" scaleDependency="Area" height="15" minScaleDenominator="0" scaleBasedVisibility="0" lineSizeType="MM" penColor="#000000" rotationOffset="270" width="15" maxScaleDenominator="1e+08" enabled="0" sizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" penAlpha="255" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" sizeType="MM">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute field="" color="#000000" label=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings placement="2" priority="0" obstacle="0" zIndex="0" dist="0" showAll="1" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties" type="Map">
           <Option name="show" type="Map">
-            <Option name="active" value="true" type="bool"/>
-            <Option name="field" value="id" type="QString"/>
-            <Option name="type" value="2" type="int"/>
+            <Option value="true" name="active" type="bool"/>
+            <Option value="id" name="field" type="QString"/>
+            <Option value="2" name="type" type="int"/>
           </Option>
         </Option>
-        <Option name="type" value="collection" type="QString"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -127,8 +127,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -137,8 +137,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -147,8 +147,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -159,16 +159,16 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="100: embedded" value="100" type="QString"/>
+                <Option value="100" name="100: embedded" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="101: isolated" value="101" type="QString"/>
+                <Option value="101" name="101: isolated" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="102: connected" value="102" type="QString"/>
+                <Option value="102" name="102: connected" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="105: double connected" value="105" type="QString"/>
+                <Option value="105" name="105: double connected" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -179,8 +179,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -191,25 +191,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" name="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" name="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" name="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" name="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" name="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" name="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" name="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -220,8 +220,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -230,69 +230,69 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="id"/>
-    <alias name="" index="1" field="display_name"/>
-    <alias name="" index="2" field="code"/>
-    <alias name="" index="3" field="calculation_type"/>
-    <alias name="" index="4" field="dist_calc_points"/>
-    <alias name="" index="5" field="zoom_category"/>
-    <alias name="" index="6" field="connection_node_start_id"/>
-    <alias name="" index="7" field="connection_node_end_id"/>
+    <alias field="id" index="0" name=""/>
+    <alias field="display_name" index="1" name=""/>
+    <alias field="code" index="2" name=""/>
+    <alias field="calculation_type" index="3" name=""/>
+    <alias field="dist_calc_points" index="4" name=""/>
+    <alias field="zoom_category" index="5" name=""/>
+    <alias field="connection_node_start_id" index="6" name=""/>
+    <alias field="connection_node_end_id" index="7" name=""/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="calculation_type" expression=""/>
-    <default applyOnUpdate="0" field="dist_calc_points" expression=""/>
-    <default applyOnUpdate="0" field="zoom_category" expression="5"/>
-    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
+    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+    <default field="display_name" expression="'new'" applyOnUpdate="0"/>
+    <default field="code" expression="'new'" applyOnUpdate="0"/>
+    <default field="calculation_type" expression="" applyOnUpdate="0"/>
+    <default field="dist_calc_points" expression="" applyOnUpdate="0"/>
+    <default field="zoom_category" expression="5" applyOnUpdate="0"/>
+    <default field="connection_node_start_id" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent))))" applyOnUpdate="0"/>
+    <default field="connection_node_end_id" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent))))" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="dist_calc_points" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
+    <constraint field="id" notnull_strength="1" exp_strength="0" constraints="3" unique_strength="1"/>
+    <constraint field="display_name" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="code" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="calculation_type" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="dist_calc_points" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="zoom_category" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="connection_node_start_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="connection_node_end_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="id" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="calculation_type" desc=""/>
-    <constraint exp="" field="dist_calc_points" desc=""/>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="connection_node_start_id" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
+    <constraint field="id" desc="" exp=""/>
+    <constraint field="display_name" desc="" exp=""/>
+    <constraint field="code" desc="" exp=""/>
+    <constraint field="calculation_type" desc="" exp=""/>
+    <constraint field="dist_calc_points" desc="" exp=""/>
+    <constraint field="zoom_category" desc="" exp=""/>
+    <constraint field="connection_node_start_id" desc="" exp=""/>
+    <constraint field="connection_node_end_id" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="calculation_type" hidden="0" width="-1" type="field"/>
-      <column name="dist_calc_points" hidden="0" width="-1" type="field"/>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
+      <column hidden="0" width="-1" name="id" type="field"/>
+      <column hidden="0" width="-1" name="display_name" type="field"/>
+      <column hidden="0" width="-1" name="code" type="field"/>
+      <column hidden="0" width="-1" name="calculation_type" type="field"/>
+      <column hidden="0" width="-1" name="dist_calc_points" type="field"/>
+      <column hidden="0" width="-1" name="zoom_category" type="field"/>
+      <column hidden="0" width="-1" name="connection_node_start_id" type="field"/>
+      <column hidden="0" width="-1" name="connection_node_end_id" type="field"/>
       <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -324,42 +324,42 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Channel" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="0" showLabel="1"/>
-        <attributeEditorField name="display_name" index="1" showLabel="1"/>
-        <attributeEditorField name="code" index="2" showLabel="1"/>
-        <attributeEditorField name="calculation_type" index="3" showLabel="1"/>
-        <attributeEditorField name="dist_calc_points" index="4" showLabel="1"/>
+    <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="0" name="Channel" columnCount="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="General" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="0" name="id"/>
+        <attributeEditorField showLabel="1" index="1" name="display_name"/>
+        <attributeEditorField showLabel="1" index="2" name="code"/>
+        <attributeEditorField showLabel="1" index="3" name="calculation_type"/>
+        <attributeEditorField showLabel="1" index="4" name="dist_calc_points"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="5" showLabel="1"/>
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Visualization" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="5" name="zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="6" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="7" showLabel="1"/>
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Connection nodes" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="6" name="connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="7" name="connection_node_end_id"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="calculation_type" editable="1"/>
-    <field name="code" editable="1"/>
-    <field name="connection_node_end_id" editable="1"/>
-    <field name="connection_node_start_id" editable="1"/>
-    <field name="display_name" editable="1"/>
-    <field name="dist_calc_points" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="zoom_category" editable="1"/>
+    <field editable="1" name="calculation_type"/>
+    <field editable="1" name="code"/>
+    <field editable="1" name="connection_node_end_id"/>
+    <field editable="1" name="connection_node_start_id"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="dist_calc_points"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="zoom_category"/>
   </editable>
   <labelOnTop>
-    <field name="calculation_type" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_end_id" labelOnTop="0"/>
-    <field name="connection_node_start_id" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="dist_calc_points" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="calculation_type"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_end_id"/>
+    <field labelOnTop="0" name="connection_node_start_id"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="dist_calc_points"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_connection_nodes.qml
+++ b/layer_styles/schematisation/v2_connection_nodes.qml
@@ -1,272 +1,151 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="the_geom_linestring">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="initial_waterlevel">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="storage_area">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="1" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="marker" name="0">
-        <layer pass="0" class="SimpleMarker" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,255,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="name" v="circle"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="scale_method" v="area"/>
           <prop k="size" v="1.2"/>
-          <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="size_unit" v="MM"/>
           <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
+  <labeling type="simple">
+    <settings>
+      <text-style multilineHeight="1" fontSize="8" fontCapitals="0" fontWeight="50" blendMode="0" textOpacity="1" namedStyle="Regular" fieldName="initial_waterlevel" fontStrikeout="0" fontItalic="0" fontSizeUnit="Point" fontLetterSpacing="0" previewBkgrdColor="#ffffff" fontWordSpacing="0" textColor="0,0,0,255" useSubstitutions="0" fontFamily="MS Shell Dlg 2" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontUnderline="0" isExpression="0">
+        <text-buffer bufferDraw="1" bufferOpacity="1" bufferColor="255,255,255,255" bufferSizeUnits="MM" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="0.6" bufferNoFill="0" bufferJoinStyle="64"/>
+        <background shapeDraw="0" shapeOffsetUnit="MM" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidth="0" shapeRadiiX="0" shapeOffsetX="0" shapeBorderColor="128,128,128,255" shapeSizeX="0" shapeBlendMode="0" shapeSVGFile="" shapeRotation="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidthUnit="MM" shapeOpacity="1" shapeRadiiY="0" shapeSizeUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeRadiiUnit="MM" shapeOffsetY="0" shapeRotationType="0" shapeSizeType="0" shapeType="0"/>
+        <shadow shadowUnder="0" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MM" shadowOpacity="0.7" shadowRadius="1.5" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowRadiusUnit="MM" shadowOffsetDist="1" shadowColor="0,0,0,255" shadowOffsetAngle="135" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1"/>
+        <substitutions/>
+      </text-style>
+      <text-format rightDirectionSymbol=">" wrapChar="" multilineAlign="0" useMaxLineLengthForAutoWrap="1" reverseDirectionSymbol="0" addDirectionSymbol="0" plussign="0" autoWrapLength="0" formatNumbers="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;"/>
+      <placement repeatDistanceUnits="MM" offsetUnits="MapUnit" centroidWhole="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" quadOffset="4" repeatDistance="0" dist="0" fitInPolygonOnly="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" maxCurvedCharAngleOut="-20" centroidInside="0" xOffset="0" distUnits="MM" placementFlags="0" priority="5" yOffset="0" distMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="0" maxCurvedCharAngleIn="20" rotationAngle="0" preserveRotation="1"/>
+      <rendering upsidedownLabels="0" zIndex="0" drawLabels="1" obstacle="1" fontLimitPixelSize="0" scaleMin="1" obstacleType="0" displayAll="0" minFeatureSize="0" mergeLines="0" limitNumLabels="0" obstacleFactor="1" scaleVisibility="1" scaleMax="2000" fontMaxPixelSize="10000" maxNumLabels="2000" labelPerPart="0" fontMinPixelSize="3"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </dd_properties>
+    </settings>
+  </labeling>
   <customproperties>
+    <property key="dualview/previewExpressions" value="id"/>
     <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="true"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="0.6"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="true"/>
-    <property key="labeling/enabled" value="true"/>
-    <property key="labeling/fieldName" value="initial_waterlevel"/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="false"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="0"/>
-    <property key="labeling/placementFlags" value="0"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="2000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="true"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>Name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
-      <fontProperties description="MS Shell Dlg 2,7.5,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="MS Shell Dlg 2,7.5,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>../../../OSGEO4~1/bin</annotationform>
+  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option type="Map" name="properties">
+          <Option type="Map" name="show">
+            <Option type="bool" value="true" name="active"/>
+            <Option type="QString" value="the_geom_linestring" name="field"/>
+            <Option type="int" value="2" name="type"/>
+          </Option>
+        </Option>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="the_geom_linestring">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_waterlevel">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="storage_area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
     <alias field="the_geom_linestring" index="0" name=""/>
     <alias field="code" index="1" name=""/>
@@ -276,8 +155,32 @@
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="the_geom_linestring"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="" applyOnUpdate="0" field="initial_waterlevel"/>
+    <default expression="" applyOnUpdate="0" field="storage_area"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="the_geom_linestring" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="code" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="initial_waterlevel" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="storage_area" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="the_geom_linestring" exp=""/>
+    <constraint desc="" field="code" exp=""/>
+    <constraint desc="" field="initial_waterlevel" exp=""/>
+    <constraint desc="" field="storage_area" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="1" actionWidgetStyle="dropDown" sortExpression="&quot;code&quot;">
     <columns>
       <column width="-1" hidden="0" type="field" name="the_geom_linestring"/>
       <column width="-1" hidden="0" type="field" name="code"/>
@@ -287,7 +190,11 @@
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform>../../../OSGEO4~1/bin</editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">../../../OSGEO4~1/bin</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>../../../OSGEO4~1/bin</editforminitfilepath>
@@ -309,19 +216,31 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="4" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="code" showLabel="1"/>
+      <attributeEditorField index="2" name="initial_waterlevel" showLabel="1"/>
+      <attributeEditorField index="3" name="storage_area" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="code"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="initial_waterlevel"/>
+    <field editable="1" name="storage_area"/>
+    <field editable="1" name="the_geom_linestring"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="initial_waterlevel"/>
+    <field labelOnTop="0" name="storage_area"/>
+    <field labelOnTop="0" name="the_geom_linestring"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="the_geom_linestring" expression=""/>
-    <default field="code" expression=""/>
-    <default field="initial_waterlevel" expression=""/>
-    <default field="storage_area" expression=""/>
-    <default field="id" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>id</previewExpression>
+  <mapTip>Name</mapTip>
   <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_cross_section_definition.qml
+++ b/layer_styles/schematisation/v2_cross_section_definition.qml
@@ -1,0 +1,180 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="dualview/previewExpressions" value="width"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: rectangle"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="2: round"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="3" name="3: egg"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="5" name="5: tabulated rectangle"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="6" name="6: tabulated trapezium"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="height">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="width" index="0" name=""/>
+    <alias field="shape" index="1" name=""/>
+    <alias field="code" index="2" name=""/>
+    <alias field="id" index="3" name=""/>
+    <alias field="height" index="4" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="width"/>
+    <default expression="" applyOnUpdate="0" field="shape"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="height"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="5" notnull_strength="2" field="width" exp_strength="2"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="shape" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="code" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="4" notnull_strength="0" field="height" exp_strength="2"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="width" exp="regexp_match(&quot;width&quot;,'^(-?\\d+(\\.\\d+)?)(\\s-?\\d+(\\.\\d+)?)*$')"/>
+    <constraint desc="" field="shape" exp=""/>
+    <constraint desc="" field="code" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="height" exp="regexp_match(&quot;height&quot;,'^(-?\\d+(\\.\\d+)?)(\\s-?\\d+(\\.\\d+)?)*$') or &quot;height&quot;is null"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="width"/>
+      <column width="-1" hidden="0" type="field" name="shape"/>
+      <column width="-1" hidden="0" type="field" name="code"/>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="height"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="3" name="id" showLabel="1"/>
+      <attributeEditorField index="2" name="code" showLabel="1"/>
+      <attributeEditorField index="1" name="shape" showLabel="1"/>
+      <attributeEditorField index="0" name="width" showLabel="1"/>
+      <attributeEditorField index="4" name="height" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="code"/>
+    <field editable="1" name="height"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="shape"/>
+    <field editable="1" name="width"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="height"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="shape"/>
+    <field labelOnTop="0" name="width"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>width</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_cross_section_location.qml
+++ b/layer_styles/schematisation/v2_cross_section_location.qml
@@ -1,255 +1,225 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.4-Essen" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="channel_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="definition_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="reference_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="friction_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="friction_value">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="bank_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis simplifyMaxScale="1" simplifyDrawingTol="1" simplifyDrawingHints="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" maxScale="0" minScale="1e+08" readOnly="0" simplifyLocal="1" styleCategories="AllStyleCategories" labelsEnabled="0" version="3.4.5-Madeira">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 type="singleSymbol" forceraster="0" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="marker" name="0">
-        <layer pass="0" class="SimpleMarker" locked="0">
+      <symbol name="0" type="marker" alpha="1" force_rhr="0" clip_to_extent="1">
+        <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="19,61,142,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
           <prop k="name" v="diamond"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="scale_method" v="area"/>
           <prop k="size" v="2"/>
-          <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="size_unit" v="MM"/>
           <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="0"/>
-    <property key="labeling/placementFlags" value="0"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property value="id" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>id</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="0">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory maxScaleDenominator="1e+08" penColor="#000000" opacity="1" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" barWidth="5" diagramOrientation="Up" scaleBasedVisibility="0" lineSizeType="MM" width="15" penAlpha="255" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" scaleDependency="Area" height="15" enabled="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" minScaleDenominator="0" sizeType="MM" penWidth="0">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings placement="0" showAll="1" linePlacementFlags="2" dist="0" obstacle="0" priority="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" type="QString" value=""/>
+        <Option name="properties"/>
+        <Option name="type" type="QString" value="collection"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="reference_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="definition_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="channel_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="friction_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: Chezy" type="QString" value="1"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: Manning" type="QString" value="2"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="friction_value">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bank_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" name="" field="reference_level"/>
+    <alias index="1" name="" field="definition_id"/>
+    <alias index="2" name="" field="channel_id"/>
+    <alias index="3" name="" field="code"/>
+    <alias index="4" name="" field="friction_type"/>
+    <alias index="5" name="" field="friction_value"/>
+    <alias index="6" name="" field="bank_level"/>
+    <alias index="7" name="" field="id"/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform>.</editform>
+  <defaults>
+    <default field="reference_level" expression="" applyOnUpdate="0"/>
+    <default field="definition_id" expression="" applyOnUpdate="0"/>
+    <default field="channel_id" expression="" applyOnUpdate="0"/>
+    <default field="code" expression="'new'" applyOnUpdate="0"/>
+    <default field="friction_type" expression="2" applyOnUpdate="0"/>
+    <default field="friction_value" expression="" applyOnUpdate="0"/>
+    <default field="bank_level" expression="" applyOnUpdate="0"/>
+    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint constraints="1" notnull_strength="2" field="reference_level" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="1" notnull_strength="2" field="definition_id" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="1" notnull_strength="2" field="channel_id" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="1" notnull_strength="2" field="code" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="1" notnull_strength="2" field="friction_type" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="1" notnull_strength="2" field="friction_value" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="4" notnull_strength="0" field="bank_level" exp_strength="2" unique_strength="0"/>
+    <constraint constraints="3" notnull_strength="1" field="id" exp_strength="0" unique_strength="1"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" desc="" field="reference_level"/>
+    <constraint exp="" desc="" field="definition_id"/>
+    <constraint exp="" desc="" field="channel_id"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="friction_type"/>
+    <constraint exp="" desc="" field="friction_value"/>
+    <constraint exp="&quot;bank_level&quot;>&quot;reference_level&quot; or &quot;bank_level&quot;  is null or &quot;reference_level&quot; is null" desc="exceeds reference" field="bank_level"/>
+    <constraint exp="" desc="" field="id"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+    <columns>
+      <column name="reference_level" type="field" hidden="0" width="-1"/>
+      <column name="definition_id" type="field" hidden="0" width="-1"/>
+      <column name="channel_id" type="field" hidden="0" width="-1"/>
+      <column name="code" type="field" hidden="0" width="-1"/>
+      <column name="friction_type" type="field" hidden="0" width="-1"/>
+      <column name="friction_value" type="field" hidden="0" width="-1"/>
+      <column name="bank_level" type="field" hidden="0" width="-1"/>
+      <column name="id" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -271,11 +241,49 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="General" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField index="7" name="id" showLabel="1"/>
+      <attributeEditorField index="3" name="code" showLabel="1"/>
+      <attributeEditorField index="0" name="reference_level" showLabel="1"/>
+      <attributeEditorField index="6" name="bank_level" showLabel="1"/>
+      <attributeEditorField index="4" name="friction_type" showLabel="1"/>
+      <attributeEditorField index="5" name="friction_value" showLabel="1"/>
+      <attributeEditorField index="1" name="definition_id" showLabel="1"/>
+      <attributeEditorField index="2" name="channel_id" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="bank_level" editable="1"/>
+    <field name="channel_id" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="definition_id" editable="1"/>
+    <field name="friction_type" editable="1"/>
+    <field name="friction_value" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="reference_level" editable="1"/>
+    <field name="v2_cross_section_definition_code" editable="0"/>
+    <field name="v2_cross_section_definition_height" editable="0"/>
+    <field name="v2_cross_section_definition_shape" editable="0"/>
+    <field name="v2_cross_section_definition_width" editable="0"/>
+  </editable>
+  <labelOnTop>
+    <field name="bank_level" labelOnTop="0"/>
+    <field name="channel_id" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="definition_id" labelOnTop="0"/>
+    <field name="friction_type" labelOnTop="0"/>
+    <field name="friction_value" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="reference_level" labelOnTop="0"/>
+    <field name="v2_cross_section_definition_code" labelOnTop="0"/>
+    <field name="v2_cross_section_definition_height" labelOnTop="0"/>
+    <field name="v2_cross_section_definition_shape" labelOnTop="0"/>
+    <field name="v2_cross_section_definition_width" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_cross_section_location.qml
+++ b/layer_styles/schematisation/v2_cross_section_location.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyMaxScale="1" simplifyDrawingTol="1" simplifyDrawingHints="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" maxScale="0" minScale="1e+08" readOnly="0" simplifyLocal="1" styleCategories="AllStyleCategories" labelsEnabled="0" version="3.4.5-Madeira">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="0" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 type="singleSymbol" forceraster="0" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol name="0" type="marker" alpha="1" force_rhr="0" clip_to_extent="1">
-        <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="0">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="19,61,142,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -29,9 +29,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -50,21 +50,21 @@
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
   <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory maxScaleDenominator="1e+08" penColor="#000000" opacity="1" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" barWidth="5" diagramOrientation="Up" scaleBasedVisibility="0" lineSizeType="MM" width="15" penAlpha="255" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" scaleDependency="Area" height="15" enabled="0" backgroundColor="#ffffff" labelPlacementMethod="XHeight" minScaleDenominator="0" sizeType="MM" penWidth="0">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" showAll="1" linePlacementFlags="2" dist="0" obstacle="0" priority="0" zIndex="0">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -73,8 +73,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -83,8 +83,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -93,8 +93,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -103,8 +103,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -113,12 +113,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" type="QString" value="1"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" type="QString" value="2"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -129,8 +129,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -139,8 +139,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -149,44 +149,44 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="reference_level"/>
-    <alias index="1" name="" field="definition_id"/>
-    <alias index="2" name="" field="channel_id"/>
-    <alias index="3" name="" field="code"/>
-    <alias index="4" name="" field="friction_type"/>
-    <alias index="5" name="" field="friction_value"/>
-    <alias index="6" name="" field="bank_level"/>
-    <alias index="7" name="" field="id"/>
+    <alias name="" field="reference_level" index="0"/>
+    <alias name="" field="definition_id" index="1"/>
+    <alias name="" field="channel_id" index="2"/>
+    <alias name="" field="code" index="3"/>
+    <alias name="" field="friction_type" index="4"/>
+    <alias name="" field="friction_value" index="5"/>
+    <alias name="" field="bank_level" index="6"/>
+    <alias name="" field="id" index="7"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="reference_level" expression="" applyOnUpdate="0"/>
-    <default field="definition_id" expression="" applyOnUpdate="0"/>
-    <default field="channel_id" expression="" applyOnUpdate="0"/>
-    <default field="code" expression="'new'" applyOnUpdate="0"/>
-    <default field="friction_type" expression="2" applyOnUpdate="0"/>
-    <default field="friction_value" expression="" applyOnUpdate="0"/>
-    <default field="bank_level" expression="" applyOnUpdate="0"/>
-    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+    <default expression="" applyOnUpdate="0" field="reference_level"/>
+    <default expression="" applyOnUpdate="0" field="definition_id"/>
+    <default expression="" applyOnUpdate="0" field="channel_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="2" applyOnUpdate="0" field="friction_type"/>
+    <default expression="" applyOnUpdate="0" field="friction_value"/>
+    <default expression="" applyOnUpdate="0" field="bank_level"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
   </defaults>
   <constraints>
-    <constraint constraints="1" notnull_strength="2" field="reference_level" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="1" notnull_strength="2" field="definition_id" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="1" notnull_strength="2" field="channel_id" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="1" notnull_strength="2" field="code" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="1" notnull_strength="2" field="friction_type" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="1" notnull_strength="2" field="friction_value" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="4" notnull_strength="0" field="bank_level" exp_strength="2" unique_strength="0"/>
-    <constraint constraints="3" notnull_strength="1" field="id" exp_strength="0" unique_strength="1"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="reference_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="definition_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="channel_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="0" constraints="4" field="bank_level"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" desc="" field="reference_level"/>
@@ -202,17 +202,17 @@
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="reference_level" type="field" hidden="0" width="-1"/>
-      <column name="definition_id" type="field" hidden="0" width="-1"/>
-      <column name="channel_id" type="field" hidden="0" width="-1"/>
-      <column name="code" type="field" hidden="0" width="-1"/>
-      <column name="friction_type" type="field" hidden="0" width="-1"/>
-      <column name="friction_value" type="field" hidden="0" width="-1"/>
-      <column name="bank_level" type="field" hidden="0" width="-1"/>
-      <column name="id" type="field" hidden="0" width="-1"/>
-      <column type="actions" hidden="1" width="-1"/>
+      <column width="-1" type="field" hidden="0" name="reference_level"/>
+      <column width="-1" type="field" hidden="0" name="definition_id"/>
+      <column width="-1" type="field" hidden="0" name="channel_id"/>
+      <column width="-1" type="field" hidden="0" name="code"/>
+      <column width="-1" type="field" hidden="0" name="friction_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_value"/>
+      <column width="-1" type="field" hidden="0" name="bank_level"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -243,15 +243,15 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="General" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" showLabel="1">
-      <attributeEditorField index="7" name="id" showLabel="1"/>
-      <attributeEditorField index="3" name="code" showLabel="1"/>
-      <attributeEditorField index="0" name="reference_level" showLabel="1"/>
-      <attributeEditorField index="6" name="bank_level" showLabel="1"/>
-      <attributeEditorField index="4" name="friction_type" showLabel="1"/>
-      <attributeEditorField index="5" name="friction_value" showLabel="1"/>
-      <attributeEditorField index="1" name="definition_id" showLabel="1"/>
-      <attributeEditorField index="2" name="channel_id" showLabel="1"/>
+    <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+      <attributeEditorField showLabel="1" name="id" index="7"/>
+      <attributeEditorField showLabel="1" name="code" index="3"/>
+      <attributeEditorField showLabel="1" name="reference_level" index="0"/>
+      <attributeEditorField showLabel="1" name="bank_level" index="6"/>
+      <attributeEditorField showLabel="1" name="friction_type" index="4"/>
+      <attributeEditorField showLabel="1" name="friction_value" index="5"/>
+      <attributeEditorField showLabel="1" name="definition_id" index="1"/>
+      <attributeEditorField showLabel="1" name="channel_id" index="2"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
@@ -269,18 +269,18 @@ def my_form_open(dialog, layer, feature):
     <field name="v2_cross_section_definition_width" editable="0"/>
   </editable>
   <labelOnTop>
-    <field name="bank_level" labelOnTop="0"/>
-    <field name="channel_id" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="definition_id" labelOnTop="0"/>
-    <field name="friction_type" labelOnTop="0"/>
-    <field name="friction_value" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="reference_level" labelOnTop="0"/>
-    <field name="v2_cross_section_definition_code" labelOnTop="0"/>
-    <field name="v2_cross_section_definition_height" labelOnTop="0"/>
-    <field name="v2_cross_section_definition_shape" labelOnTop="0"/>
-    <field name="v2_cross_section_definition_width" labelOnTop="0"/>
+    <field labelOnTop="0" name="bank_level"/>
+    <field labelOnTop="0" name="channel_id"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="definition_id"/>
+    <field labelOnTop="0" name="friction_type"/>
+    <field labelOnTop="0" name="friction_value"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="reference_level"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_code"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_height"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_shape"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_width"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>id</previewExpression>

--- a/layer_styles/schematisation/v2_cross_section_location.qml
+++ b/layer_styles/schematisation/v2_cross_section_location.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="0" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis version="3.4.5-Madeira" labelsEnabled="0" styleCategories="AllStyleCategories" simplifyLocal="1" simplifyMaxScale="1" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" maxScale="0" readOnly="0" minScale="1e+08">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="0">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+      <symbol type="marker" name="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="19,61,142,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -29,9 +29,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -49,18 +49,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory scaleBasedVisibility="0" sizeType="MM" lineSizeType="MM" diagramOrientation="Up" barWidth="5" maxScaleDenominator="1e+08" labelPlacementMethod="XHeight" width="15" penAlpha="255" backgroundAlpha="255" penColor="#000000" penWidth="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" minimumSize="0" rotationOffset="270" minScaleDenominator="0" opacity="1" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0" enabled="0" height="15">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="0" zIndex="0">
+  <DiagramLayerSettings zIndex="0" obstacle="0" showAll="1" priority="0" placement="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option type="QString" name="name" value=""/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option type="QString" name="type" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -73,8 +73,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -83,8 +83,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -93,8 +93,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -103,8 +103,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -115,10 +115,10 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Chèzy"/>
+                <Option type="QString" name="1: Chèzy" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Manning"/>
+                <Option type="QString" name="2: Manning" value="2"/>
               </Option>
             </Option>
           </Option>
@@ -129,8 +129,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -139,8 +139,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -149,8 +149,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -169,50 +169,50 @@
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="reference_level"/>
-    <default expression="" applyOnUpdate="0" field="definition_id"/>
-    <default expression="" applyOnUpdate="0" field="channel_id"/>
-    <default expression="'new'" applyOnUpdate="0" field="code"/>
-    <default expression="2" applyOnUpdate="0" field="friction_type"/>
-    <default expression="" applyOnUpdate="0" field="friction_value"/>
-    <default expression="" applyOnUpdate="0" field="bank_level"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default field="reference_level" applyOnUpdate="0" expression=""/>
+    <default field="definition_id" applyOnUpdate="0" expression=""/>
+    <default field="channel_id" applyOnUpdate="0" expression="aggregate('v2_channel','min',&quot;id&quot;, intersects($geometry,geometry(@parent)))"/>
+    <default field="code" applyOnUpdate="0" expression="'new'"/>
+    <default field="friction_type" applyOnUpdate="0" expression="2"/>
+    <default field="friction_value" applyOnUpdate="0" expression=""/>
+    <default field="bank_level" applyOnUpdate="0" expression=""/>
+    <default field="id" applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="reference_level"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="definition_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="channel_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="0" constraints="4" field="bank_level"/>
-    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="reference_level" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="definition_id" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="channel_id" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="code" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="friction_type" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="friction_value" exp_strength="0"/>
+    <constraint constraints="4" unique_strength="0" notnull_strength="0" field="bank_level" exp_strength="2"/>
+    <constraint constraints="3" unique_strength="1" notnull_strength="1" field="id" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="reference_level"/>
-    <constraint exp="" desc="" field="definition_id"/>
-    <constraint exp="" desc="" field="channel_id"/>
-    <constraint exp="" desc="" field="code"/>
-    <constraint exp="" desc="" field="friction_type"/>
-    <constraint exp="" desc="" field="friction_value"/>
-    <constraint exp="&quot;bank_level&quot;>&quot;reference_level&quot; or &quot;bank_level&quot;  is null or &quot;reference_level&quot; is null" desc="exceeds reference" field="bank_level"/>
-    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" field="reference_level" desc=""/>
+    <constraint exp="" field="definition_id" desc=""/>
+    <constraint exp="" field="channel_id" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="friction_type" desc=""/>
+    <constraint exp="" field="friction_value" desc=""/>
+    <constraint exp="&quot;bank_level&quot;>&quot;reference_level&quot; or &quot;bank_level&quot;  is null or &quot;reference_level&quot; is null" field="bank_level" desc="exceeds reference"/>
+    <constraint exp="" field="id" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="reference_level"/>
-      <column width="-1" type="field" hidden="0" name="definition_id"/>
-      <column width="-1" type="field" hidden="0" name="channel_id"/>
-      <column width="-1" type="field" hidden="0" name="code"/>
-      <column width="-1" type="field" hidden="0" name="friction_type"/>
-      <column width="-1" type="field" hidden="0" name="friction_value"/>
-      <column width="-1" type="field" hidden="0" name="bank_level"/>
-      <column width="-1" type="field" hidden="0" name="id"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column type="field" name="reference_level" width="-1" hidden="0"/>
+      <column type="field" name="definition_id" width="-1" hidden="0"/>
+      <column type="field" name="channel_id" width="-1" hidden="0"/>
+      <column type="field" name="code" width="-1" hidden="0"/>
+      <column type="field" name="friction_type" width="-1" hidden="0"/>
+      <column type="field" name="friction_value" width="-1" hidden="0"/>
+      <column type="field" name="bank_level" width="-1" hidden="0"/>
+      <column type="field" name="id" width="-1" hidden="0"/>
+      <column type="actions" width="-1" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -243,15 +243,15 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-      <attributeEditorField showLabel="1" name="id" index="7"/>
-      <attributeEditorField showLabel="1" name="code" index="3"/>
-      <attributeEditorField showLabel="1" name="reference_level" index="0"/>
-      <attributeEditorField showLabel="1" name="bank_level" index="6"/>
-      <attributeEditorField showLabel="1" name="friction_type" index="4"/>
-      <attributeEditorField showLabel="1" name="friction_value" index="5"/>
-      <attributeEditorField showLabel="1" name="definition_id" index="1"/>
-      <attributeEditorField showLabel="1" name="channel_id" index="2"/>
+    <attributeEditorContainer columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+      <attributeEditorField name="id" index="7" showLabel="1"/>
+      <attributeEditorField name="code" index="3" showLabel="1"/>
+      <attributeEditorField name="reference_level" index="0" showLabel="1"/>
+      <attributeEditorField name="bank_level" index="6" showLabel="1"/>
+      <attributeEditorField name="friction_type" index="4" showLabel="1"/>
+      <attributeEditorField name="friction_value" index="5" showLabel="1"/>
+      <attributeEditorField name="definition_id" index="1" showLabel="1"/>
+      <attributeEditorField name="channel_id" index="2" showLabel="1"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>

--- a/layer_styles/schematisation/v2_cross_section_location_view.qml
+++ b/layer_styles/schematisation/v2_cross_section_location_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyDrawingHints="0" simplifyMaxScale="1" styleCategories="AllStyleCategories" simplifyLocal="1" minScale="1e+08" simplifyAlgorithm="0" readOnly="0" maxScale="0" labelsEnabled="0" version="3.4.5-Madeira" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1">
+<qgis labelsEnabled="0" readOnly="0" simplifyLocal="1" simplifyDrawingTol="1" minScale="1e+08" simplifyDrawingHints="0" simplifyAlgorithm="0" styleCategories="AllStyleCategories" simplifyMaxScale="1" version="3.4.5-Madeira" maxScale="0" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+  <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+      <symbol name="0" type="marker" alpha="1" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
           <prop k="angle" v="0"/>
           <prop k="color" v="19,61,142,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -29,9 +29,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -41,26 +41,26 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="dualview/previewExpressions" value="id"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="id" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory diagramOrientation="Up" barWidth="5" penAlpha="255" rotationOffset="270" penWidth="0" labelPlacementMethod="XHeight" lineSizeType="MM" height="15" opacity="1" minimumSize="0" backgroundColor="#ffffff" enabled="0" width="15" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" backgroundAlpha="255" penColor="#000000" scaleDependency="Area" maxScaleDenominator="1e+08">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" color="#000000" field=""/>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory minimumSize="0" opacity="1" penWidth="0" scaleDependency="Area" height="15" minScaleDenominator="0" scaleBasedVisibility="0" lineSizeType="MM" penColor="#000000" rotationOffset="270" width="15" maxScaleDenominator="1e+08" enabled="0" sizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" penAlpha="255" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" sizeType="MM">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute field="" color="#000000" label=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings obstacle="0" showAll="1" placement="0" dist="0" linePlacementFlags="18" priority="0" zIndex="0">
+  <DiagramLayerSettings placement="0" priority="0" obstacle="0" zIndex="0" dist="0" showAll="1" linePlacementFlags="18">
     <properties>
       <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -80,8 +80,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -90,8 +90,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -100,8 +100,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -110,8 +110,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -122,10 +122,10 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="1: Chèzy" type="QString" value="1"/>
+                <Option value="1" name="1: Chèzy" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" type="QString" value="2"/>
+                <Option value="2" name="2: Manning" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -136,8 +136,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -146,8 +146,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -156,8 +156,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -166,8 +166,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -178,19 +178,19 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="1: rectangle" type="QString" value="1"/>
+                <Option value="1" name="1: rectangle" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2: round" type="QString" value="2"/>
+                <Option value="2" name="2: round" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="3: egg" type="QString" value="3"/>
+                <Option value="3" name="3: egg" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="5: tabulated rectangle" type="QString" value="5"/>
+                <Option value="5" name="5: tabulated rectangle" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="6: tabulated trapezium" type="QString" value="6"/>
+                <Option value="6" name="6: tabulated trapezium" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -201,8 +201,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -211,8 +211,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -221,100 +221,100 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="ROWID" index="0"/>
-    <alias name="id" field="loc_id" index="1"/>
-    <alias name="code" field="loc_code" index="2"/>
-    <alias name="" field="loc_reference_level" index="3"/>
-    <alias name="" field="loc_bank_level" index="4"/>
-    <alias name="" field="loc_friction_type" index="5"/>
-    <alias name="" field="loc_friction_value" index="6"/>
-    <alias name="" field="loc_definition_id" index="7"/>
-    <alias name="" field="loc_channel_id" index="8"/>
-    <alias name="" field="def_id" index="9"/>
-    <alias name="" field="def_shape" index="10"/>
-    <alias name="" field="def_width" index="11"/>
-    <alias name="" field="def_code" index="12"/>
-    <alias name="" field="def_height" index="13"/>
+    <alias field="ROWID" index="0" name=""/>
+    <alias field="loc_id" index="1" name="id"/>
+    <alias field="loc_code" index="2" name="code"/>
+    <alias field="loc_reference_level" index="3" name="reference_level"/>
+    <alias field="loc_bank_level" index="4" name="bank_level"/>
+    <alias field="loc_friction_type" index="5" name="friction_type"/>
+    <alias field="loc_friction_value" index="6" name="friction_value"/>
+    <alias field="loc_definition_id" index="7" name="definition_id"/>
+    <alias field="loc_channel_id" index="8" name="channel_id"/>
+    <alias field="def_id" index="9" name=""/>
+    <alias field="def_shape" index="10" name=""/>
+    <alias field="def_width" index="11" name=""/>
+    <alias field="def_code" index="12" name=""/>
+    <alias field="def_height" index="13" name=""/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" field="ROWID" applyOnUpdate="0"/>
-    <default expression="if(maximum(loc_id) is null,1,maximum(loc_id)+1)" field="loc_id" applyOnUpdate="0"/>
-    <default expression="'new'" field="loc_code" applyOnUpdate="0"/>
-    <default expression="" field="loc_reference_level" applyOnUpdate="0"/>
-    <default expression="" field="loc_bank_level" applyOnUpdate="0"/>
-    <default expression="2" field="loc_friction_type" applyOnUpdate="0"/>
-    <default expression="" field="loc_friction_value" applyOnUpdate="0"/>
-    <default expression="" field="loc_definition_id" applyOnUpdate="0"/>
-    <default expression="'filled automatically'" field="loc_channel_id" applyOnUpdate="0"/>
-    <default expression="" field="def_id" applyOnUpdate="0"/>
-    <default expression="" field="def_shape" applyOnUpdate="0"/>
-    <default expression="" field="def_width" applyOnUpdate="0"/>
-    <default expression="" field="def_code" applyOnUpdate="0"/>
-    <default expression="" field="def_height" applyOnUpdate="0"/>
+    <default field="ROWID" expression="" applyOnUpdate="0"/>
+    <default field="loc_id" expression="if(maximum(loc_id) is null,1,maximum(loc_id)+1)" applyOnUpdate="0"/>
+    <default field="loc_code" expression="'new'" applyOnUpdate="0"/>
+    <default field="loc_reference_level" expression="" applyOnUpdate="0"/>
+    <default field="loc_bank_level" expression="" applyOnUpdate="0"/>
+    <default field="loc_friction_type" expression="2" applyOnUpdate="0"/>
+    <default field="loc_friction_value" expression="" applyOnUpdate="0"/>
+    <default field="loc_definition_id" expression="" applyOnUpdate="0"/>
+    <default field="loc_channel_id" expression="aggregate('v2_channel','min',&quot;id&quot;, intersects($geometry,geometry(@parent)))" applyOnUpdate="0"/>
+    <default field="def_id" expression="" applyOnUpdate="0"/>
+    <default field="def_shape" expression="" applyOnUpdate="0"/>
+    <default field="def_width" expression="" applyOnUpdate="0"/>
+    <default field="def_code" expression="" applyOnUpdate="0"/>
+    <default field="def_height" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="ROWID" unique_strength="0"/>
-    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_id" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="loc_code" unique_strength="0"/>
-    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_reference_level" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="loc_bank_level" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="loc_friction_type" unique_strength="0"/>
-    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_friction_value" unique_strength="0"/>
-    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_channel_id" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_id" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_shape" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_width" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_code" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_height" unique_strength="0"/>
+    <constraint field="ROWID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="loc_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="loc_code" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="loc_reference_level" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="loc_bank_level" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="loc_friction_type" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="loc_friction_value" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="loc_definition_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="loc_channel_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="def_id" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="def_shape" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="def_width" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="def_code" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="def_height" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="loc_id"/>
-    <constraint exp="" desc="" field="loc_code"/>
-    <constraint exp="" desc="" field="loc_reference_level"/>
-    <constraint exp="" desc="" field="loc_bank_level"/>
-    <constraint exp="" desc="" field="loc_friction_type"/>
-    <constraint exp="" desc="" field="loc_friction_value"/>
-    <constraint exp="" desc="" field="loc_definition_id"/>
-    <constraint exp="" desc="" field="loc_channel_id"/>
-    <constraint exp="" desc="" field="def_id"/>
-    <constraint exp="" desc="" field="def_shape"/>
-    <constraint exp="" desc="" field="def_width"/>
-    <constraint exp="" desc="" field="def_code"/>
-    <constraint exp="" desc="" field="def_height"/>
+    <constraint field="ROWID" desc="" exp=""/>
+    <constraint field="loc_id" desc="" exp=""/>
+    <constraint field="loc_code" desc="" exp=""/>
+    <constraint field="loc_reference_level" desc="" exp=""/>
+    <constraint field="loc_bank_level" desc="" exp=""/>
+    <constraint field="loc_friction_type" desc="" exp=""/>
+    <constraint field="loc_friction_value" desc="" exp=""/>
+    <constraint field="loc_definition_id" desc="" exp=""/>
+    <constraint field="loc_channel_id" desc="" exp=""/>
+    <constraint field="def_id" desc="" exp=""/>
+    <constraint field="def_shape" desc="" exp=""/>
+    <constraint field="def_width" desc="" exp=""/>
+    <constraint field="def_code" desc="" exp=""/>
+    <constraint field="def_height" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
-      <column type="actions" hidden="1" width="-1"/>
-      <column name="def_id" type="field" hidden="0" width="-1"/>
-      <column name="def_shape" type="field" hidden="0" width="-1"/>
-      <column name="def_width" type="field" hidden="0" width="-1"/>
-      <column name="def_code" type="field" hidden="0" width="-1"/>
-      <column name="def_height" type="field" hidden="0" width="-1"/>
-      <column name="ROWID" type="field" hidden="0" width="-1"/>
-      <column name="loc_id" type="field" hidden="0" width="-1"/>
-      <column name="loc_code" type="field" hidden="0" width="-1"/>
-      <column name="loc_reference_level" type="field" hidden="0" width="-1"/>
-      <column name="loc_bank_level" type="field" hidden="0" width="-1"/>
-      <column name="loc_friction_type" type="field" hidden="0" width="-1"/>
-      <column name="loc_friction_value" type="field" hidden="0" width="-1"/>
-      <column name="loc_definition_id" type="field" hidden="0" width="-1"/>
-      <column name="loc_channel_id" type="field" hidden="0" width="-1"/>
+      <column hidden="1" width="-1" type="actions"/>
+      <column hidden="0" width="-1" name="def_id" type="field"/>
+      <column hidden="0" width="-1" name="def_shape" type="field"/>
+      <column hidden="0" width="-1" name="def_width" type="field"/>
+      <column hidden="0" width="-1" name="def_code" type="field"/>
+      <column hidden="0" width="-1" name="def_height" type="field"/>
+      <column hidden="0" width="-1" name="ROWID" type="field"/>
+      <column hidden="0" width="-1" name="loc_id" type="field"/>
+      <column hidden="0" width="-1" name="loc_code" type="field"/>
+      <column hidden="0" width="-1" name="loc_reference_level" type="field"/>
+      <column hidden="0" width="-1" name="loc_bank_level" type="field"/>
+      <column hidden="0" width="-1" name="loc_friction_type" type="field"/>
+      <column hidden="0" width="-1" name="loc_friction_value" type="field"/>
+      <column hidden="0" width="-1" name="loc_definition_id" type="field"/>
+      <column hidden="0" width="-1" name="loc_channel_id" type="field"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -345,22 +345,22 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" name="Cross section location view" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1">
-      <attributeEditorContainer groupBox="1" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1">
-        <attributeEditorField name="loc_id" showLabel="1" index="1"/>
-        <attributeEditorField name="loc_code" showLabel="1" index="2"/>
-        <attributeEditorField name="loc_reference_level" showLabel="1" index="3"/>
-        <attributeEditorField name="loc_bank_level" showLabel="1" index="4"/>
-        <attributeEditorField name="loc_friction_type" showLabel="1" index="5"/>
-        <attributeEditorField name="loc_friction_value" showLabel="1" index="6"/>
-        <attributeEditorField name="loc_channel_id" showLabel="1" index="8"/>
+    <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="0" name="Cross section location view" columnCount="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="General" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="1" name="loc_id"/>
+        <attributeEditorField showLabel="1" index="2" name="loc_code"/>
+        <attributeEditorField showLabel="1" index="3" name="loc_reference_level"/>
+        <attributeEditorField showLabel="1" index="4" name="loc_bank_level"/>
+        <attributeEditorField showLabel="1" index="5" name="loc_friction_type"/>
+        <attributeEditorField showLabel="1" index="6" name="loc_friction_value"/>
+        <attributeEditorField showLabel="1" index="8" name="loc_channel_id"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" name="Cross section" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1">
-        <attributeEditorField name="definition_id" showLabel="1" index="-1"/>
-        <attributeEditorField name="def_code" showLabel="1" index="12"/>
-        <attributeEditorField name="def_shape" showLabel="1" index="10"/>
-        <attributeEditorField name="def_width" showLabel="1" index="11"/>
-        <attributeEditorField name="def_height" showLabel="1" index="13"/>
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Cross section" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="7" name="loc_definition_id"/>
+        <attributeEditorField showLabel="1" index="12" name="def_code"/>
+        <attributeEditorField showLabel="1" index="10" name="def_shape"/>
+        <attributeEditorField showLabel="1" index="11" name="def_width"/>
+        <attributeEditorField showLabel="1" index="13" name="def_height"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_cross_section_location_view.qml
+++ b/layer_styles/schematisation/v2_cross_section_location_view.qml
@@ -1,37 +1,37 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.4.5-Madeira" simplifyDrawingTol="1" minScale="1e+08" readOnly="0" styleCategories="AllStyleCategories" maxScale="0" simplifyDrawingHints="0" simplifyLocal="1" labelsEnabled="0" simplifyAlgorithm="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0">
+<qgis simplifyDrawingHints="0" simplifyMaxScale="1" styleCategories="AllStyleCategories" simplifyLocal="1" minScale="1e+08" simplifyAlgorithm="0" readOnly="0" maxScale="0" labelsEnabled="0" version="3.4.5-Madeira" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 symbollevels="0" forceraster="0" type="singleSymbol" enableorderby="0">
+  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
     <symbols>
-      <symbol alpha="1" force_rhr="0" type="marker" clip_to_extent="1" name="0">
-        <layer pass="0" class="SimpleMarker" enabled="1" locked="0">
-          <prop v="0" k="angle"/>
-          <prop v="19,61,142,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="diamond" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="area" k="scale_method"/>
-          <prop v="2" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+      <symbol name="0" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="19,61,142,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="diamond"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="2"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -41,9 +41,7 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="dualview/previewExpressions">
-      <value>id</value>
-    </property>
+    <property key="dualview/previewExpressions" value="id"/>
     <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
@@ -52,106 +50,114 @@
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
   <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory opacity="1" height="15" enabled="0" sizeType="MM" width="15" diagramOrientation="Up" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" penColor="#000000" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" rotationOffset="270" maxScaleDenominator="1e+08" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" barWidth="5">
-      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+    <DiagramCategory diagramOrientation="Up" barWidth="5" penAlpha="255" rotationOffset="270" penWidth="0" labelPlacementMethod="XHeight" lineSizeType="MM" height="15" opacity="1" minimumSize="0" backgroundColor="#ffffff" enabled="0" width="15" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" backgroundAlpha="255" penColor="#000000" scaleDependency="Area" maxScaleDenominator="1e+08">
+      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings obstacle="0" linePlacementFlags="18" showAll="1" dist="0" zIndex="0" placement="0" priority="0">
+  <DiagramLayerSettings obstacle="0" showAll="1" placement="0" dist="0" linePlacementFlags="18" priority="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option name="type" type="QString" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
   <fieldConfiguration>
-    <field name="location_id">
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="loc_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="location_code">
+    <field name="loc_code">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="location_reference_level">
+    <field name="loc_reference_level">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="location_bank_level">
+    <field name="loc_bank_level">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="location_friction_type">
+    <field name="loc_friction_type">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Chèzy"/>
+                <Option name="1: Chèzy" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Manning"/>
+                <Option name="2: Manning" type="QString" value="2"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="location_friction_value">
+    <field name="loc_friction_value">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="location_definition_id">
+    <field name="loc_definition_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="location_channel_id">
+    <field name="loc_channel_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -160,8 +166,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -170,21 +176,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: rectangle"/>
+                <Option name="1: rectangle" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: round"/>
+                <Option name="2: round" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: egg"/>
+                <Option name="3: egg" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: tabulated rectangle"/>
+                <Option name="5: tabulated rectangle" type="QString" value="5"/>
               </Option>
               <Option type="Map">
-                <Option value="6" type="QString" name="6: tabulated trapezium"/>
+                <Option name="6: tabulated trapezium" type="QString" value="6"/>
               </Option>
             </Option>
           </Option>
@@ -195,8 +201,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -205,8 +211,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -215,95 +221,100 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" field="location_id" name="id"/>
-    <alias index="1" field="location_code" name="code"/>
-    <alias index="2" field="location_reference_level" name=""/>
-    <alias index="3" field="location_bank_level" name="bank_level"/>
-    <alias index="4" field="location_friction_type" name="friction_type"/>
-    <alias index="5" field="location_friction_value" name="friction_value"/>
-    <alias index="6" field="location_definition_id" name="definition_id"/>
-    <alias index="7" field="location_channel_id" name="channel_id"/>
-    <alias index="8" field="def_id" name=""/>
-    <alias index="9" field="def_shape" name=""/>
-    <alias index="10" field="def_width" name=""/>
-    <alias index="11" field="def_code" name=""/>
-    <alias index="12" field="def_height" name=""/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="id" field="loc_id" index="1"/>
+    <alias name="code" field="loc_code" index="2"/>
+    <alias name="" field="loc_reference_level" index="3"/>
+    <alias name="" field="loc_bank_level" index="4"/>
+    <alias name="" field="loc_friction_type" index="5"/>
+    <alias name="" field="loc_friction_value" index="6"/>
+    <alias name="" field="loc_definition_id" index="7"/>
+    <alias name="" field="loc_channel_id" index="8"/>
+    <alias name="" field="def_id" index="9"/>
+    <alias name="" field="def_shape" index="10"/>
+    <alias name="" field="def_width" index="11"/>
+    <alias name="" field="def_code" index="12"/>
+    <alias name="" field="def_height" index="13"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="if(maximum(location_id) is null,1,maximum(location_id)+1)" applyOnUpdate="0" field="location_id"/>
-    <default expression="'new'" applyOnUpdate="0" field="location_code"/>
-    <default expression="" applyOnUpdate="0" field="location_reference_level"/>
-    <default expression="" applyOnUpdate="0" field="location_bank_level"/>
-    <default expression="2" applyOnUpdate="0" field="location_friction_type"/>
-    <default expression="" applyOnUpdate="0" field="location_friction_value"/>
-    <default expression="" applyOnUpdate="0" field="location_definition_id"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="location_channel_id"/>
-    <default expression="" applyOnUpdate="0" field="def_id"/>
-    <default expression="" applyOnUpdate="0" field="def_shape"/>
-    <default expression="" applyOnUpdate="0" field="def_width"/>
-    <default expression="" applyOnUpdate="0" field="def_code"/>
-    <default expression="" applyOnUpdate="0" field="def_height"/>
+    <default expression="" field="ROWID" applyOnUpdate="0"/>
+    <default expression="if(maximum(loc_id) is null,1,maximum(loc_id)+1)" field="loc_id" applyOnUpdate="0"/>
+    <default expression="'new'" field="loc_code" applyOnUpdate="0"/>
+    <default expression="" field="loc_reference_level" applyOnUpdate="0"/>
+    <default expression="" field="loc_bank_level" applyOnUpdate="0"/>
+    <default expression="2" field="loc_friction_type" applyOnUpdate="0"/>
+    <default expression="" field="loc_friction_value" applyOnUpdate="0"/>
+    <default expression="" field="loc_definition_id" applyOnUpdate="0"/>
+    <default expression="'filled automatically'" field="loc_channel_id" applyOnUpdate="0"/>
+    <default expression="" field="def_id" applyOnUpdate="0"/>
+    <default expression="" field="def_shape" applyOnUpdate="0"/>
+    <default expression="" field="def_width" applyOnUpdate="0"/>
+    <default expression="" field="def_code" applyOnUpdate="0"/>
+    <default expression="" field="def_height" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" notnull_strength="2" unique_strength="1" exp_strength="0" field="location_id"/>
-    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_code"/>
-    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_reference_level"/>
-    <constraint constraints="4" notnull_strength="0" unique_strength="0" exp_strength="2" field="location_bank_level"/>
-    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_friction_type"/>
-    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_friction_value"/>
-    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_definition_id"/>
-    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_channel_id"/>
-    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_id"/>
-    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_shape"/>
-    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_width"/>
-    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_code"/>
-    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_height"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="ROWID" unique_strength="0"/>
+    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_id" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="loc_code" unique_strength="0"/>
+    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_reference_level" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="loc_bank_level" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="loc_friction_type" unique_strength="0"/>
+    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_friction_value" unique_strength="0"/>
+    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_definition_id" unique_strength="0"/>
+    <constraint notnull_strength="2" exp_strength="0" constraints="1" field="loc_channel_id" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_id" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_shape" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_width" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_code" unique_strength="0"/>
+    <constraint notnull_strength="0" exp_strength="0" constraints="0" field="def_height" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="location_id" desc=""/>
-    <constraint exp="" field="location_code" desc=""/>
-    <constraint exp="" field="location_reference_level" desc=""/>
-    <constraint exp="&quot;bank_level&quot;>&quot;reference_level&quot; or &quot;bank_level&quot;  is null or &quot;reference_level&quot; is null" field="location_bank_level" desc="exceeds reference"/>
-    <constraint exp="" field="location_friction_type" desc=""/>
-    <constraint exp="" field="location_friction_value" desc=""/>
-    <constraint exp="" field="location_definition_id" desc=""/>
-    <constraint exp="" field="location_channel_id" desc=""/>
-    <constraint exp="" field="def_id" desc=""/>
-    <constraint exp="" field="def_shape" desc=""/>
-    <constraint exp="" field="def_width" desc=""/>
-    <constraint exp="" field="def_code" desc=""/>
-    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="loc_id"/>
+    <constraint exp="" desc="" field="loc_code"/>
+    <constraint exp="" desc="" field="loc_reference_level"/>
+    <constraint exp="" desc="" field="loc_bank_level"/>
+    <constraint exp="" desc="" field="loc_friction_type"/>
+    <constraint exp="" desc="" field="loc_friction_value"/>
+    <constraint exp="" desc="" field="loc_definition_id"/>
+    <constraint exp="" desc="" field="loc_channel_id"/>
+    <constraint exp="" desc="" field="def_id"/>
+    <constraint exp="" desc="" field="def_shape"/>
+    <constraint exp="" desc="" field="def_width"/>
+    <constraint exp="" desc="" field="def_code"/>
+    <constraint exp="" desc="" field="def_height"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column hidden="1" type="actions" width="-1"/>
-      <column hidden="0" type="field" width="-1" name="location_id"/>
-      <column hidden="0" type="field" width="-1" name="location_code"/>
-      <column hidden="0" type="field" width="-1" name="location_reference_level"/>
-      <column hidden="0" type="field" width="-1" name="location_bank_level"/>
-      <column hidden="0" type="field" width="-1" name="location_friction_type"/>
-      <column hidden="0" type="field" width="-1" name="location_friction_value"/>
-      <column hidden="0" type="field" width="-1" name="location_definition_id"/>
-      <column hidden="0" type="field" width="-1" name="location_channel_id"/>
-      <column hidden="0" type="field" width="-1" name="def_id"/>
-      <column hidden="0" type="field" width="-1" name="def_shape"/>
-      <column hidden="0" type="field" width="-1" name="def_width"/>
-      <column hidden="0" type="field" width="-1" name="def_code"/>
-      <column hidden="0" type="field" width="-1" name="def_height"/>
+      <column type="actions" hidden="1" width="-1"/>
+      <column name="def_id" type="field" hidden="0" width="-1"/>
+      <column name="def_shape" type="field" hidden="0" width="-1"/>
+      <column name="def_width" type="field" hidden="0" width="-1"/>
+      <column name="def_code" type="field" hidden="0" width="-1"/>
+      <column name="def_height" type="field" hidden="0" width="-1"/>
+      <column name="ROWID" type="field" hidden="0" width="-1"/>
+      <column name="loc_id" type="field" hidden="0" width="-1"/>
+      <column name="loc_code" type="field" hidden="0" width="-1"/>
+      <column name="loc_reference_level" type="field" hidden="0" width="-1"/>
+      <column name="loc_bank_level" type="field" hidden="0" width="-1"/>
+      <column name="loc_friction_type" type="field" hidden="0" width="-1"/>
+      <column name="loc_friction_value" type="field" hidden="0" width="-1"/>
+      <column name="loc_definition_id" type="field" hidden="0" width="-1"/>
+      <column name="loc_channel_id" type="field" hidden="0" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -334,26 +345,27 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer columnCount="1" visibilityExpression="" groupBox="0" showLabel="1" name="Cross section location view" visibilityExpressionEnabled="0">
-      <attributeEditorContainer columnCount="1" visibilityExpression="" groupBox="1" showLabel="1" name="General" visibilityExpressionEnabled="0">
-        <attributeEditorField index="0" showLabel="1" name="location_id"/>
-        <attributeEditorField index="1" showLabel="1" name="location_code"/>
-        <attributeEditorField index="2" showLabel="1" name="location_reference_level"/>
-        <attributeEditorField index="3" showLabel="1" name="location_bank_level"/>
-        <attributeEditorField index="4" showLabel="1" name="location_friction_type"/>
-        <attributeEditorField index="5" showLabel="1" name="location_friction_value"/>
-        <attributeEditorField index="7" showLabel="1" name="location_channel_id"/>
+    <attributeEditorContainer groupBox="0" name="Cross section location view" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1">
+      <attributeEditorContainer groupBox="1" name="General" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1">
+        <attributeEditorField name="loc_id" showLabel="1" index="1"/>
+        <attributeEditorField name="loc_code" showLabel="1" index="2"/>
+        <attributeEditorField name="loc_reference_level" showLabel="1" index="3"/>
+        <attributeEditorField name="loc_bank_level" showLabel="1" index="4"/>
+        <attributeEditorField name="loc_friction_type" showLabel="1" index="5"/>
+        <attributeEditorField name="loc_friction_value" showLabel="1" index="6"/>
+        <attributeEditorField name="loc_channel_id" showLabel="1" index="8"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" visibilityExpression="" groupBox="1" showLabel="1" name="Cross section" visibilityExpressionEnabled="0">
-        <attributeEditorField index="6" showLabel="1" name="definition_id"/>
-        <attributeEditorField index="11" showLabel="1" name="def_code"/>
-        <attributeEditorField index="9" showLabel="1" name="def_shape"/>
-        <attributeEditorField index="10" showLabel="1" name="def_width"/>
-        <attributeEditorField index="12" showLabel="1" name="def_height"/>
+      <attributeEditorContainer groupBox="1" name="Cross section" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1">
+        <attributeEditorField name="definition_id" showLabel="1" index="-1"/>
+        <attributeEditorField name="def_code" showLabel="1" index="12"/>
+        <attributeEditorField name="def_shape" showLabel="1" index="10"/>
+        <attributeEditorField name="def_width" showLabel="1" index="11"/>
+        <attributeEditorField name="def_height" showLabel="1" index="13"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
+    <field editable="1" name="ROWID"/>
     <field editable="1" name="bank_level"/>
     <field editable="1" name="channel_id"/>
     <field editable="1" name="code"/>
@@ -366,6 +378,14 @@ def my_form_open(dialog, layer, feature):
     <field editable="1" name="friction_type"/>
     <field editable="1" name="friction_value"/>
     <field editable="1" name="id"/>
+    <field editable="1" name="loc_bank_level"/>
+    <field editable="1" name="loc_channel_id"/>
+    <field editable="1" name="loc_code"/>
+    <field editable="1" name="loc_definition_id"/>
+    <field editable="1" name="loc_friction_type"/>
+    <field editable="1" name="loc_friction_value"/>
+    <field editable="1" name="loc_id"/>
+    <field editable="1" name="loc_reference_level"/>
     <field editable="1" name="location_bank_level"/>
     <field editable="1" name="location_channel_id"/>
     <field editable="1" name="location_code"/>
@@ -381,6 +401,7 @@ def my_form_open(dialog, layer, feature):
     <field editable="0" name="v2_cross_section_definition_width"/>
   </editable>
   <labelOnTop>
+    <field labelOnTop="0" name="ROWID"/>
     <field labelOnTop="0" name="bank_level"/>
     <field labelOnTop="0" name="channel_id"/>
     <field labelOnTop="0" name="code"/>
@@ -393,6 +414,14 @@ def my_form_open(dialog, layer, feature):
     <field labelOnTop="0" name="friction_type"/>
     <field labelOnTop="0" name="friction_value"/>
     <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="loc_bank_level"/>
+    <field labelOnTop="0" name="loc_channel_id"/>
+    <field labelOnTop="0" name="loc_code"/>
+    <field labelOnTop="0" name="loc_definition_id"/>
+    <field labelOnTop="0" name="loc_friction_type"/>
+    <field labelOnTop="0" name="loc_friction_value"/>
+    <field labelOnTop="0" name="loc_id"/>
+    <field labelOnTop="0" name="loc_reference_level"/>
     <field labelOnTop="0" name="location_bank_level"/>
     <field labelOnTop="0" name="location_channel_id"/>
     <field labelOnTop="0" name="location_code"/>

--- a/layer_styles/schematisation/v2_cross_section_location_view.qml
+++ b/layer_styles/schematisation/v2_cross_section_location_view.qml
@@ -1,0 +1,414 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.4.5-Madeira" simplifyDrawingTol="1" minScale="1e+08" readOnly="0" styleCategories="AllStyleCategories" maxScale="0" simplifyDrawingHints="0" simplifyLocal="1" labelsEnabled="0" simplifyAlgorithm="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 symbollevels="0" forceraster="0" type="singleSymbol" enableorderby="0">
+    <symbols>
+      <symbol alpha="1" force_rhr="0" type="marker" clip_to_extent="1" name="0">
+        <layer pass="0" class="SimpleMarker" enabled="1" locked="0">
+          <prop v="0" k="angle"/>
+          <prop v="19,61,142,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="diamond" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="area" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <customproperties>
+    <property key="dualview/previewExpressions">
+      <value>id</value>
+    </property>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory opacity="1" height="15" enabled="0" sizeType="MM" width="15" diagramOrientation="Up" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" penColor="#000000" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" rotationOffset="270" maxScaleDenominator="1e+08" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" barWidth="5">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" linePlacementFlags="18" showAll="1" dist="0" zIndex="0" placement="0" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option value="" type="QString" name="name"/>
+        <Option name="properties"/>
+        <Option value="collection" type="QString" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="location_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="location_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="location_reference_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="location_bank_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="location_friction_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option value="1" type="QString" name="1: Chèzy"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" type="QString" name="2: Manning"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="location_friction_value">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="location_definition_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="location_channel_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option value="1" type="QString" name="1: rectangle"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" type="QString" name="2: round"/>
+              </Option>
+              <Option type="Map">
+                <Option value="3" type="QString" name="3: egg"/>
+              </Option>
+              <Option type="Map">
+                <Option value="5" type="QString" name="5: tabulated rectangle"/>
+              </Option>
+              <Option type="Map">
+                <Option value="6" type="QString" name="6: tabulated trapezium"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_height">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="location_id" name="id"/>
+    <alias index="1" field="location_code" name="code"/>
+    <alias index="2" field="location_reference_level" name=""/>
+    <alias index="3" field="location_bank_level" name="bank_level"/>
+    <alias index="4" field="location_friction_type" name="friction_type"/>
+    <alias index="5" field="location_friction_value" name="friction_value"/>
+    <alias index="6" field="location_definition_id" name="definition_id"/>
+    <alias index="7" field="location_channel_id" name="channel_id"/>
+    <alias index="8" field="def_id" name=""/>
+    <alias index="9" field="def_shape" name=""/>
+    <alias index="10" field="def_width" name=""/>
+    <alias index="11" field="def_code" name=""/>
+    <alias index="12" field="def_height" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="if(maximum(location_id) is null,1,maximum(location_id)+1)" applyOnUpdate="0" field="location_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="location_code"/>
+    <default expression="" applyOnUpdate="0" field="location_reference_level"/>
+    <default expression="" applyOnUpdate="0" field="location_bank_level"/>
+    <default expression="2" applyOnUpdate="0" field="location_friction_type"/>
+    <default expression="" applyOnUpdate="0" field="location_friction_value"/>
+    <default expression="" applyOnUpdate="0" field="location_definition_id"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="location_channel_id"/>
+    <default expression="" applyOnUpdate="0" field="def_id"/>
+    <default expression="" applyOnUpdate="0" field="def_shape"/>
+    <default expression="" applyOnUpdate="0" field="def_width"/>
+    <default expression="" applyOnUpdate="0" field="def_code"/>
+    <default expression="" applyOnUpdate="0" field="def_height"/>
+  </defaults>
+  <constraints>
+    <constraint constraints="3" notnull_strength="2" unique_strength="1" exp_strength="0" field="location_id"/>
+    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_code"/>
+    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_reference_level"/>
+    <constraint constraints="4" notnull_strength="0" unique_strength="0" exp_strength="2" field="location_bank_level"/>
+    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_friction_type"/>
+    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_friction_value"/>
+    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_definition_id"/>
+    <constraint constraints="1" notnull_strength="2" unique_strength="0" exp_strength="0" field="location_channel_id"/>
+    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_id"/>
+    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_shape"/>
+    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_width"/>
+    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_code"/>
+    <constraint constraints="0" notnull_strength="0" unique_strength="0" exp_strength="0" field="def_height"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="location_id" desc=""/>
+    <constraint exp="" field="location_code" desc=""/>
+    <constraint exp="" field="location_reference_level" desc=""/>
+    <constraint exp="&quot;bank_level&quot;>&quot;reference_level&quot; or &quot;bank_level&quot;  is null or &quot;reference_level&quot; is null" field="location_bank_level" desc="exceeds reference"/>
+    <constraint exp="" field="location_friction_type" desc=""/>
+    <constraint exp="" field="location_friction_value" desc=""/>
+    <constraint exp="" field="location_definition_id" desc=""/>
+    <constraint exp="" field="location_channel_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+    <columns>
+      <column hidden="1" type="actions" width="-1"/>
+      <column hidden="0" type="field" width="-1" name="location_id"/>
+      <column hidden="0" type="field" width="-1" name="location_code"/>
+      <column hidden="0" type="field" width="-1" name="location_reference_level"/>
+      <column hidden="0" type="field" width="-1" name="location_bank_level"/>
+      <column hidden="0" type="field" width="-1" name="location_friction_type"/>
+      <column hidden="0" type="field" width="-1" name="location_friction_value"/>
+      <column hidden="0" type="field" width="-1" name="location_definition_id"/>
+      <column hidden="0" type="field" width="-1" name="location_channel_id"/>
+      <column hidden="0" type="field" width="-1" name="def_id"/>
+      <column hidden="0" type="field" width="-1" name="def_shape"/>
+      <column hidden="0" type="field" width="-1" name="def_width"/>
+      <column hidden="0" type="field" width="-1" name="def_code"/>
+      <column hidden="0" type="field" width="-1" name="def_height"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath>.</editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from PyQt4.QtGui import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer columnCount="1" visibilityExpression="" groupBox="0" showLabel="1" name="Cross section location view" visibilityExpressionEnabled="0">
+      <attributeEditorContainer columnCount="1" visibilityExpression="" groupBox="1" showLabel="1" name="General" visibilityExpressionEnabled="0">
+        <attributeEditorField index="0" showLabel="1" name="location_id"/>
+        <attributeEditorField index="1" showLabel="1" name="location_code"/>
+        <attributeEditorField index="2" showLabel="1" name="location_reference_level"/>
+        <attributeEditorField index="3" showLabel="1" name="location_bank_level"/>
+        <attributeEditorField index="4" showLabel="1" name="location_friction_type"/>
+        <attributeEditorField index="5" showLabel="1" name="location_friction_value"/>
+        <attributeEditorField index="7" showLabel="1" name="location_channel_id"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" groupBox="1" showLabel="1" name="Cross section" visibilityExpressionEnabled="0">
+        <attributeEditorField index="6" showLabel="1" name="definition_id"/>
+        <attributeEditorField index="11" showLabel="1" name="def_code"/>
+        <attributeEditorField index="9" showLabel="1" name="def_shape"/>
+        <attributeEditorField index="10" showLabel="1" name="def_width"/>
+        <attributeEditorField index="12" showLabel="1" name="def_height"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="bank_level"/>
+    <field editable="1" name="channel_id"/>
+    <field editable="1" name="code"/>
+    <field editable="0" name="def_code"/>
+    <field editable="0" name="def_height"/>
+    <field editable="1" name="def_id"/>
+    <field editable="0" name="def_shape"/>
+    <field editable="0" name="def_width"/>
+    <field editable="1" name="definition_id"/>
+    <field editable="1" name="friction_type"/>
+    <field editable="1" name="friction_value"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="location_bank_level"/>
+    <field editable="1" name="location_channel_id"/>
+    <field editable="1" name="location_code"/>
+    <field editable="1" name="location_definition_id"/>
+    <field editable="1" name="location_friction_type"/>
+    <field editable="1" name="location_friction_value"/>
+    <field editable="1" name="location_id"/>
+    <field editable="1" name="location_reference_level"/>
+    <field editable="1" name="reference_level"/>
+    <field editable="0" name="v2_cross_section_definition_code"/>
+    <field editable="0" name="v2_cross_section_definition_height"/>
+    <field editable="0" name="v2_cross_section_definition_shape"/>
+    <field editable="0" name="v2_cross_section_definition_width"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="bank_level"/>
+    <field labelOnTop="0" name="channel_id"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="def_code"/>
+    <field labelOnTop="0" name="def_height"/>
+    <field labelOnTop="0" name="def_id"/>
+    <field labelOnTop="0" name="def_shape"/>
+    <field labelOnTop="0" name="def_width"/>
+    <field labelOnTop="0" name="definition_id"/>
+    <field labelOnTop="0" name="friction_type"/>
+    <field labelOnTop="0" name="friction_value"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="location_bank_level"/>
+    <field labelOnTop="0" name="location_channel_id"/>
+    <field labelOnTop="0" name="location_code"/>
+    <field labelOnTop="0" name="location_definition_id"/>
+    <field labelOnTop="0" name="location_friction_type"/>
+    <field labelOnTop="0" name="location_friction_value"/>
+    <field labelOnTop="0" name="location_id"/>
+    <field labelOnTop="0" name="location_reference_level"/>
+    <field labelOnTop="0" name="reference_level"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_code"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_height"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_shape"/>
+    <field labelOnTop="0" name="v2_cross_section_definition_width"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>location_id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_culvert.qml
+++ b/layer_styles/schematisation/v2_culvert.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis labelsEnabled="0" readOnly="0" simplifyLocal="1" simplifyDrawingTol="1" minScale="1e+08" simplifyDrawingHints="1" simplifyAlgorithm="0" styleCategories="AllStyleCategories" simplifyMaxScale="1" version="3.4.5-Madeira" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+      <symbol name="0" type="line" alpha="1" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
-            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <symbol name="@0@1" type="marker" alpha="1" clip_to_extent="1" force_rhr="0">
+            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
               <prop k="angle" v="0"/>
               <prop k="color" v="101,101,101,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" type="QString" name="name"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option value="collection" type="QString" name="type"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -96,22 +96,22 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory minimumSize="0" opacity="1" penWidth="0" scaleDependency="Area" height="15" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" lineSizeType="MM" penColor="#000000" rotationOffset="270" width="15" maxScaleDenominator="1e+08" enabled="0" sizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" penAlpha="255" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" sizeType="MM">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+      <attribute field="" color="#000000" label=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
+  <DiagramLayerSettings placement="2" priority="0" obstacle="0" zIndex="0" dist="0" showAll="1" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -120,27 +120,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="-1" type="QString" name="-1"/>
+                <Option value="-1" name="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="0" type="QString" name="0"/>
+                <Option value="0" name="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1"/>
+                <Option value="1" name="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2"/>
+                <Option value="2" name="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3"/>
+                <Option value="3" name="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4"/>
+                <Option value="4" name="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5"/>
+                <Option value="5" name="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -151,8 +151,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -161,8 +161,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -171,8 +171,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -181,8 +181,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -191,8 +191,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -201,8 +201,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -211,8 +211,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -221,8 +221,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -231,8 +231,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -241,18 +241,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="100" type="QString" name="100: embedded"/>
+                <Option value="100" name="100: embedded" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="101" type="QString" name="101: isolated"/>
+                <Option value="101" name="101: isolated" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="102" type="QString" name="102: connected"/>
+                <Option value="102" name="102: connected" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="105" type="QString" name="105: double connected"/>
+                <Option value="105" name="105: double connected" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -263,12 +263,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Chèzy"/>
+                <Option value="1" name="1: Chèzy" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Manning"/>
+                <Option value="2" name="2: Manning" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -279,8 +279,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -289,8 +289,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -299,105 +299,105 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="zoom_category" index="0"/>
-    <alias name="" field="code" index="1"/>
-    <alias name="" field="display_name" index="2"/>
-    <alias name="" field="discharge_coefficient_negative" index="3"/>
-    <alias name="" field="dist_calc_points" index="4"/>
-    <alias name="" field="connection_node_start_id" index="5"/>
-    <alias name="" field="discharge_coefficient_positive" index="6"/>
-    <alias name="" field="cross_section_definition_id" index="7"/>
-    <alias name="" field="invert_level_end_point" index="8"/>
-    <alias name="" field="invert_level_start_point" index="9"/>
-    <alias name="" field="calculation_type" index="10"/>
-    <alias name="" field="friction_type" index="11"/>
-    <alias name="" field="friction_value" index="12"/>
-    <alias name="" field="id" index="13"/>
-    <alias name="" field="connection_node_end_id" index="14"/>
+    <alias field="zoom_category" index="0" name=""/>
+    <alias field="code" index="1" name=""/>
+    <alias field="display_name" index="2" name=""/>
+    <alias field="discharge_coefficient_negative" index="3" name=""/>
+    <alias field="dist_calc_points" index="4" name=""/>
+    <alias field="connection_node_start_id" index="5" name=""/>
+    <alias field="discharge_coefficient_positive" index="6" name=""/>
+    <alias field="cross_section_definition_id" index="7" name=""/>
+    <alias field="invert_level_end_point" index="8" name=""/>
+    <alias field="invert_level_start_point" index="9" name=""/>
+    <alias field="calculation_type" index="10" name=""/>
+    <alias field="friction_type" index="11" name=""/>
+    <alias field="friction_value" index="12" name=""/>
+    <alias field="id" index="13" name=""/>
+    <alias field="connection_node_end_id" index="14" name=""/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="4" applyOnUpdate="0" field="zoom_category"/>
-    <default expression="'new'" applyOnUpdate="0" field="code"/>
-    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
-    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_negative"/>
-    <default expression="10000" applyOnUpdate="0" field="dist_calc_points"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_start_id"/>
-    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_positive"/>
-    <default expression="" applyOnUpdate="0" field="cross_section_definition_id"/>
-    <default expression="" applyOnUpdate="0" field="invert_level_end_point"/>
-    <default expression="" applyOnUpdate="0" field="invert_level_start_point"/>
-    <default expression="101" applyOnUpdate="0" field="calculation_type"/>
-    <default expression="2" applyOnUpdate="0" field="friction_type"/>
-    <default expression="0.0145" applyOnUpdate="0" field="friction_value"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_end_id"/>
+    <default field="zoom_category" expression="4" applyOnUpdate="0"/>
+    <default field="code" expression="'new'" applyOnUpdate="0"/>
+    <default field="display_name" expression="'new'" applyOnUpdate="0"/>
+    <default field="discharge_coefficient_negative" expression="0.8" applyOnUpdate="0"/>
+    <default field="dist_calc_points" expression="10000" applyOnUpdate="0"/>
+    <default field="connection_node_start_id" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent))))" applyOnUpdate="0"/>
+    <default field="discharge_coefficient_positive" expression="0.8" applyOnUpdate="0"/>
+    <default field="cross_section_definition_id" expression="" applyOnUpdate="0"/>
+    <default field="invert_level_end_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,end_point(geometry(@parent)))) " applyOnUpdate="0"/>
+    <default field="invert_level_start_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,start_point(geometry(@parent)))) " applyOnUpdate="0"/>
+    <default field="calculation_type" expression="101" applyOnUpdate="0"/>
+    <default field="friction_type" expression="2" applyOnUpdate="0"/>
+    <default field="friction_value" expression="0.0145" applyOnUpdate="0"/>
+    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+    <default field="connection_node_end_id" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent))))" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_negative"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="dist_calc_points"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_start_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_positive"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cross_section_definition_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_end_point"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_start_point"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="calculation_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
-    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_end_id"/>
+    <constraint field="zoom_category" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="code" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="display_name" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="discharge_coefficient_negative" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="dist_calc_points" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="connection_node_start_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="discharge_coefficient_positive" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="cross_section_definition_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="invert_level_end_point" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="invert_level_start_point" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="calculation_type" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="friction_type" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="friction_value" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint field="id" notnull_strength="1" exp_strength="0" constraints="3" unique_strength="1"/>
+    <constraint field="connection_node_end_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="zoom_category"/>
-    <constraint exp="" desc="" field="code"/>
-    <constraint exp="" desc="" field="display_name"/>
-    <constraint exp="" desc="" field="discharge_coefficient_negative"/>
-    <constraint exp="" desc="" field="dist_calc_points"/>
-    <constraint exp="" desc="" field="connection_node_start_id"/>
-    <constraint exp="" desc="" field="discharge_coefficient_positive"/>
-    <constraint exp="" desc="" field="cross_section_definition_id"/>
-    <constraint exp="" desc="" field="invert_level_end_point"/>
-    <constraint exp="" desc="" field="invert_level_start_point"/>
-    <constraint exp="" desc="" field="calculation_type"/>
-    <constraint exp="" desc="" field="friction_type"/>
-    <constraint exp="" desc="" field="friction_value"/>
-    <constraint exp="" desc="" field="id"/>
-    <constraint exp="" desc="" field="connection_node_end_id"/>
+    <constraint field="zoom_category" desc="" exp=""/>
+    <constraint field="code" desc="" exp=""/>
+    <constraint field="display_name" desc="" exp=""/>
+    <constraint field="discharge_coefficient_negative" desc="" exp=""/>
+    <constraint field="dist_calc_points" desc="" exp=""/>
+    <constraint field="connection_node_start_id" desc="" exp=""/>
+    <constraint field="discharge_coefficient_positive" desc="" exp=""/>
+    <constraint field="cross_section_definition_id" desc="" exp=""/>
+    <constraint field="invert_level_end_point" desc="" exp=""/>
+    <constraint field="invert_level_start_point" desc="" exp=""/>
+    <constraint field="calculation_type" desc="" exp=""/>
+    <constraint field="friction_type" desc="" exp=""/>
+    <constraint field="friction_value" desc="" exp=""/>
+    <constraint field="id" desc="" exp=""/>
+    <constraint field="connection_node_end_id" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
-      <column width="-1" type="field" hidden="0" name="zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="code"/>
-      <column width="-1" type="field" hidden="0" name="display_name"/>
-      <column width="-1" type="field" hidden="0" name="discharge_coefficient_negative"/>
-      <column width="-1" type="field" hidden="0" name="dist_calc_points"/>
-      <column width="-1" type="field" hidden="0" name="connection_node_start_id"/>
-      <column width="-1" type="field" hidden="0" name="discharge_coefficient_positive"/>
-      <column width="-1" type="field" hidden="0" name="cross_section_definition_id"/>
-      <column width="-1" type="field" hidden="0" name="invert_level_end_point"/>
-      <column width="-1" type="field" hidden="0" name="invert_level_start_point"/>
-      <column width="-1" type="field" hidden="0" name="calculation_type"/>
-      <column width="-1" type="field" hidden="0" name="friction_type"/>
-      <column width="-1" type="field" hidden="0" name="friction_value"/>
-      <column width="-1" type="field" hidden="0" name="id"/>
-      <column width="-1" type="field" hidden="0" name="connection_node_end_id"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column hidden="0" width="-1" name="zoom_category" type="field"/>
+      <column hidden="0" width="-1" name="code" type="field"/>
+      <column hidden="0" width="-1" name="display_name" type="field"/>
+      <column hidden="0" width="-1" name="discharge_coefficient_negative" type="field"/>
+      <column hidden="0" width="-1" name="dist_calc_points" type="field"/>
+      <column hidden="0" width="-1" name="connection_node_start_id" type="field"/>
+      <column hidden="0" width="-1" name="discharge_coefficient_positive" type="field"/>
+      <column hidden="0" width="-1" name="cross_section_definition_id" type="field"/>
+      <column hidden="0" width="-1" name="invert_level_end_point" type="field"/>
+      <column hidden="0" width="-1" name="invert_level_start_point" type="field"/>
+      <column hidden="0" width="-1" name="calculation_type" type="field"/>
+      <column hidden="0" width="-1" name="friction_type" type="field"/>
+      <column hidden="0" width="-1" name="friction_value" type="field"/>
+      <column hidden="0" width="-1" name="id" type="field"/>
+      <column hidden="0" width="-1" name="connection_node_end_id" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -428,48 +428,48 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Culvert" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-        <attributeEditorField showLabel="1" name="id" index="13"/>
-        <attributeEditorField showLabel="1" name="display_name" index="2"/>
-        <attributeEditorField showLabel="1" name="code" index="1"/>
-        <attributeEditorField showLabel="1" name="calculation_type" index="10"/>
-        <attributeEditorField showLabel="1" name="dist_calc_points" index="4"/>
+    <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="0" name="Culvert" columnCount="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="General" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="13" name="id"/>
+        <attributeEditorField showLabel="1" index="2" name="display_name"/>
+        <attributeEditorField showLabel="1" index="1" name="code"/>
+        <attributeEditorField showLabel="1" index="10" name="calculation_type"/>
+        <attributeEditorField showLabel="1" index="4" name="dist_calc_points"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
-        <attributeEditorField showLabel="1" name="invert_level_start_point" index="9"/>
-        <attributeEditorField showLabel="1" name="invert_level_end_point" index="8"/>
-        <attributeEditorField showLabel="1" name="friction_value" index="12"/>
-        <attributeEditorField showLabel="1" name="friction_type" index="11"/>
-        <attributeEditorField showLabel="1" name="cross_section_definition_id" index="7"/>
-        <attributeEditorField showLabel="1" name="discharge_coefficient_positive" index="6"/>
-        <attributeEditorField showLabel="1" name="discharge_coefficient_negative" index="3"/>
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Characteristics" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="9" name="invert_level_start_point"/>
+        <attributeEditorField showLabel="1" index="8" name="invert_level_end_point"/>
+        <attributeEditorField showLabel="1" index="12" name="friction_value"/>
+        <attributeEditorField showLabel="1" index="11" name="friction_type"/>
+        <attributeEditorField showLabel="1" index="7" name="cross_section_definition_id"/>
+        <attributeEditorField showLabel="1" index="6" name="discharge_coefficient_positive"/>
+        <attributeEditorField showLabel="1" index="3" name="discharge_coefficient_negative"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
-        <attributeEditorField showLabel="1" name="zoom_category" index="0"/>
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Visualization" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="0" name="zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
-        <attributeEditorField showLabel="1" name="connection_node_start_id" index="5"/>
-        <attributeEditorField showLabel="1" name="connection_node_end_id" index="14"/>
+      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Connection nodes" columnCount="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="5" name="connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="14" name="connection_node_end_id"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="calculation_type" editable="1"/>
-    <field name="code" editable="1"/>
-    <field name="connection_node_end_id" editable="1"/>
-    <field name="connection_node_start_id" editable="1"/>
-    <field name="cross_section_definition_id" editable="1"/>
-    <field name="discharge_coefficient_negative" editable="1"/>
-    <field name="discharge_coefficient_positive" editable="1"/>
-    <field name="display_name" editable="1"/>
-    <field name="dist_calc_points" editable="1"/>
-    <field name="friction_type" editable="1"/>
-    <field name="friction_value" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="invert_level_end_point" editable="1"/>
-    <field name="invert_level_start_point" editable="1"/>
-    <field name="zoom_category" editable="1"/>
+    <field editable="1" name="calculation_type"/>
+    <field editable="1" name="code"/>
+    <field editable="1" name="connection_node_end_id"/>
+    <field editable="1" name="connection_node_start_id"/>
+    <field editable="1" name="cross_section_definition_id"/>
+    <field editable="1" name="discharge_coefficient_negative"/>
+    <field editable="1" name="discharge_coefficient_positive"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="dist_calc_points"/>
+    <field editable="1" name="friction_type"/>
+    <field editable="1" name="friction_value"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="invert_level_end_point"/>
+    <field editable="1" name="invert_level_start_point"/>
+    <field editable="1" name="zoom_category"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="calculation_type"/>

--- a/layer_styles/schematisation/v2_culvert.qml
+++ b/layer_styles/schematisation/v2_culvert.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
+        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
+            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
               <prop k="angle" v="0"/>
               <prop k="color" v="101,101,101,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -96,18 +96,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -120,27 +120,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -151,8 +151,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -161,8 +161,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -171,8 +171,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -181,8 +181,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -191,8 +191,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -201,8 +201,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -211,8 +211,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -221,8 +221,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -231,8 +231,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -241,18 +241,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="100: embedded" value="100" type="QString"/>
+                <Option value="100" type="QString" name="100: embedded"/>
               </Option>
               <Option type="Map">
-                <Option name="101: isolated" value="101" type="QString"/>
+                <Option value="101" type="QString" name="101: isolated"/>
               </Option>
               <Option type="Map">
-                <Option name="102: connected" value="102" type="QString"/>
+                <Option value="102" type="QString" name="102: connected"/>
               </Option>
               <Option type="Map">
-                <Option name="105: double connected" value="105" type="QString"/>
+                <Option value="105" type="QString" name="105: double connected"/>
               </Option>
             </Option>
           </Option>
@@ -263,12 +263,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -279,8 +279,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -289,8 +289,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -299,105 +299,105 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="zoom_category"/>
-    <alias name="" index="1" field="code"/>
-    <alias name="" index="2" field="display_name"/>
-    <alias name="" index="3" field="discharge_coefficient_negative"/>
-    <alias name="" index="4" field="dist_calc_points"/>
-    <alias name="" index="5" field="connection_node_start_id"/>
-    <alias name="" index="6" field="discharge_coefficient_positive"/>
-    <alias name="" index="7" field="cross_section_definition_id"/>
-    <alias name="" index="8" field="invert_level_end_point"/>
-    <alias name="" index="9" field="invert_level_start_point"/>
-    <alias name="" index="10" field="calculation_type"/>
-    <alias name="" index="11" field="friction_type"/>
-    <alias name="" index="12" field="friction_value"/>
-    <alias name="" index="13" field="id"/>
-    <alias name="" index="14" field="connection_node_end_id"/>
+    <alias name="" field="zoom_category" index="0"/>
+    <alias name="" field="code" index="1"/>
+    <alias name="" field="display_name" index="2"/>
+    <alias name="" field="discharge_coefficient_negative" index="3"/>
+    <alias name="" field="dist_calc_points" index="4"/>
+    <alias name="" field="connection_node_start_id" index="5"/>
+    <alias name="" field="discharge_coefficient_positive" index="6"/>
+    <alias name="" field="cross_section_definition_id" index="7"/>
+    <alias name="" field="invert_level_end_point" index="8"/>
+    <alias name="" field="invert_level_start_point" index="9"/>
+    <alias name="" field="calculation_type" index="10"/>
+    <alias name="" field="friction_type" index="11"/>
+    <alias name="" field="friction_value" index="12"/>
+    <alias name="" field="id" index="13"/>
+    <alias name="" field="connection_node_end_id" index="14"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="zoom_category" expression="4"/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="dist_calc_points" expression="10000"/>
-    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
-    <default applyOnUpdate="0" field="discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_end_point" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_start_point" expression=""/>
-    <default applyOnUpdate="0" field="calculation_type" expression="101"/>
-    <default applyOnUpdate="0" field="friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="friction_value" expression="0.0145"/>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
+    <default expression="4" applyOnUpdate="0" field="zoom_category"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_negative"/>
+    <default expression="10000" applyOnUpdate="0" field="dist_calc_points"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_start_id"/>
+    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_positive"/>
+    <default expression="" applyOnUpdate="0" field="cross_section_definition_id"/>
+    <default expression="" applyOnUpdate="0" field="invert_level_end_point"/>
+    <default expression="" applyOnUpdate="0" field="invert_level_start_point"/>
+    <default expression="101" applyOnUpdate="0" field="calculation_type"/>
+    <default expression="2" applyOnUpdate="0" field="friction_type"/>
+    <default expression="0.0145" applyOnUpdate="0" field="friction_value"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_end_id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dist_calc_points" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_end_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_start_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_value" unique_strength="0"/>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_negative"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="dist_calc_points"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_positive"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cross_section_definition_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_end_point"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_start_point"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="calculation_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_end_id"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="dist_calc_points" desc=""/>
-    <constraint exp="" field="connection_node_start_id" desc=""/>
-    <constraint exp="" field="discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="cross_section_definition_id" desc=""/>
-    <constraint exp="" field="invert_level_end_point" desc=""/>
-    <constraint exp="" field="invert_level_start_point" desc=""/>
-    <constraint exp="" field="calculation_type" desc=""/>
-    <constraint exp="" field="friction_type" desc=""/>
-    <constraint exp="" field="friction_value" desc=""/>
-    <constraint exp="" field="id" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="dist_calc_points"/>
+    <constraint exp="" desc="" field="connection_node_start_id"/>
+    <constraint exp="" desc="" field="discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="cross_section_definition_id"/>
+    <constraint exp="" desc="" field="invert_level_end_point"/>
+    <constraint exp="" desc="" field="invert_level_start_point"/>
+    <constraint exp="" desc="" field="calculation_type"/>
+    <constraint exp="" desc="" field="friction_type"/>
+    <constraint exp="" desc="" field="friction_value"/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="connection_node_end_id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="dist_calc_points" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_end_point" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_start_point" hidden="0" width="-1" type="field"/>
-      <column name="calculation_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_value" hidden="0" width="-1" type="field"/>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="code"/>
+      <column width="-1" type="field" hidden="0" name="display_name"/>
+      <column width="-1" type="field" hidden="0" name="discharge_coefficient_negative"/>
+      <column width="-1" type="field" hidden="0" name="dist_calc_points"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="discharge_coefficient_positive"/>
+      <column width="-1" type="field" hidden="0" name="cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="invert_level_end_point"/>
+      <column width="-1" type="field" hidden="0" name="invert_level_start_point"/>
+      <column width="-1" type="field" hidden="0" name="calculation_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_value"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_end_id"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -428,29 +428,29 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Culvert" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="13" showLabel="1"/>
-        <attributeEditorField name="display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="code" index="1" showLabel="1"/>
-        <attributeEditorField name="calculation_type" index="10" showLabel="1"/>
-        <attributeEditorField name="dist_calc_points" index="4" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Culvert" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="id" index="13"/>
+        <attributeEditorField showLabel="1" name="display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="code" index="1"/>
+        <attributeEditorField showLabel="1" name="calculation_type" index="10"/>
+        <attributeEditorField showLabel="1" name="dist_calc_points" index="4"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="invert_level_start_point" index="9" showLabel="1"/>
-        <attributeEditorField name="invert_level_end_point" index="8" showLabel="1"/>
-        <attributeEditorField name="friction_value" index="12" showLabel="1"/>
-        <attributeEditorField name="friction_type" index="11" showLabel="1"/>
-        <attributeEditorField name="cross_section_definition_id" index="7" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_positive" index="6" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_negative" index="3" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="invert_level_start_point" index="9"/>
+        <attributeEditorField showLabel="1" name="invert_level_end_point" index="8"/>
+        <attributeEditorField showLabel="1" name="friction_value" index="12"/>
+        <attributeEditorField showLabel="1" name="friction_type" index="11"/>
+        <attributeEditorField showLabel="1" name="cross_section_definition_id" index="7"/>
+        <attributeEditorField showLabel="1" name="discharge_coefficient_positive" index="6"/>
+        <attributeEditorField showLabel="1" name="discharge_coefficient_negative" index="3"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="0" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="zoom_category" index="0"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="5" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="14" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="connection_node_start_id" index="5"/>
+        <attributeEditorField showLabel="1" name="connection_node_end_id" index="14"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -472,21 +472,21 @@ def my_form_open(dialog, layer, feature):
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="calculation_type" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_end_id" labelOnTop="0"/>
-    <field name="connection_node_start_id" labelOnTop="0"/>
-    <field name="cross_section_definition_id" labelOnTop="0"/>
-    <field name="discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="discharge_coefficient_positive" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="dist_calc_points" labelOnTop="0"/>
-    <field name="friction_type" labelOnTop="0"/>
-    <field name="friction_value" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="invert_level_end_point" labelOnTop="0"/>
-    <field name="invert_level_start_point" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="calculation_type"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_end_id"/>
+    <field labelOnTop="0" name="connection_node_start_id"/>
+    <field labelOnTop="0" name="cross_section_definition_id"/>
+    <field labelOnTop="0" name="discharge_coefficient_negative"/>
+    <field labelOnTop="0" name="discharge_coefficient_positive"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="dist_calc_points"/>
+    <field labelOnTop="0" name="friction_type"/>
+    <field labelOnTop="0" name="friction_value"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="invert_level_end_point"/>
+    <field labelOnTop="0" name="invert_level_start_point"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_culvert.qml
+++ b/layer_styles/schematisation/v2_culvert.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" readOnly="0" simplifyLocal="1" simplifyDrawingTol="1" minScale="1e+08" simplifyDrawingHints="1" simplifyAlgorithm="0" styleCategories="AllStyleCategories" simplifyMaxScale="1" version="3.4.5-Madeira" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0">
+<qgis maxScale="-4.65661e-10" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol name="0" type="line" alpha="1" clip_to_extent="1" force_rhr="0">
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="0" type="line" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -33,7 +33,7 @@
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer enabled="1" locked="0" pass="0" class="MarkerLine">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -53,8 +53,8 @@
               <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" type="marker" alpha="1" clip_to_extent="1" force_rhr="0">
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+          <symbol clip_to_extent="1" alpha="1" name="@0@1" type="marker" force_rhr="0">
+            <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
               <prop k="angle" v="0"/>
               <prop k="color" v="101,101,101,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -96,13 +96,13 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory minimumSize="0" opacity="1" penWidth="0" scaleDependency="Area" height="15" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" lineSizeType="MM" penColor="#000000" rotationOffset="270" width="15" maxScaleDenominator="1e+08" enabled="0" sizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" penAlpha="255" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" sizeType="MM">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="-4.65661e-10" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute field="" color="#000000" label=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" priority="0" obstacle="0" zIndex="0" dist="0" showAll="1" linePlacementFlags="2">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="2" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
         <Option value="" name="name" type="QString"/>
@@ -307,97 +307,97 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="zoom_category" index="0" name=""/>
-    <alias field="code" index="1" name=""/>
-    <alias field="display_name" index="2" name=""/>
-    <alias field="discharge_coefficient_negative" index="3" name=""/>
-    <alias field="dist_calc_points" index="4" name=""/>
-    <alias field="connection_node_start_id" index="5" name=""/>
-    <alias field="discharge_coefficient_positive" index="6" name=""/>
-    <alias field="cross_section_definition_id" index="7" name=""/>
-    <alias field="invert_level_end_point" index="8" name=""/>
-    <alias field="invert_level_start_point" index="9" name=""/>
-    <alias field="calculation_type" index="10" name=""/>
-    <alias field="friction_type" index="11" name=""/>
-    <alias field="friction_value" index="12" name=""/>
-    <alias field="id" index="13" name=""/>
-    <alias field="connection_node_end_id" index="14" name=""/>
+    <alias index="0" name="" field="zoom_category"/>
+    <alias index="1" name="" field="code"/>
+    <alias index="2" name="" field="display_name"/>
+    <alias index="3" name="" field="discharge_coefficient_negative"/>
+    <alias index="4" name="" field="dist_calc_points"/>
+    <alias index="5" name="" field="connection_node_start_id"/>
+    <alias index="6" name="" field="discharge_coefficient_positive"/>
+    <alias index="7" name="" field="cross_section_definition_id"/>
+    <alias index="8" name="" field="invert_level_end_point"/>
+    <alias index="9" name="" field="invert_level_start_point"/>
+    <alias index="10" name="" field="calculation_type"/>
+    <alias index="11" name="" field="friction_type"/>
+    <alias index="12" name="" field="friction_value"/>
+    <alias index="13" name="" field="id"/>
+    <alias index="14" name="" field="connection_node_end_id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="zoom_category" expression="4" applyOnUpdate="0"/>
-    <default field="code" expression="'new'" applyOnUpdate="0"/>
-    <default field="display_name" expression="'new'" applyOnUpdate="0"/>
-    <default field="discharge_coefficient_negative" expression="0.8" applyOnUpdate="0"/>
-    <default field="dist_calc_points" expression="10000" applyOnUpdate="0"/>
-    <default field="connection_node_start_id" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent))))" applyOnUpdate="0"/>
-    <default field="discharge_coefficient_positive" expression="0.8" applyOnUpdate="0"/>
-    <default field="cross_section_definition_id" expression="" applyOnUpdate="0"/>
-    <default field="invert_level_end_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,end_point(geometry(@parent)))) " applyOnUpdate="0"/>
-    <default field="invert_level_start_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,start_point(geometry(@parent)))) " applyOnUpdate="0"/>
-    <default field="calculation_type" expression="101" applyOnUpdate="0"/>
-    <default field="friction_type" expression="2" applyOnUpdate="0"/>
-    <default field="friction_value" expression="0.0145" applyOnUpdate="0"/>
-    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
-    <default field="connection_node_end_id" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent))))" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" expression="4" field="zoom_category"/>
+    <default applyOnUpdate="0" expression="'new'" field="code"/>
+    <default applyOnUpdate="0" expression="'new'" field="display_name"/>
+    <default applyOnUpdate="0" expression="0.8" field="discharge_coefficient_negative"/>
+    <default applyOnUpdate="0" expression="10000" field="dist_calc_points"/>
+    <default applyOnUpdate="0" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent))))" field="connection_node_start_id"/>
+    <default applyOnUpdate="0" expression="0.8" field="discharge_coefficient_positive"/>
+    <default applyOnUpdate="0" expression="" field="cross_section_definition_id"/>
+    <default applyOnUpdate="0" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,end_point(geometry(@parent)))) " field="invert_level_end_point"/>
+    <default applyOnUpdate="0" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,start_point(geometry(@parent)))) " field="invert_level_start_point"/>
+    <default applyOnUpdate="0" expression="101" field="calculation_type"/>
+    <default applyOnUpdate="0" expression="2" field="friction_type"/>
+    <default applyOnUpdate="0" expression="" field="friction_value"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent))))" field="connection_node_end_id"/>
   </defaults>
   <constraints>
-    <constraint field="zoom_category" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="code" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="display_name" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="discharge_coefficient_negative" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="dist_calc_points" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
-    <constraint field="connection_node_start_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="discharge_coefficient_positive" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="cross_section_definition_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="invert_level_end_point" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="invert_level_start_point" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="calculation_type" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="friction_type" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="friction_value" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
-    <constraint field="id" notnull_strength="1" exp_strength="0" constraints="3" unique_strength="1"/>
-    <constraint field="connection_node_end_id" notnull_strength="2" exp_strength="0" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="zoom_category" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="display_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="discharge_coefficient_negative" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="dist_calc_points" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="connection_node_start_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="discharge_coefficient_positive" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cross_section_definition_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="invert_level_end_point" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="invert_level_start_point" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="calculation_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="friction_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="friction_value" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="2" field="connection_node_end_id" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="zoom_category" desc="" exp=""/>
-    <constraint field="code" desc="" exp=""/>
-    <constraint field="display_name" desc="" exp=""/>
-    <constraint field="discharge_coefficient_negative" desc="" exp=""/>
-    <constraint field="dist_calc_points" desc="" exp=""/>
-    <constraint field="connection_node_start_id" desc="" exp=""/>
-    <constraint field="discharge_coefficient_positive" desc="" exp=""/>
-    <constraint field="cross_section_definition_id" desc="" exp=""/>
-    <constraint field="invert_level_end_point" desc="" exp=""/>
-    <constraint field="invert_level_start_point" desc="" exp=""/>
-    <constraint field="calculation_type" desc="" exp=""/>
-    <constraint field="friction_type" desc="" exp=""/>
-    <constraint field="friction_value" desc="" exp=""/>
-    <constraint field="id" desc="" exp=""/>
-    <constraint field="connection_node_end_id" desc="" exp=""/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="dist_calc_points"/>
+    <constraint exp="" desc="" field="connection_node_start_id"/>
+    <constraint exp="" desc="" field="discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="cross_section_definition_id"/>
+    <constraint exp="" desc="" field="invert_level_end_point"/>
+    <constraint exp="" desc="" field="invert_level_start_point"/>
+    <constraint exp="" desc="" field="calculation_type"/>
+    <constraint exp="" desc="" field="friction_type"/>
+    <constraint exp="" desc="" field="friction_value"/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="connection_node_end_id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column hidden="0" width="-1" name="zoom_category" type="field"/>
-      <column hidden="0" width="-1" name="code" type="field"/>
-      <column hidden="0" width="-1" name="display_name" type="field"/>
-      <column hidden="0" width="-1" name="discharge_coefficient_negative" type="field"/>
-      <column hidden="0" width="-1" name="dist_calc_points" type="field"/>
-      <column hidden="0" width="-1" name="connection_node_start_id" type="field"/>
-      <column hidden="0" width="-1" name="discharge_coefficient_positive" type="field"/>
-      <column hidden="0" width="-1" name="cross_section_definition_id" type="field"/>
-      <column hidden="0" width="-1" name="invert_level_end_point" type="field"/>
-      <column hidden="0" width="-1" name="invert_level_start_point" type="field"/>
-      <column hidden="0" width="-1" name="calculation_type" type="field"/>
-      <column hidden="0" width="-1" name="friction_type" type="field"/>
-      <column hidden="0" width="-1" name="friction_value" type="field"/>
-      <column hidden="0" width="-1" name="id" type="field"/>
-      <column hidden="0" width="-1" name="connection_node_end_id" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" hidden="0" name="zoom_category" type="field"/>
+      <column width="-1" hidden="0" name="code" type="field"/>
+      <column width="-1" hidden="0" name="display_name" type="field"/>
+      <column width="-1" hidden="0" name="discharge_coefficient_negative" type="field"/>
+      <column width="-1" hidden="0" name="dist_calc_points" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_start_id" type="field"/>
+      <column width="-1" hidden="0" name="discharge_coefficient_positive" type="field"/>
+      <column width="-1" hidden="0" name="cross_section_definition_id" type="field"/>
+      <column width="-1" hidden="0" name="invert_level_end_point" type="field"/>
+      <column width="-1" hidden="0" name="invert_level_start_point" type="field"/>
+      <column width="-1" hidden="0" name="calculation_type" type="field"/>
+      <column width="-1" hidden="0" name="friction_type" type="field"/>
+      <column width="-1" hidden="0" name="friction_value" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_end_id" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -428,15 +428,15 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="0" name="Culvert" columnCount="1" visibilityExpressionEnabled="0">
-      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="General" columnCount="1" visibilityExpressionEnabled="0">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Culvert" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="13" name="id"/>
         <attributeEditorField showLabel="1" index="2" name="display_name"/>
         <attributeEditorField showLabel="1" index="1" name="code"/>
         <attributeEditorField showLabel="1" index="10" name="calculation_type"/>
         <attributeEditorField showLabel="1" index="4" name="dist_calc_points"/>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Characteristics" columnCount="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="9" name="invert_level_start_point"/>
         <attributeEditorField showLabel="1" index="8" name="invert_level_end_point"/>
         <attributeEditorField showLabel="1" index="12" name="friction_value"/>
@@ -445,10 +445,10 @@ def my_form_open(dialog, layer, feature):
         <attributeEditorField showLabel="1" index="6" name="discharge_coefficient_positive"/>
         <attributeEditorField showLabel="1" index="3" name="discharge_coefficient_negative"/>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Visualization" columnCount="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="0" name="zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpression="" showLabel="1" groupBox="1" name="Connection nodes" columnCount="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Connection nodes" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="5" name="connection_node_start_id"/>
         <attributeEditorField showLabel="1" index="14" name="connection_node_end_id"/>
       </attributeEditorContainer>

--- a/layer_styles/schematisation/v2_culvert_view.qml
+++ b/layer_styles/schematisation/v2_culvert_view.qml
@@ -1,30 +1,30 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.4.5-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" minScale="1e+08" labelsEnabled="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" readOnly="0" simplifyMaxScale="1" simplifyAlgorithm="0" maxScale="-4.65661e-10">
+<qgis maxScale="-4.65661e-10" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol alpha="1" name="0" force_rhr="0" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="101,101,101,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.66" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol clip_to_extent="1" alpha="1" name="0" type="line" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="101,101,101,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" name="name" type="QString"/>
@@ -33,19 +33,19 @@
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" enabled="1" locked="0" pass="0">
-          <prop v="3" k="interval"/>
-          <prop v="3x:0,0,0,0,0,0" k="interval_map_unit_scale"/>
-          <prop v="MM" k="interval_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="0" k="offset_along_line"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-          <prop v="MM" k="offset_along_line_unit"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="centralpoint" k="placement"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="rotate"/>
+        <layer enabled="1" locked="0" pass="0" class="MarkerLine">
+          <prop k="interval" v="3"/>
+          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="interval_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_along_line" v="0"/>
+          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_along_line_unit" v="MM"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="placement" v="centralpoint"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" name="name" type="QString"/>
@@ -53,26 +53,26 @@
               <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" name="@0@1" force_rhr="0" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
-              <prop v="0" k="angle"/>
-              <prop v="101,101,101,255" k="color"/>
-              <prop v="1" k="horizontal_anchor_point"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="circle" k="name"/>
-              <prop v="0,0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0,0,0,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0" k="outline_width"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="area" k="scale_method"/>
-              <prop v="2" k="size"/>
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-              <prop v="MM" k="size_unit"/>
-              <prop v="1" k="vertical_anchor_point"/>
+          <symbol clip_to_extent="1" alpha="1" name="@0@1" type="marker" force_rhr="0">
+            <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="101,101,101,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="name" v="circle"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="area"/>
+              <prop k="size" v="2"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
                   <Option value="" name="name" type="QString"/>
@@ -89,21 +89,21 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="dualview/previewExpressions" value="ROWID"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="ROWID" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" penAlpha="255" width="15" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" rotationOffset="270" barWidth="5" sizeType="MM" backgroundColor="#ffffff" diagramOrientation="Up" maxScaleDenominator="1e+08" enabled="0" lineSizeType="MM" backgroundAlpha="255" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" opacity="1" height="15" minimumSize="0">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="-4.65661e-10" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" field="" label=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" linePlacementFlags="2" obstacle="0" dist="0" showAll="1" priority="0" zIndex="0">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="2" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
         <Option value="" name="name" type="QString"/>
@@ -112,7 +112,7 @@
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -380,127 +380,127 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="ROWID" name="" index="0"/>
-    <alias field="cul_id" name="id" index="1"/>
-    <alias field="cul_display_name" name="display_name" index="2"/>
-    <alias field="cul_code" name="code" index="3"/>
-    <alias field="cul_calculation_type" name="calculation_type" index="4"/>
-    <alias field="cul_friction_value" name="friction_value" index="5"/>
-    <alias field="cul_friction_type" name="friction_type" index="6"/>
-    <alias field="cul_dist_calc_points" name="dist_calc_points" index="7"/>
-    <alias field="cul_zoom_category" name="zoom_category" index="8"/>
-    <alias field="cul_cross_section_definition_id" name="cross_section_definition_id" index="9"/>
-    <alias field="cul_discharge_coefficient_positive" name="discharge_coefficient_positive" index="10"/>
-    <alias field="cul_discharge_coefficient_negative" name="discharge_coefficient_negative" index="11"/>
-    <alias field="cul_invert_level_start_point" name="invert_level_start_point" index="12"/>
-    <alias field="cul_invert_level_end_point" name="invert_level_end_point" index="13"/>
-    <alias field="cul_connection_node_start_id" name="connection_node_start_id" index="14"/>
-    <alias field="cul_connection_node_end_id" name="connection_node_end_id" index="15"/>
-    <alias field="def_id" name="id" index="16"/>
-    <alias field="def_shape" name="shape" index="17"/>
-    <alias field="def_width" name="width" index="18"/>
-    <alias field="def_height" name="height" index="19"/>
-    <alias field="def_code" name="code" index="20"/>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="id" field="cul_id"/>
+    <alias index="2" name="display_name" field="cul_display_name"/>
+    <alias index="3" name="code" field="cul_code"/>
+    <alias index="4" name="calculation_type" field="cul_calculation_type"/>
+    <alias index="5" name="friction_value" field="cul_friction_value"/>
+    <alias index="6" name="friction_type" field="cul_friction_type"/>
+    <alias index="7" name="dist_calc_points" field="cul_dist_calc_points"/>
+    <alias index="8" name="zoom_category" field="cul_zoom_category"/>
+    <alias index="9" name="cross_section_definition_id" field="cul_cross_section_definition_id"/>
+    <alias index="10" name="discharge_coefficient_positive" field="cul_discharge_coefficient_positive"/>
+    <alias index="11" name="discharge_coefficient_negative" field="cul_discharge_coefficient_negative"/>
+    <alias index="12" name="invert_level_start_point" field="cul_invert_level_start_point"/>
+    <alias index="13" name="invert_level_end_point" field="cul_invert_level_end_point"/>
+    <alias index="14" name="connection_node_start_id" field="cul_connection_node_start_id"/>
+    <alias index="15" name="connection_node_end_id" field="cul_connection_node_end_id"/>
+    <alias index="16" name="id" field="def_id"/>
+    <alias index="17" name="shape" field="def_shape"/>
+    <alias index="18" name="width" field="def_width"/>
+    <alias index="19" name="height" field="def_height"/>
+    <alias index="20" name="code" field="def_code"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="ROWID" expression="" applyOnUpdate="0"/>
-    <default field="cul_id" expression="if(maximum(cul_id) is null,1, maximum(cul_id)+1)" applyOnUpdate="0"/>
-    <default field="cul_display_name" expression="'new'" applyOnUpdate="0"/>
-    <default field="cul_code" expression="'new'" applyOnUpdate="0"/>
-    <default field="cul_calculation_type" expression="101" applyOnUpdate="0"/>
-    <default field="cul_friction_value" expression="0.0145" applyOnUpdate="0"/>
-    <default field="cul_friction_type" expression="2" applyOnUpdate="0"/>
-    <default field="cul_dist_calc_points" expression="10000" applyOnUpdate="0"/>
-    <default field="cul_zoom_category" expression="3" applyOnUpdate="0"/>
-    <default field="cul_cross_section_definition_id" expression="" applyOnUpdate="0"/>
-    <default field="cul_discharge_coefficient_positive" expression="0.8" applyOnUpdate="0"/>
-    <default field="cul_discharge_coefficient_negative" expression="0.8" applyOnUpdate="0"/>
-    <default field="cul_invert_level_start_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,start_point(geometry(@parent)))) " applyOnUpdate="0"/>
-    <default field="cul_invert_level_end_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,end_point(geometry(@parent)))) " applyOnUpdate="0"/>
-    <default field="cul_connection_node_start_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))" applyOnUpdate="0"/>
-    <default field="cul_connection_node_end_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))" applyOnUpdate="0"/>
-    <default field="def_id" expression="" applyOnUpdate="0"/>
-    <default field="def_shape" expression="" applyOnUpdate="0"/>
-    <default field="def_width" expression="" applyOnUpdate="0"/>
-    <default field="def_height" expression="" applyOnUpdate="0"/>
-    <default field="def_code" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="if(maximum(cul_id) is null,1, maximum(cul_id)+1)" field="cul_id"/>
+    <default applyOnUpdate="0" expression="'new'" field="cul_display_name"/>
+    <default applyOnUpdate="0" expression="'new'" field="cul_code"/>
+    <default applyOnUpdate="0" expression="101" field="cul_calculation_type"/>
+    <default applyOnUpdate="0" expression="" field="cul_friction_value"/>
+    <default applyOnUpdate="0" expression="2" field="cul_friction_type"/>
+    <default applyOnUpdate="0" expression="10000" field="cul_dist_calc_points"/>
+    <default applyOnUpdate="0" expression="3" field="cul_zoom_category"/>
+    <default applyOnUpdate="0" expression="" field="cul_cross_section_definition_id"/>
+    <default applyOnUpdate="0" expression="0.8" field="cul_discharge_coefficient_positive"/>
+    <default applyOnUpdate="0" expression="0.8" field="cul_discharge_coefficient_negative"/>
+    <default applyOnUpdate="0" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,start_point(geometry(@parent)))) " field="cul_invert_level_start_point"/>
+    <default applyOnUpdate="0" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,end_point(geometry(@parent)))) " field="cul_invert_level_end_point"/>
+    <default applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))" field="cul_connection_node_start_id"/>
+    <default applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))" field="cul_connection_node_end_id"/>
+    <default applyOnUpdate="0" expression="" field="def_id"/>
+    <default applyOnUpdate="0" expression="" field="def_shape"/>
+    <default applyOnUpdate="0" expression="" field="def_width"/>
+    <default applyOnUpdate="0" expression="" field="def_height"/>
+    <default applyOnUpdate="0" expression="" field="def_code"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" exp_strength="0" field="ROWID" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_id" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_display_name" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_code" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_calculation_type" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_friction_value" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_friction_type" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_dist_calc_points" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_zoom_category" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_cross_section_definition_id" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_discharge_coefficient_positive" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_discharge_coefficient_negative" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_invert_level_start_point" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_invert_level_end_point" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_connection_node_start_id" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="cul_connection_node_end_id" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="def_id" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="def_shape" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="def_width" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="def_height" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="def_code" notnull_strength="0" constraints="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="ROWID" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_display_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_calculation_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_friction_value" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_friction_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_dist_calc_points" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_zoom_category" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_cross_section_definition_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_discharge_coefficient_positive" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_discharge_coefficient_negative" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_invert_level_start_point" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="cul_invert_level_end_point" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="cul_connection_node_start_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="cul_connection_node_end_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="def_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="def_shape" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="def_width" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="def_height" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="def_code" constraints="0" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="ROWID" desc="" exp=""/>
-    <constraint field="cul_id" desc="" exp=""/>
-    <constraint field="cul_display_name" desc="" exp=""/>
-    <constraint field="cul_code" desc="" exp=""/>
-    <constraint field="cul_calculation_type" desc="" exp=""/>
-    <constraint field="cul_friction_value" desc="" exp=""/>
-    <constraint field="cul_friction_type" desc="" exp=""/>
-    <constraint field="cul_dist_calc_points" desc="" exp=""/>
-    <constraint field="cul_zoom_category" desc="" exp=""/>
-    <constraint field="cul_cross_section_definition_id" desc="" exp=""/>
-    <constraint field="cul_discharge_coefficient_positive" desc="" exp=""/>
-    <constraint field="cul_discharge_coefficient_negative" desc="" exp=""/>
-    <constraint field="cul_invert_level_start_point" desc="" exp=""/>
-    <constraint field="cul_invert_level_end_point" desc="" exp=""/>
-    <constraint field="cul_connection_node_start_id" desc="" exp=""/>
-    <constraint field="cul_connection_node_end_id" desc="" exp=""/>
-    <constraint field="def_id" desc="" exp=""/>
-    <constraint field="def_shape" desc="" exp=""/>
-    <constraint field="def_width" desc="" exp=""/>
-    <constraint field="def_height" desc="" exp=""/>
-    <constraint field="def_code" desc="" exp=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="cul_id"/>
+    <constraint exp="" desc="" field="cul_display_name"/>
+    <constraint exp="" desc="" field="cul_code"/>
+    <constraint exp="" desc="" field="cul_calculation_type"/>
+    <constraint exp="" desc="" field="cul_friction_value"/>
+    <constraint exp="" desc="" field="cul_friction_type"/>
+    <constraint exp="" desc="" field="cul_dist_calc_points"/>
+    <constraint exp="" desc="" field="cul_zoom_category"/>
+    <constraint exp="" desc="" field="cul_cross_section_definition_id"/>
+    <constraint exp="" desc="" field="cul_discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="cul_discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="cul_invert_level_start_point"/>
+    <constraint exp="" desc="" field="cul_invert_level_end_point"/>
+    <constraint exp="" desc="" field="cul_connection_node_start_id"/>
+    <constraint exp="" desc="" field="cul_connection_node_end_id"/>
+    <constraint exp="" desc="" field="def_id"/>
+    <constraint exp="" desc="" field="def_shape"/>
+    <constraint exp="" desc="" field="def_width"/>
+    <constraint exp="" desc="" field="def_height"/>
+    <constraint exp="" desc="" field="def_code"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column hidden="0" name="ROWID" type="field" width="-1"/>
-      <column hidden="0" name="cul_id" type="field" width="-1"/>
-      <column hidden="0" name="cul_display_name" type="field" width="-1"/>
-      <column hidden="0" name="cul_code" type="field" width="-1"/>
-      <column hidden="0" name="cul_calculation_type" type="field" width="-1"/>
-      <column hidden="0" name="cul_friction_value" type="field" width="-1"/>
-      <column hidden="0" name="cul_friction_type" type="field" width="-1"/>
-      <column hidden="0" name="cul_dist_calc_points" type="field" width="-1"/>
-      <column hidden="0" name="cul_zoom_category" type="field" width="-1"/>
-      <column hidden="0" name="cul_cross_section_definition_id" type="field" width="-1"/>
-      <column hidden="0" name="cul_discharge_coefficient_positive" type="field" width="-1"/>
-      <column hidden="0" name="cul_discharge_coefficient_negative" type="field" width="-1"/>
-      <column hidden="0" name="cul_invert_level_start_point" type="field" width="-1"/>
-      <column hidden="0" name="cul_invert_level_end_point" type="field" width="-1"/>
-      <column hidden="0" name="cul_connection_node_start_id" type="field" width="-1"/>
-      <column hidden="0" name="cul_connection_node_end_id" type="field" width="-1"/>
-      <column hidden="0" name="def_id" type="field" width="-1"/>
-      <column hidden="0" name="def_shape" type="field" width="-1"/>
-      <column hidden="0" name="def_width" type="field" width="-1"/>
-      <column hidden="0" name="def_height" type="field" width="-1"/>
-      <column hidden="0" name="def_code" type="field" width="-1"/>
-      <column hidden="1" type="actions" width="-1"/>
+      <column width="-1" hidden="0" name="ROWID" type="field"/>
+      <column width="-1" hidden="0" name="cul_id" type="field"/>
+      <column width="-1" hidden="0" name="cul_display_name" type="field"/>
+      <column width="-1" hidden="0" name="cul_code" type="field"/>
+      <column width="-1" hidden="0" name="cul_calculation_type" type="field"/>
+      <column width="-1" hidden="0" name="cul_friction_value" type="field"/>
+      <column width="-1" hidden="0" name="cul_friction_type" type="field"/>
+      <column width="-1" hidden="0" name="cul_dist_calc_points" type="field"/>
+      <column width="-1" hidden="0" name="cul_zoom_category" type="field"/>
+      <column width="-1" hidden="0" name="cul_cross_section_definition_id" type="field"/>
+      <column width="-1" hidden="0" name="cul_discharge_coefficient_positive" type="field"/>
+      <column width="-1" hidden="0" name="cul_discharge_coefficient_negative" type="field"/>
+      <column width="-1" hidden="0" name="cul_invert_level_start_point" type="field"/>
+      <column width="-1" hidden="0" name="cul_invert_level_end_point" type="field"/>
+      <column width="-1" hidden="0" name="cul_connection_node_start_id" type="field"/>
+      <column width="-1" hidden="0" name="cul_connection_node_end_id" type="field"/>
+      <column width="-1" hidden="0" name="def_id" type="field"/>
+      <column width="-1" hidden="0" name="def_shape" type="field"/>
+      <column width="-1" hidden="0" name="def_width" type="field"/>
+      <column width="-1" hidden="0" name="def_height" type="field"/>
+      <column width="-1" hidden="0" name="def_code" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -531,83 +531,83 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="Culvert view" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0" columnCount="1">
-      <attributeEditorContainer showLabel="1" name="General" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
-        <attributeEditorField showLabel="1" name="cul_id" index="1"/>
-        <attributeEditorField showLabel="1" name="cul_display_name" index="2"/>
-        <attributeEditorField showLabel="1" name="cul_code" index="3"/>
-        <attributeEditorField showLabel="1" name="cul_calculation_type" index="4"/>
-        <attributeEditorField showLabel="1" name="cul_dist_calc_points" index="7"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Culvert view" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="1" name="cul_id"/>
+        <attributeEditorField showLabel="1" index="2" name="cul_display_name"/>
+        <attributeEditorField showLabel="1" index="3" name="cul_code"/>
+        <attributeEditorField showLabel="1" index="4" name="cul_calculation_type"/>
+        <attributeEditorField showLabel="1" index="7" name="cul_dist_calc_points"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
-        <attributeEditorField showLabel="1" name="cul_invert_level_start_point" index="12"/>
-        <attributeEditorField showLabel="1" name="cul_invert_level_end_point" index="13"/>
-        <attributeEditorField showLabel="1" name="cul_friction_type" index="6"/>
-        <attributeEditorField showLabel="1" name="cul_friction_value" index="5"/>
-        <attributeEditorField showLabel="1" name="cul_discharge_coefficient_positive" index="10"/>
-        <attributeEditorField showLabel="1" name="cul_discharge_coefficient_negative" index="11"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="12" name="cul_invert_level_start_point"/>
+        <attributeEditorField showLabel="1" index="13" name="cul_invert_level_end_point"/>
+        <attributeEditorField showLabel="1" index="6" name="cul_friction_type"/>
+        <attributeEditorField showLabel="1" index="5" name="cul_friction_value"/>
+        <attributeEditorField showLabel="1" index="10" name="cul_discharge_coefficient_positive"/>
+        <attributeEditorField showLabel="1" index="11" name="cul_discharge_coefficient_negative"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Cross section definition" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
-        <attributeEditorField showLabel="1" name="cul_cross_section_definition_id" index="9"/>
-        <attributeEditorField showLabel="1" name="def_code" index="20"/>
-        <attributeEditorField showLabel="1" name="def_shape" index="17"/>
-        <attributeEditorField showLabel="1" name="def_width" index="18"/>
-        <attributeEditorField showLabel="1" name="def_height" index="19"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Cross section definition" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="9" name="cul_cross_section_definition_id"/>
+        <attributeEditorField showLabel="1" index="20" name="def_code"/>
+        <attributeEditorField showLabel="1" index="17" name="def_shape"/>
+        <attributeEditorField showLabel="1" index="18" name="def_width"/>
+        <attributeEditorField showLabel="1" index="19" name="def_height"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
-        <attributeEditorField showLabel="1" name="cul_zoom_category" index="8"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="8" name="cul_zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Connection nodes" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
-        <attributeEditorField showLabel="1" name="cul_connection_node_start_id" index="14"/>
-        <attributeEditorField showLabel="1" name="cul_connection_node_end_id" index="15"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Connection nodes" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="14" name="cul_connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="15" name="cul_connection_node_end_id"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="ROWID" editable="1"/>
-    <field name="cul_calculation_type" editable="1"/>
-    <field name="cul_code" editable="1"/>
-    <field name="cul_connection_node_end_id" editable="0"/>
-    <field name="cul_connection_node_start_id" editable="0"/>
-    <field name="cul_cross_section_definition_id" editable="1"/>
-    <field name="cul_discharge_coefficient_negative" editable="1"/>
-    <field name="cul_discharge_coefficient_positive" editable="1"/>
-    <field name="cul_display_name" editable="1"/>
-    <field name="cul_dist_calc_points" editable="1"/>
-    <field name="cul_friction_type" editable="1"/>
-    <field name="cul_friction_value" editable="1"/>
-    <field name="cul_id" editable="1"/>
-    <field name="cul_invert_level_end_point" editable="1"/>
-    <field name="cul_invert_level_start_point" editable="1"/>
-    <field name="cul_zoom_category" editable="1"/>
-    <field name="def_code" editable="0"/>
-    <field name="def_height" editable="0"/>
-    <field name="def_id" editable="0"/>
-    <field name="def_shape" editable="0"/>
-    <field name="def_width" editable="0"/>
+    <field editable="1" name="ROWID"/>
+    <field editable="1" name="cul_calculation_type"/>
+    <field editable="1" name="cul_code"/>
+    <field editable="0" name="cul_connection_node_end_id"/>
+    <field editable="0" name="cul_connection_node_start_id"/>
+    <field editable="1" name="cul_cross_section_definition_id"/>
+    <field editable="1" name="cul_discharge_coefficient_negative"/>
+    <field editable="1" name="cul_discharge_coefficient_positive"/>
+    <field editable="1" name="cul_display_name"/>
+    <field editable="1" name="cul_dist_calc_points"/>
+    <field editable="1" name="cul_friction_type"/>
+    <field editable="1" name="cul_friction_value"/>
+    <field editable="1" name="cul_id"/>
+    <field editable="1" name="cul_invert_level_end_point"/>
+    <field editable="1" name="cul_invert_level_start_point"/>
+    <field editable="1" name="cul_zoom_category"/>
+    <field editable="0" name="def_code"/>
+    <field editable="0" name="def_height"/>
+    <field editable="0" name="def_id"/>
+    <field editable="0" name="def_shape"/>
+    <field editable="0" name="def_width"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="cul_calculation_type" labelOnTop="0"/>
-    <field name="cul_code" labelOnTop="0"/>
-    <field name="cul_connection_node_end_id" labelOnTop="0"/>
-    <field name="cul_connection_node_start_id" labelOnTop="0"/>
-    <field name="cul_cross_section_definition_id" labelOnTop="0"/>
-    <field name="cul_discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="cul_discharge_coefficient_positive" labelOnTop="0"/>
-    <field name="cul_display_name" labelOnTop="0"/>
-    <field name="cul_dist_calc_points" labelOnTop="0"/>
-    <field name="cul_friction_type" labelOnTop="0"/>
-    <field name="cul_friction_value" labelOnTop="0"/>
-    <field name="cul_id" labelOnTop="0"/>
-    <field name="cul_invert_level_end_point" labelOnTop="0"/>
-    <field name="cul_invert_level_start_point" labelOnTop="0"/>
-    <field name="cul_zoom_category" labelOnTop="0"/>
-    <field name="def_code" labelOnTop="0"/>
-    <field name="def_height" labelOnTop="0"/>
-    <field name="def_id" labelOnTop="0"/>
-    <field name="def_shape" labelOnTop="0"/>
-    <field name="def_width" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="cul_calculation_type"/>
+    <field labelOnTop="0" name="cul_code"/>
+    <field labelOnTop="0" name="cul_connection_node_end_id"/>
+    <field labelOnTop="0" name="cul_connection_node_start_id"/>
+    <field labelOnTop="0" name="cul_cross_section_definition_id"/>
+    <field labelOnTop="0" name="cul_discharge_coefficient_negative"/>
+    <field labelOnTop="0" name="cul_discharge_coefficient_positive"/>
+    <field labelOnTop="0" name="cul_display_name"/>
+    <field labelOnTop="0" name="cul_dist_calc_points"/>
+    <field labelOnTop="0" name="cul_friction_type"/>
+    <field labelOnTop="0" name="cul_friction_value"/>
+    <field labelOnTop="0" name="cul_id"/>
+    <field labelOnTop="0" name="cul_invert_level_end_point"/>
+    <field labelOnTop="0" name="cul_invert_level_start_point"/>
+    <field labelOnTop="0" name="cul_zoom_category"/>
+    <field labelOnTop="0" name="def_code"/>
+    <field labelOnTop="0" name="def_height"/>
+    <field labelOnTop="0" name="def_id"/>
+    <field labelOnTop="0" name="def_shape"/>
+    <field labelOnTop="0" name="def_width"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_culvert_view.qml
+++ b/layer_styles/schematisation/v2_culvert_view.qml
@@ -1,83 +1,83 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis version="3.4.5-Madeira" styleCategories="AllStyleCategories" simplifyDrawingTol="1" minScale="1e+08" labelsEnabled="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" readOnly="0" simplifyMaxScale="1" simplifyAlgorithm="0" maxScale="-4.65661e-10">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" forceraster="0" type="singleSymbol" symbollevels="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="101,101,101,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.66"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol alpha="1" name="0" force_rhr="0" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="101,101,101,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.66" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
-          <prop k="interval" v="3"/>
-          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="interval_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="placement" v="centralpoint"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="rotate" v="0"/>
+        <layer class="MarkerLine" enabled="1" locked="0" pass="0">
+          <prop v="3" k="interval"/>
+          <prop v="3x:0,0,0,0,0,0" k="interval_map_unit_scale"/>
+          <prop v="MM" k="interval_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="0" k="offset_along_line"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
+          <prop v="MM" k="offset_along_line_unit"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="centralpoint" k="placement"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="rotate"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
-            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
-              <prop k="angle" v="0"/>
-              <prop k="color" v="101,101,101,255"/>
-              <prop k="horizontal_anchor_point" v="1"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="name" v="circle"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="0,0,0,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="scale_method" v="area"/>
-              <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="size_unit" v="MM"/>
-              <prop k="vertical_anchor_point" v="1"/>
+          <symbol alpha="1" name="@0@1" force_rhr="0" type="marker" clip_to_extent="1">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="101,101,101,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="0,0,0,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="area" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" type="QString" name="name"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option value="collection" type="QString" name="type"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -89,26 +89,26 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property value="ROWID" key="dualview/previewExpressions"/>
-    <property value="0" key="embeddedWidgets/count"/>
+    <property key="dualview/previewExpressions" value="ROWID"/>
+    <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" penAlpha="255" width="15" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" rotationOffset="270" barWidth="5" sizeType="MM" backgroundColor="#ffffff" diagramOrientation="Up" maxScaleDenominator="1e+08" enabled="0" lineSizeType="MM" backgroundAlpha="255" labelPlacementMethod="XHeight" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" opacity="1" height="15" minimumSize="0">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+      <attribute color="#000000" field="" label=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
+  <DiagramLayerSettings placement="2" linePlacementFlags="2" obstacle="0" dist="0" showAll="1" priority="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -128,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -138,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -148,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -158,18 +158,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="100" type="QString" name="100: embedded"/>
+                <Option value="100" name="100: embedded" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="101" type="QString" name="101: isolated"/>
+                <Option value="101" name="101: isolated" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="102" type="QString" name="102: connected"/>
+                <Option value="102" name="102: connected" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="105" type="QString" name="105: double connected"/>
+                <Option value="105" name="105: double connected" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -180,8 +180,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -190,12 +190,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Chèzy"/>
+                <Option value="1" name="1: Chèzy" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Manning"/>
+                <Option value="2" name="2: Manning" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -206,8 +206,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -216,27 +216,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="-1" type="QString" name="-1"/>
+                <Option value="-1" name="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="0" type="QString" name="0"/>
+                <Option value="0" name="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1"/>
+                <Option value="1" name="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2"/>
+                <Option value="2" name="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3"/>
+                <Option value="3" name="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4"/>
+                <Option value="4" name="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5"/>
+                <Option value="5" name="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -247,8 +247,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -257,8 +257,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -267,8 +267,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -277,8 +277,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -287,8 +287,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -297,8 +297,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -307,8 +307,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -317,8 +317,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -327,21 +327,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: rectangle"/>
+                <Option value="1" name="1: rectangle" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: round"/>
+                <Option value="2" name="2: round" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: egg"/>
+                <Option value="3" name="3: egg" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: tabulated rectangle"/>
+                <Option value="5" name="5: tabulated rectangle" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="6" type="QString" name="6: tabulated trapezium"/>
+                <Option value="6" name="6: tabulated trapezium" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -352,8 +352,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -362,8 +362,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -372,135 +372,135 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="ROWID" index="0"/>
-    <alias name="id" field="cul_id" index="1"/>
-    <alias name="display_name" field="cul_display_name" index="2"/>
-    <alias name="code" field="cul_code" index="3"/>
-    <alias name="calculation_type" field="cul_calculation_type" index="4"/>
-    <alias name="friction_value" field="cul_friction_value" index="5"/>
-    <alias name="friction_type" field="cul_friction_type" index="6"/>
-    <alias name="dist_calc_points" field="cul_dist_calc_points" index="7"/>
-    <alias name="zoom_category" field="cul_zoom_category" index="8"/>
-    <alias name="cross_section_definition_id" field="cul_cross_section_definition_id" index="9"/>
-    <alias name="discharge_coefficient_positive" field="cul_discharge_coefficient_positive" index="10"/>
-    <alias name="discharge_coefficient_negative" field="cul_discharge_coefficient_negative" index="11"/>
-    <alias name="invert_level_start_point" field="cul_invert_level_start_point" index="12"/>
-    <alias name="invert_level_end_point" field="cul_invert_level_end_point" index="13"/>
-    <alias name="connection_node_start_id" field="cul_connection_node_start_id" index="14"/>
-    <alias name="connection_node_end_id" field="cul_connection_node_end_id" index="15"/>
-    <alias name="id" field="def_id" index="16"/>
-    <alias name="shape" field="def_shape" index="17"/>
-    <alias name="width" field="def_width" index="18"/>
-    <alias name="height" field="def_height" index="19"/>
-    <alias name="code" field="def_code" index="20"/>
+    <alias field="ROWID" name="" index="0"/>
+    <alias field="cul_id" name="id" index="1"/>
+    <alias field="cul_display_name" name="display_name" index="2"/>
+    <alias field="cul_code" name="code" index="3"/>
+    <alias field="cul_calculation_type" name="calculation_type" index="4"/>
+    <alias field="cul_friction_value" name="friction_value" index="5"/>
+    <alias field="cul_friction_type" name="friction_type" index="6"/>
+    <alias field="cul_dist_calc_points" name="dist_calc_points" index="7"/>
+    <alias field="cul_zoom_category" name="zoom_category" index="8"/>
+    <alias field="cul_cross_section_definition_id" name="cross_section_definition_id" index="9"/>
+    <alias field="cul_discharge_coefficient_positive" name="discharge_coefficient_positive" index="10"/>
+    <alias field="cul_discharge_coefficient_negative" name="discharge_coefficient_negative" index="11"/>
+    <alias field="cul_invert_level_start_point" name="invert_level_start_point" index="12"/>
+    <alias field="cul_invert_level_end_point" name="invert_level_end_point" index="13"/>
+    <alias field="cul_connection_node_start_id" name="connection_node_start_id" index="14"/>
+    <alias field="cul_connection_node_end_id" name="connection_node_end_id" index="15"/>
+    <alias field="def_id" name="id" index="16"/>
+    <alias field="def_shape" name="shape" index="17"/>
+    <alias field="def_width" name="width" index="18"/>
+    <alias field="def_height" name="height" index="19"/>
+    <alias field="def_code" name="code" index="20"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="if(maximum(cul_id) is null,1, maximum(cul_id)+1)" applyOnUpdate="0" field="cul_id"/>
-    <default expression="'new'" applyOnUpdate="0" field="cul_display_name"/>
-    <default expression="'new'" applyOnUpdate="0" field="cul_code"/>
-    <default expression="101" applyOnUpdate="0" field="cul_calculation_type"/>
-    <default expression="0.0145" applyOnUpdate="0" field="cul_friction_value"/>
-    <default expression="2" applyOnUpdate="0" field="cul_friction_type"/>
-    <default expression="10000" applyOnUpdate="0" field="cul_dist_calc_points"/>
-    <default expression="3" applyOnUpdate="0" field="cul_zoom_category"/>
-    <default expression="" applyOnUpdate="0" field="cul_cross_section_definition_id"/>
-    <default expression="0.8" applyOnUpdate="0" field="cul_discharge_coefficient_positive"/>
-    <default expression="0.8" applyOnUpdate="0" field="cul_discharge_coefficient_negative"/>
-    <default expression="" applyOnUpdate="0" field="cul_invert_level_start_point"/>
-    <default expression="" applyOnUpdate="0" field="cul_invert_level_end_point"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="cul_connection_node_start_id"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="cul_connection_node_end_id"/>
-    <default expression="" applyOnUpdate="0" field="def_id"/>
-    <default expression="" applyOnUpdate="0" field="def_shape"/>
-    <default expression="" applyOnUpdate="0" field="def_width"/>
-    <default expression="" applyOnUpdate="0" field="def_height"/>
-    <default expression="" applyOnUpdate="0" field="def_code"/>
+    <default field="ROWID" expression="" applyOnUpdate="0"/>
+    <default field="cul_id" expression="if(maximum(cul_id) is null,1, maximum(cul_id)+1)" applyOnUpdate="0"/>
+    <default field="cul_display_name" expression="'new'" applyOnUpdate="0"/>
+    <default field="cul_code" expression="'new'" applyOnUpdate="0"/>
+    <default field="cul_calculation_type" expression="101" applyOnUpdate="0"/>
+    <default field="cul_friction_value" expression="0.0145" applyOnUpdate="0"/>
+    <default field="cul_friction_type" expression="2" applyOnUpdate="0"/>
+    <default field="cul_dist_calc_points" expression="10000" applyOnUpdate="0"/>
+    <default field="cul_zoom_category" expression="3" applyOnUpdate="0"/>
+    <default field="cul_cross_section_definition_id" expression="" applyOnUpdate="0"/>
+    <default field="cul_discharge_coefficient_positive" expression="0.8" applyOnUpdate="0"/>
+    <default field="cul_discharge_coefficient_negative" expression="0.8" applyOnUpdate="0"/>
+    <default field="cul_invert_level_start_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,start_point(geometry(@parent)))) " applyOnUpdate="0"/>
+    <default field="cul_invert_level_end_point" expression="aggregate('v2_manhole_view','min',&quot;bottom_level&quot;, intersects($geometry,end_point(geometry(@parent)))) " applyOnUpdate="0"/>
+    <default field="cul_connection_node_start_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))" applyOnUpdate="0"/>
+    <default field="cul_connection_node_end_id" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))" applyOnUpdate="0"/>
+    <default field="def_id" expression="" applyOnUpdate="0"/>
+    <default field="def_shape" expression="" applyOnUpdate="0"/>
+    <default field="def_width" expression="" applyOnUpdate="0"/>
+    <default field="def_height" expression="" applyOnUpdate="0"/>
+    <default field="def_code" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_calculation_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_friction_value"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_friction_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_dist_calc_points"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_cross_section_definition_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_discharge_coefficient_positive"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_discharge_coefficient_negative"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_invert_level_start_point"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_invert_level_end_point"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="cul_connection_node_start_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="cul_connection_node_end_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
+    <constraint unique_strength="0" exp_strength="0" field="ROWID" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_id" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_display_name" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_code" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_calculation_type" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_friction_value" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_friction_type" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_dist_calc_points" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_zoom_category" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_cross_section_definition_id" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_discharge_coefficient_positive" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_discharge_coefficient_negative" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_invert_level_start_point" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_invert_level_end_point" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_connection_node_start_id" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="cul_connection_node_end_id" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="def_id" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" exp_strength="0" field="def_shape" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="def_width" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="def_height" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" exp_strength="0" field="def_code" notnull_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="cul_id"/>
-    <constraint exp="" desc="" field="cul_display_name"/>
-    <constraint exp="" desc="" field="cul_code"/>
-    <constraint exp="" desc="" field="cul_calculation_type"/>
-    <constraint exp="" desc="" field="cul_friction_value"/>
-    <constraint exp="" desc="" field="cul_friction_type"/>
-    <constraint exp="" desc="" field="cul_dist_calc_points"/>
-    <constraint exp="" desc="" field="cul_zoom_category"/>
-    <constraint exp="" desc="" field="cul_cross_section_definition_id"/>
-    <constraint exp="" desc="" field="cul_discharge_coefficient_positive"/>
-    <constraint exp="" desc="" field="cul_discharge_coefficient_negative"/>
-    <constraint exp="" desc="" field="cul_invert_level_start_point"/>
-    <constraint exp="" desc="" field="cul_invert_level_end_point"/>
-    <constraint exp="" desc="" field="cul_connection_node_start_id"/>
-    <constraint exp="" desc="" field="cul_connection_node_end_id"/>
-    <constraint exp="" desc="" field="def_id"/>
-    <constraint exp="" desc="" field="def_shape"/>
-    <constraint exp="" desc="" field="def_width"/>
-    <constraint exp="" desc="" field="def_height"/>
-    <constraint exp="" desc="" field="def_code"/>
+    <constraint field="ROWID" desc="" exp=""/>
+    <constraint field="cul_id" desc="" exp=""/>
+    <constraint field="cul_display_name" desc="" exp=""/>
+    <constraint field="cul_code" desc="" exp=""/>
+    <constraint field="cul_calculation_type" desc="" exp=""/>
+    <constraint field="cul_friction_value" desc="" exp=""/>
+    <constraint field="cul_friction_type" desc="" exp=""/>
+    <constraint field="cul_dist_calc_points" desc="" exp=""/>
+    <constraint field="cul_zoom_category" desc="" exp=""/>
+    <constraint field="cul_cross_section_definition_id" desc="" exp=""/>
+    <constraint field="cul_discharge_coefficient_positive" desc="" exp=""/>
+    <constraint field="cul_discharge_coefficient_negative" desc="" exp=""/>
+    <constraint field="cul_invert_level_start_point" desc="" exp=""/>
+    <constraint field="cul_invert_level_end_point" desc="" exp=""/>
+    <constraint field="cul_connection_node_start_id" desc="" exp=""/>
+    <constraint field="cul_connection_node_end_id" desc="" exp=""/>
+    <constraint field="def_id" desc="" exp=""/>
+    <constraint field="def_shape" desc="" exp=""/>
+    <constraint field="def_width" desc="" exp=""/>
+    <constraint field="def_height" desc="" exp=""/>
+    <constraint field="def_code" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
   <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column width="-1" type="field" hidden="0" name="ROWID"/>
-      <column width="-1" type="field" hidden="0" name="cul_id"/>
-      <column width="-1" type="field" hidden="0" name="cul_display_name"/>
-      <column width="-1" type="field" hidden="0" name="cul_code"/>
-      <column width="-1" type="field" hidden="0" name="cul_calculation_type"/>
-      <column width="-1" type="field" hidden="0" name="cul_friction_value"/>
-      <column width="-1" type="field" hidden="0" name="cul_friction_type"/>
-      <column width="-1" type="field" hidden="0" name="cul_dist_calc_points"/>
-      <column width="-1" type="field" hidden="0" name="cul_zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="cul_cross_section_definition_id"/>
-      <column width="-1" type="field" hidden="0" name="cul_discharge_coefficient_positive"/>
-      <column width="-1" type="field" hidden="0" name="cul_discharge_coefficient_negative"/>
-      <column width="-1" type="field" hidden="0" name="cul_invert_level_start_point"/>
-      <column width="-1" type="field" hidden="0" name="cul_invert_level_end_point"/>
-      <column width="-1" type="field" hidden="0" name="cul_connection_node_start_id"/>
-      <column width="-1" type="field" hidden="0" name="cul_connection_node_end_id"/>
-      <column width="-1" type="field" hidden="0" name="def_id"/>
-      <column width="-1" type="field" hidden="0" name="def_shape"/>
-      <column width="-1" type="field" hidden="0" name="def_width"/>
-      <column width="-1" type="field" hidden="0" name="def_height"/>
-      <column width="-1" type="field" hidden="0" name="def_code"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column hidden="0" name="ROWID" type="field" width="-1"/>
+      <column hidden="0" name="cul_id" type="field" width="-1"/>
+      <column hidden="0" name="cul_display_name" type="field" width="-1"/>
+      <column hidden="0" name="cul_code" type="field" width="-1"/>
+      <column hidden="0" name="cul_calculation_type" type="field" width="-1"/>
+      <column hidden="0" name="cul_friction_value" type="field" width="-1"/>
+      <column hidden="0" name="cul_friction_type" type="field" width="-1"/>
+      <column hidden="0" name="cul_dist_calc_points" type="field" width="-1"/>
+      <column hidden="0" name="cul_zoom_category" type="field" width="-1"/>
+      <column hidden="0" name="cul_cross_section_definition_id" type="field" width="-1"/>
+      <column hidden="0" name="cul_discharge_coefficient_positive" type="field" width="-1"/>
+      <column hidden="0" name="cul_discharge_coefficient_negative" type="field" width="-1"/>
+      <column hidden="0" name="cul_invert_level_start_point" type="field" width="-1"/>
+      <column hidden="0" name="cul_invert_level_end_point" type="field" width="-1"/>
+      <column hidden="0" name="cul_connection_node_start_id" type="field" width="-1"/>
+      <column hidden="0" name="cul_connection_node_end_id" type="field" width="-1"/>
+      <column hidden="0" name="def_id" type="field" width="-1"/>
+      <column hidden="0" name="def_shape" type="field" width="-1"/>
+      <column hidden="0" name="def_width" type="field" width="-1"/>
+      <column hidden="0" name="def_height" type="field" width="-1"/>
+      <column hidden="0" name="def_code" type="field" width="-1"/>
+      <column hidden="1" type="actions" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -531,15 +531,15 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Culvert view" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+    <attributeEditorContainer showLabel="1" name="Culvert view" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0" columnCount="1">
+      <attributeEditorContainer showLabel="1" name="General" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
         <attributeEditorField showLabel="1" name="cul_id" index="1"/>
         <attributeEditorField showLabel="1" name="cul_display_name" index="2"/>
         <attributeEditorField showLabel="1" name="cul_code" index="3"/>
         <attributeEditorField showLabel="1" name="cul_calculation_type" index="4"/>
         <attributeEditorField showLabel="1" name="cul_dist_calc_points" index="7"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
         <attributeEditorField showLabel="1" name="cul_invert_level_start_point" index="12"/>
         <attributeEditorField showLabel="1" name="cul_invert_level_end_point" index="13"/>
         <attributeEditorField showLabel="1" name="cul_friction_type" index="6"/>
@@ -547,17 +547,17 @@ def my_form_open(dialog, layer, feature):
         <attributeEditorField showLabel="1" name="cul_discharge_coefficient_positive" index="10"/>
         <attributeEditorField showLabel="1" name="cul_discharge_coefficient_negative" index="11"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section definition" columnCount="1">
+      <attributeEditorContainer showLabel="1" name="Cross section definition" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
         <attributeEditorField showLabel="1" name="cul_cross_section_definition_id" index="9"/>
         <attributeEditorField showLabel="1" name="def_code" index="20"/>
         <attributeEditorField showLabel="1" name="def_shape" index="17"/>
         <attributeEditorField showLabel="1" name="def_width" index="18"/>
         <attributeEditorField showLabel="1" name="def_height" index="19"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
         <attributeEditorField showLabel="1" name="cul_zoom_category" index="8"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+      <attributeEditorContainer showLabel="1" name="Connection nodes" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0" columnCount="1">
         <attributeEditorField showLabel="1" name="cul_connection_node_start_id" index="14"/>
         <attributeEditorField showLabel="1" name="cul_connection_node_end_id" index="15"/>
       </attributeEditorContainer>
@@ -587,27 +587,27 @@ def my_form_open(dialog, layer, feature):
     <field name="def_width" editable="0"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ROWID"/>
-    <field labelOnTop="0" name="cul_calculation_type"/>
-    <field labelOnTop="0" name="cul_code"/>
-    <field labelOnTop="0" name="cul_connection_node_end_id"/>
-    <field labelOnTop="0" name="cul_connection_node_start_id"/>
-    <field labelOnTop="0" name="cul_cross_section_definition_id"/>
-    <field labelOnTop="0" name="cul_discharge_coefficient_negative"/>
-    <field labelOnTop="0" name="cul_discharge_coefficient_positive"/>
-    <field labelOnTop="0" name="cul_display_name"/>
-    <field labelOnTop="0" name="cul_dist_calc_points"/>
-    <field labelOnTop="0" name="cul_friction_type"/>
-    <field labelOnTop="0" name="cul_friction_value"/>
-    <field labelOnTop="0" name="cul_id"/>
-    <field labelOnTop="0" name="cul_invert_level_end_point"/>
-    <field labelOnTop="0" name="cul_invert_level_start_point"/>
-    <field labelOnTop="0" name="cul_zoom_category"/>
-    <field labelOnTop="0" name="def_code"/>
-    <field labelOnTop="0" name="def_height"/>
-    <field labelOnTop="0" name="def_id"/>
-    <field labelOnTop="0" name="def_shape"/>
-    <field labelOnTop="0" name="def_width"/>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="cul_calculation_type" labelOnTop="0"/>
+    <field name="cul_code" labelOnTop="0"/>
+    <field name="cul_connection_node_end_id" labelOnTop="0"/>
+    <field name="cul_connection_node_start_id" labelOnTop="0"/>
+    <field name="cul_cross_section_definition_id" labelOnTop="0"/>
+    <field name="cul_discharge_coefficient_negative" labelOnTop="0"/>
+    <field name="cul_discharge_coefficient_positive" labelOnTop="0"/>
+    <field name="cul_display_name" labelOnTop="0"/>
+    <field name="cul_dist_calc_points" labelOnTop="0"/>
+    <field name="cul_friction_type" labelOnTop="0"/>
+    <field name="cul_friction_value" labelOnTop="0"/>
+    <field name="cul_id" labelOnTop="0"/>
+    <field name="cul_invert_level_end_point" labelOnTop="0"/>
+    <field name="cul_invert_level_start_point" labelOnTop="0"/>
+    <field name="cul_zoom_category" labelOnTop="0"/>
+    <field name="def_code" labelOnTop="0"/>
+    <field name="def_height" labelOnTop="0"/>
+    <field name="def_id" labelOnTop="0"/>
+    <field name="def_shape" labelOnTop="0"/>
+    <field name="def_width" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_culvert_view.qml
+++ b/layer_styles/schematisation/v2_culvert_view.qml
@@ -1,74 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.4-Essen" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="ROWID">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_calculation_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_friction_value">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_friction_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_dist_calc_points">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_cross_section_definition_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_discharge_coefficient_positive">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_discharge_coefficient_negative">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_invert_level_start_point">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_invert_level_end_point">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_connection_node_start_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="cul_connection_node_end_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_shape">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_width">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_height">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -77,250 +20,494 @@
           <prop k="line_width" v="0.66"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="MarkerLine" locked="0">
+        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
           <prop k="interval" v="3"/>
-          <prop k="interval_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="placement" v="centralpoint"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="rotate" v="0"/>
-          <symbol alpha="1" clip_to_extent="1" type="marker" name="@0@1">
-            <layer pass="0" class="SimpleMarker" locked="0">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
+            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
               <prop k="angle" v="0"/>
               <prop k="color" v="101,101,101,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
               <prop k="name" v="circle"/>
               <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="outline_color" v="0,0,0,255"/>
               <prop k="outline_style" v="solid"/>
               <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="outline_width_unit" v="MM"/>
               <prop k="scale_method" v="area"/>
               <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="size_unit" v="MM"/>
               <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property value="ROWID" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="-4.65661e-10">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_calculation_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="100: embedded" value="100" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="101: isolated" value="101" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="102: connected" value="102" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="105: double connected" value="105" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_friction_value">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_friction_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: Chezy" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: Manning" value="2" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_dist_calc_points">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_cross_section_definition_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_discharge_coefficient_positive">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_discharge_coefficient_negative">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_invert_level_start_point">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_invert_level_end_point">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cul_connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: rectangle" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: round" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: egg" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: tabulated rectangle" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: tabulated trapezium" value="6" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_height">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="ROWID"/>
+    <alias name="id" index="1" field="cul_id"/>
+    <alias name="display_name" index="2" field="cul_display_name"/>
+    <alias name="code" index="3" field="cul_code"/>
+    <alias name="calculation_type" index="4" field="cul_calculation_type"/>
+    <alias name="friction_value" index="5" field="cul_friction_value"/>
+    <alias name="friction_type" index="6" field="cul_friction_type"/>
+    <alias name="dist_calc_points" index="7" field="cul_dist_calc_points"/>
+    <alias name="zoom_category" index="8" field="cul_zoom_category"/>
+    <alias name="cross_section_definition_id" index="9" field="cul_cross_section_definition_id"/>
+    <alias name="discharge_coefficient_positive" index="10" field="cul_discharge_coefficient_positive"/>
+    <alias name="discharge_coefficient_negative" index="11" field="cul_discharge_coefficient_negative"/>
+    <alias name="invert_level_start_point" index="12" field="cul_invert_level_start_point"/>
+    <alias name="invert_level_end_point" index="13" field="cul_invert_level_end_point"/>
+    <alias name="connection_node_start_id" index="14" field="cul_connection_node_start_id"/>
+    <alias name="connection_node_end_id" index="15" field="cul_connection_node_end_id"/>
+    <alias name="id" index="16" field="def_id"/>
+    <alias name="shape" index="17" field="def_shape"/>
+    <alias name="width" index="18" field="def_width"/>
+    <alias name="height" index="19" field="def_height"/>
+    <alias name="code" index="20" field="def_code"/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform>.</editform>
+  <defaults>
+    <default applyOnUpdate="0" field="ROWID" expression=""/>
+    <default applyOnUpdate="0" field="cul_id" expression="if(maximum(cul_id) is null,1, maximum(cul_id)+1)"/>
+    <default applyOnUpdate="0" field="cul_display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="cul_code" expression="'new'"/>
+    <default applyOnUpdate="0" field="cul_calculation_type" expression="101"/>
+    <default applyOnUpdate="0" field="cul_friction_value" expression="0.0145"/>
+    <default applyOnUpdate="0" field="cul_friction_type" expression="2"/>
+    <default applyOnUpdate="0" field="cul_dist_calc_points" expression="10000"/>
+    <default applyOnUpdate="0" field="cul_zoom_category" expression="3"/>
+    <default applyOnUpdate="0" field="cul_cross_section_definition_id" expression=""/>
+    <default applyOnUpdate="0" field="cul_discharge_coefficient_positive" expression="0.8"/>
+    <default applyOnUpdate="0" field="cul_discharge_coefficient_negative" expression="0.8"/>
+    <default applyOnUpdate="0" field="cul_invert_level_start_point" expression=""/>
+    <default applyOnUpdate="0" field="cul_invert_level_end_point" expression=""/>
+    <default applyOnUpdate="0" field="cul_connection_node_start_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="cul_connection_node_end_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="def_id" expression=""/>
+    <default applyOnUpdate="0" field="def_shape" expression=""/>
+    <default applyOnUpdate="0" field="def_width" expression=""/>
+    <default applyOnUpdate="0" field="def_height" expression=""/>
+    <default applyOnUpdate="0" field="def_code" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_calculation_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_friction_value" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_friction_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_dist_calc_points" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_cross_section_definition_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_discharge_coefficient_positive" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_discharge_coefficient_negative" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_invert_level_start_point" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_invert_level_end_point" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="cul_connection_node_start_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="cul_connection_node_end_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="cul_id" desc=""/>
+    <constraint exp="" field="cul_display_name" desc=""/>
+    <constraint exp="" field="cul_code" desc=""/>
+    <constraint exp="" field="cul_calculation_type" desc=""/>
+    <constraint exp="" field="cul_friction_value" desc=""/>
+    <constraint exp="" field="cul_friction_type" desc=""/>
+    <constraint exp="" field="cul_dist_calc_points" desc=""/>
+    <constraint exp="" field="cul_zoom_category" desc=""/>
+    <constraint exp="" field="cul_cross_section_definition_id" desc=""/>
+    <constraint exp="" field="cul_discharge_coefficient_positive" desc=""/>
+    <constraint exp="" field="cul_discharge_coefficient_negative" desc=""/>
+    <constraint exp="" field="cul_invert_level_start_point" desc=""/>
+    <constraint exp="" field="cul_invert_level_end_point" desc=""/>
+    <constraint exp="" field="cul_connection_node_start_id" desc=""/>
+    <constraint exp="" field="cul_connection_node_end_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+    <columns>
+      <column name="ROWID" hidden="0" width="-1" type="field"/>
+      <column name="cul_id" hidden="0" width="-1" type="field"/>
+      <column name="cul_display_name" hidden="0" width="-1" type="field"/>
+      <column name="cul_code" hidden="0" width="-1" type="field"/>
+      <column name="cul_calculation_type" hidden="0" width="-1" type="field"/>
+      <column name="cul_friction_value" hidden="0" width="-1" type="field"/>
+      <column name="cul_friction_type" hidden="0" width="-1" type="field"/>
+      <column name="cul_dist_calc_points" hidden="0" width="-1" type="field"/>
+      <column name="cul_zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="cul_cross_section_definition_id" hidden="0" width="-1" type="field"/>
+      <column name="cul_discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
+      <column name="cul_discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
+      <column name="cul_invert_level_start_point" hidden="0" width="-1" type="field"/>
+      <column name="cul_invert_level_end_point" hidden="0" width="-1" type="field"/>
+      <column name="cul_connection_node_start_id" hidden="0" width="-1" type="field"/>
+      <column name="cul_connection_node_end_id" hidden="0" width="-1" type="field"/>
+      <column name="def_id" hidden="0" width="-1" type="field"/>
+      <column name="def_shape" hidden="0" width="-1" type="field"/>
+      <column name="def_width" hidden="0" width="-1" type="field"/>
+      <column name="def_height" hidden="0" width="-1" type="field"/>
+      <column name="def_code" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -342,11 +529,88 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Culvert view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="cul_id" index="1" showLabel="1"/>
+        <attributeEditorField name="cul_display_name" index="2" showLabel="1"/>
+        <attributeEditorField name="cul_code" index="3" showLabel="1"/>
+        <attributeEditorField name="cul_calculation_type" index="4" showLabel="1"/>
+        <attributeEditorField name="cul_dist_calc_points" index="7" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="cul_invert_level_start_point" index="12" showLabel="1"/>
+        <attributeEditorField name="cul_invert_level_end_point" index="13" showLabel="1"/>
+        <attributeEditorField name="cul_friction_type" index="6" showLabel="1"/>
+        <attributeEditorField name="cul_friction_value" index="5" showLabel="1"/>
+        <attributeEditorField name="cul_discharge_coefficient_positive" index="10" showLabel="1"/>
+        <attributeEditorField name="cul_discharge_coefficient_negative" index="11" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Cross section definition" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="cul_cross_section_definition_id" index="9" showLabel="1"/>
+        <attributeEditorField name="def_code" index="20" showLabel="1"/>
+        <attributeEditorField name="def_shape" index="17" showLabel="1"/>
+        <attributeEditorField name="def_width" index="18" showLabel="1"/>
+        <attributeEditorField name="def_height" index="19" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="cul_zoom_category" index="8" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="cul_connection_node_start_id" index="14" showLabel="1"/>
+        <attributeEditorField name="cul_connection_node_end_id" index="15" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="ROWID" editable="1"/>
+    <field name="cul_calculation_type" editable="1"/>
+    <field name="cul_code" editable="1"/>
+    <field name="cul_connection_node_end_id" editable="0"/>
+    <field name="cul_connection_node_start_id" editable="0"/>
+    <field name="cul_cross_section_definition_id" editable="1"/>
+    <field name="cul_discharge_coefficient_negative" editable="1"/>
+    <field name="cul_discharge_coefficient_positive" editable="1"/>
+    <field name="cul_display_name" editable="1"/>
+    <field name="cul_dist_calc_points" editable="1"/>
+    <field name="cul_friction_type" editable="1"/>
+    <field name="cul_friction_value" editable="1"/>
+    <field name="cul_id" editable="1"/>
+    <field name="cul_invert_level_end_point" editable="1"/>
+    <field name="cul_invert_level_start_point" editable="1"/>
+    <field name="cul_zoom_category" editable="1"/>
+    <field name="def_code" editable="0"/>
+    <field name="def_height" editable="0"/>
+    <field name="def_id" editable="0"/>
+    <field name="def_shape" editable="0"/>
+    <field name="def_width" editable="0"/>
+  </editable>
+  <labelOnTop>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="cul_calculation_type" labelOnTop="0"/>
+    <field name="cul_code" labelOnTop="0"/>
+    <field name="cul_connection_node_end_id" labelOnTop="0"/>
+    <field name="cul_connection_node_start_id" labelOnTop="0"/>
+    <field name="cul_cross_section_definition_id" labelOnTop="0"/>
+    <field name="cul_discharge_coefficient_negative" labelOnTop="0"/>
+    <field name="cul_discharge_coefficient_positive" labelOnTop="0"/>
+    <field name="cul_display_name" labelOnTop="0"/>
+    <field name="cul_dist_calc_points" labelOnTop="0"/>
+    <field name="cul_friction_type" labelOnTop="0"/>
+    <field name="cul_friction_value" labelOnTop="0"/>
+    <field name="cul_id" labelOnTop="0"/>
+    <field name="cul_invert_level_end_point" labelOnTop="0"/>
+    <field name="cul_invert_level_start_point" labelOnTop="0"/>
+    <field name="cul_zoom_category" labelOnTop="0"/>
+    <field name="def_code" labelOnTop="0"/>
+    <field name="def_height" labelOnTop="0"/>
+    <field name="def_id" labelOnTop="0"/>
+    <field name="def_shape" labelOnTop="0"/>
+    <field name="def_width" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>ROWID</previewExpression>
+  <mapTip>display_name</mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_culvert_view.qml
+++ b/layer_styles/schematisation/v2_culvert_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
+        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
+            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
               <prop k="angle" v="0"/>
               <prop k="color" v="101,101,101,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -97,18 +97,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -128,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -138,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -148,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -158,18 +158,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="100: embedded" value="100" type="QString"/>
+                <Option value="100" type="QString" name="100: embedded"/>
               </Option>
               <Option type="Map">
-                <Option name="101: isolated" value="101" type="QString"/>
+                <Option value="101" type="QString" name="101: isolated"/>
               </Option>
               <Option type="Map">
-                <Option name="102: connected" value="102" type="QString"/>
+                <Option value="102" type="QString" name="102: connected"/>
               </Option>
               <Option type="Map">
-                <Option name="105: double connected" value="105" type="QString"/>
+                <Option value="105" type="QString" name="105: double connected"/>
               </Option>
             </Option>
           </Option>
@@ -180,8 +180,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -190,12 +190,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -206,8 +206,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -216,27 +216,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -247,8 +247,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -257,8 +257,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -267,8 +267,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -277,8 +277,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -287,8 +287,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -297,8 +297,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -307,8 +307,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -317,8 +317,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -327,21 +327,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: rectangle" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="2: round" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: round"/>
               </Option>
               <Option type="Map">
-                <Option name="3: egg" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: egg"/>
               </Option>
               <Option type="Map">
-                <Option name="5: tabulated rectangle" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: tabulated rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="6: tabulated trapezium" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: tabulated trapezium"/>
               </Option>
             </Option>
           </Option>
@@ -352,8 +352,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -362,8 +362,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -372,135 +372,135 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="ROWID"/>
-    <alias name="id" index="1" field="cul_id"/>
-    <alias name="display_name" index="2" field="cul_display_name"/>
-    <alias name="code" index="3" field="cul_code"/>
-    <alias name="calculation_type" index="4" field="cul_calculation_type"/>
-    <alias name="friction_value" index="5" field="cul_friction_value"/>
-    <alias name="friction_type" index="6" field="cul_friction_type"/>
-    <alias name="dist_calc_points" index="7" field="cul_dist_calc_points"/>
-    <alias name="zoom_category" index="8" field="cul_zoom_category"/>
-    <alias name="cross_section_definition_id" index="9" field="cul_cross_section_definition_id"/>
-    <alias name="discharge_coefficient_positive" index="10" field="cul_discharge_coefficient_positive"/>
-    <alias name="discharge_coefficient_negative" index="11" field="cul_discharge_coefficient_negative"/>
-    <alias name="invert_level_start_point" index="12" field="cul_invert_level_start_point"/>
-    <alias name="invert_level_end_point" index="13" field="cul_invert_level_end_point"/>
-    <alias name="connection_node_start_id" index="14" field="cul_connection_node_start_id"/>
-    <alias name="connection_node_end_id" index="15" field="cul_connection_node_end_id"/>
-    <alias name="id" index="16" field="def_id"/>
-    <alias name="shape" index="17" field="def_shape"/>
-    <alias name="width" index="18" field="def_width"/>
-    <alias name="height" index="19" field="def_height"/>
-    <alias name="code" index="20" field="def_code"/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="id" field="cul_id" index="1"/>
+    <alias name="display_name" field="cul_display_name" index="2"/>
+    <alias name="code" field="cul_code" index="3"/>
+    <alias name="calculation_type" field="cul_calculation_type" index="4"/>
+    <alias name="friction_value" field="cul_friction_value" index="5"/>
+    <alias name="friction_type" field="cul_friction_type" index="6"/>
+    <alias name="dist_calc_points" field="cul_dist_calc_points" index="7"/>
+    <alias name="zoom_category" field="cul_zoom_category" index="8"/>
+    <alias name="cross_section_definition_id" field="cul_cross_section_definition_id" index="9"/>
+    <alias name="discharge_coefficient_positive" field="cul_discharge_coefficient_positive" index="10"/>
+    <alias name="discharge_coefficient_negative" field="cul_discharge_coefficient_negative" index="11"/>
+    <alias name="invert_level_start_point" field="cul_invert_level_start_point" index="12"/>
+    <alias name="invert_level_end_point" field="cul_invert_level_end_point" index="13"/>
+    <alias name="connection_node_start_id" field="cul_connection_node_start_id" index="14"/>
+    <alias name="connection_node_end_id" field="cul_connection_node_end_id" index="15"/>
+    <alias name="id" field="def_id" index="16"/>
+    <alias name="shape" field="def_shape" index="17"/>
+    <alias name="width" field="def_width" index="18"/>
+    <alias name="height" field="def_height" index="19"/>
+    <alias name="code" field="def_code" index="20"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="ROWID" expression=""/>
-    <default applyOnUpdate="0" field="cul_id" expression="if(maximum(cul_id) is null,1, maximum(cul_id)+1)"/>
-    <default applyOnUpdate="0" field="cul_display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="cul_code" expression="'new'"/>
-    <default applyOnUpdate="0" field="cul_calculation_type" expression="101"/>
-    <default applyOnUpdate="0" field="cul_friction_value" expression="0.0145"/>
-    <default applyOnUpdate="0" field="cul_friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="cul_dist_calc_points" expression="10000"/>
-    <default applyOnUpdate="0" field="cul_zoom_category" expression="3"/>
-    <default applyOnUpdate="0" field="cul_cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="cul_discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="cul_discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="cul_invert_level_start_point" expression=""/>
-    <default applyOnUpdate="0" field="cul_invert_level_end_point" expression=""/>
-    <default applyOnUpdate="0" field="cul_connection_node_start_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="cul_connection_node_end_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="def_id" expression=""/>
-    <default applyOnUpdate="0" field="def_shape" expression=""/>
-    <default applyOnUpdate="0" field="def_width" expression=""/>
-    <default applyOnUpdate="0" field="def_height" expression=""/>
-    <default applyOnUpdate="0" field="def_code" expression=""/>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="if(maximum(cul_id) is null,1, maximum(cul_id)+1)" applyOnUpdate="0" field="cul_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="cul_display_name"/>
+    <default expression="'new'" applyOnUpdate="0" field="cul_code"/>
+    <default expression="101" applyOnUpdate="0" field="cul_calculation_type"/>
+    <default expression="0.0145" applyOnUpdate="0" field="cul_friction_value"/>
+    <default expression="2" applyOnUpdate="0" field="cul_friction_type"/>
+    <default expression="10000" applyOnUpdate="0" field="cul_dist_calc_points"/>
+    <default expression="3" applyOnUpdate="0" field="cul_zoom_category"/>
+    <default expression="" applyOnUpdate="0" field="cul_cross_section_definition_id"/>
+    <default expression="0.8" applyOnUpdate="0" field="cul_discharge_coefficient_positive"/>
+    <default expression="0.8" applyOnUpdate="0" field="cul_discharge_coefficient_negative"/>
+    <default expression="" applyOnUpdate="0" field="cul_invert_level_start_point"/>
+    <default expression="" applyOnUpdate="0" field="cul_invert_level_end_point"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="cul_connection_node_start_id"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="cul_connection_node_end_id"/>
+    <default expression="" applyOnUpdate="0" field="def_id"/>
+    <default expression="" applyOnUpdate="0" field="def_shape"/>
+    <default expression="" applyOnUpdate="0" field="def_width"/>
+    <default expression="" applyOnUpdate="0" field="def_height"/>
+    <default expression="" applyOnUpdate="0" field="def_code"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_calculation_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_friction_value" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_friction_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_dist_calc_points" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_invert_level_start_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cul_invert_level_end_point" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="cul_connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="cul_connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_calculation_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_friction_value"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_dist_calc_points"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_cross_section_definition_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_discharge_coefficient_positive"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_discharge_coefficient_negative"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_invert_level_start_point"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cul_invert_level_end_point"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="cul_connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="cul_connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="ROWID" desc=""/>
-    <constraint exp="" field="cul_id" desc=""/>
-    <constraint exp="" field="cul_display_name" desc=""/>
-    <constraint exp="" field="cul_code" desc=""/>
-    <constraint exp="" field="cul_calculation_type" desc=""/>
-    <constraint exp="" field="cul_friction_value" desc=""/>
-    <constraint exp="" field="cul_friction_type" desc=""/>
-    <constraint exp="" field="cul_dist_calc_points" desc=""/>
-    <constraint exp="" field="cul_zoom_category" desc=""/>
-    <constraint exp="" field="cul_cross_section_definition_id" desc=""/>
-    <constraint exp="" field="cul_discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="cul_discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="cul_invert_level_start_point" desc=""/>
-    <constraint exp="" field="cul_invert_level_end_point" desc=""/>
-    <constraint exp="" field="cul_connection_node_start_id" desc=""/>
-    <constraint exp="" field="cul_connection_node_end_id" desc=""/>
-    <constraint exp="" field="def_id" desc=""/>
-    <constraint exp="" field="def_shape" desc=""/>
-    <constraint exp="" field="def_width" desc=""/>
-    <constraint exp="" field="def_height" desc=""/>
-    <constraint exp="" field="def_code" desc=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="cul_id"/>
+    <constraint exp="" desc="" field="cul_display_name"/>
+    <constraint exp="" desc="" field="cul_code"/>
+    <constraint exp="" desc="" field="cul_calculation_type"/>
+    <constraint exp="" desc="" field="cul_friction_value"/>
+    <constraint exp="" desc="" field="cul_friction_type"/>
+    <constraint exp="" desc="" field="cul_dist_calc_points"/>
+    <constraint exp="" desc="" field="cul_zoom_category"/>
+    <constraint exp="" desc="" field="cul_cross_section_definition_id"/>
+    <constraint exp="" desc="" field="cul_discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="cul_discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="cul_invert_level_start_point"/>
+    <constraint exp="" desc="" field="cul_invert_level_end_point"/>
+    <constraint exp="" desc="" field="cul_connection_node_start_id"/>
+    <constraint exp="" desc="" field="cul_connection_node_end_id"/>
+    <constraint exp="" desc="" field="def_id"/>
+    <constraint exp="" desc="" field="def_shape"/>
+    <constraint exp="" desc="" field="def_width"/>
+    <constraint exp="" desc="" field="def_height"/>
+    <constraint exp="" desc="" field="def_code"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="ROWID" hidden="0" width="-1" type="field"/>
-      <column name="cul_id" hidden="0" width="-1" type="field"/>
-      <column name="cul_display_name" hidden="0" width="-1" type="field"/>
-      <column name="cul_code" hidden="0" width="-1" type="field"/>
-      <column name="cul_calculation_type" hidden="0" width="-1" type="field"/>
-      <column name="cul_friction_value" hidden="0" width="-1" type="field"/>
-      <column name="cul_friction_type" hidden="0" width="-1" type="field"/>
-      <column name="cul_dist_calc_points" hidden="0" width="-1" type="field"/>
-      <column name="cul_zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="cul_cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="cul_discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="cul_discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="cul_invert_level_start_point" hidden="0" width="-1" type="field"/>
-      <column name="cul_invert_level_end_point" hidden="0" width="-1" type="field"/>
-      <column name="cul_connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="cul_connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="def_id" hidden="0" width="-1" type="field"/>
-      <column name="def_shape" hidden="0" width="-1" type="field"/>
-      <column name="def_width" hidden="0" width="-1" type="field"/>
-      <column name="def_height" hidden="0" width="-1" type="field"/>
-      <column name="def_code" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="cul_id"/>
+      <column width="-1" type="field" hidden="0" name="cul_display_name"/>
+      <column width="-1" type="field" hidden="0" name="cul_code"/>
+      <column width="-1" type="field" hidden="0" name="cul_calculation_type"/>
+      <column width="-1" type="field" hidden="0" name="cul_friction_value"/>
+      <column width="-1" type="field" hidden="0" name="cul_friction_type"/>
+      <column width="-1" type="field" hidden="0" name="cul_dist_calc_points"/>
+      <column width="-1" type="field" hidden="0" name="cul_zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="cul_cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="cul_discharge_coefficient_positive"/>
+      <column width="-1" type="field" hidden="0" name="cul_discharge_coefficient_negative"/>
+      <column width="-1" type="field" hidden="0" name="cul_invert_level_start_point"/>
+      <column width="-1" type="field" hidden="0" name="cul_invert_level_end_point"/>
+      <column width="-1" type="field" hidden="0" name="cul_connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="cul_connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="def_id"/>
+      <column width="-1" type="field" hidden="0" name="def_shape"/>
+      <column width="-1" type="field" hidden="0" name="def_width"/>
+      <column width="-1" type="field" hidden="0" name="def_height"/>
+      <column width="-1" type="field" hidden="0" name="def_code"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -531,35 +531,35 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Culvert view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="cul_id" index="1" showLabel="1"/>
-        <attributeEditorField name="cul_display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="cul_code" index="3" showLabel="1"/>
-        <attributeEditorField name="cul_calculation_type" index="4" showLabel="1"/>
-        <attributeEditorField name="cul_dist_calc_points" index="7" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Culvert view" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="cul_id" index="1"/>
+        <attributeEditorField showLabel="1" name="cul_display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="cul_code" index="3"/>
+        <attributeEditorField showLabel="1" name="cul_calculation_type" index="4"/>
+        <attributeEditorField showLabel="1" name="cul_dist_calc_points" index="7"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="cul_invert_level_start_point" index="12" showLabel="1"/>
-        <attributeEditorField name="cul_invert_level_end_point" index="13" showLabel="1"/>
-        <attributeEditorField name="cul_friction_type" index="6" showLabel="1"/>
-        <attributeEditorField name="cul_friction_value" index="5" showLabel="1"/>
-        <attributeEditorField name="cul_discharge_coefficient_positive" index="10" showLabel="1"/>
-        <attributeEditorField name="cul_discharge_coefficient_negative" index="11" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="cul_invert_level_start_point" index="12"/>
+        <attributeEditorField showLabel="1" name="cul_invert_level_end_point" index="13"/>
+        <attributeEditorField showLabel="1" name="cul_friction_type" index="6"/>
+        <attributeEditorField showLabel="1" name="cul_friction_value" index="5"/>
+        <attributeEditorField showLabel="1" name="cul_discharge_coefficient_positive" index="10"/>
+        <attributeEditorField showLabel="1" name="cul_discharge_coefficient_negative" index="11"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Cross section definition" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="cul_cross_section_definition_id" index="9" showLabel="1"/>
-        <attributeEditorField name="def_code" index="20" showLabel="1"/>
-        <attributeEditorField name="def_shape" index="17" showLabel="1"/>
-        <attributeEditorField name="def_width" index="18" showLabel="1"/>
-        <attributeEditorField name="def_height" index="19" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section definition" columnCount="1">
+        <attributeEditorField showLabel="1" name="cul_cross_section_definition_id" index="9"/>
+        <attributeEditorField showLabel="1" name="def_code" index="20"/>
+        <attributeEditorField showLabel="1" name="def_shape" index="17"/>
+        <attributeEditorField showLabel="1" name="def_width" index="18"/>
+        <attributeEditorField showLabel="1" name="def_height" index="19"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="cul_zoom_category" index="8" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="cul_zoom_category" index="8"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="cul_connection_node_start_id" index="14" showLabel="1"/>
-        <attributeEditorField name="cul_connection_node_end_id" index="15" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="cul_connection_node_start_id" index="14"/>
+        <attributeEditorField showLabel="1" name="cul_connection_node_end_id" index="15"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -587,27 +587,27 @@ def my_form_open(dialog, layer, feature):
     <field name="def_width" editable="0"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="cul_calculation_type" labelOnTop="0"/>
-    <field name="cul_code" labelOnTop="0"/>
-    <field name="cul_connection_node_end_id" labelOnTop="0"/>
-    <field name="cul_connection_node_start_id" labelOnTop="0"/>
-    <field name="cul_cross_section_definition_id" labelOnTop="0"/>
-    <field name="cul_discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="cul_discharge_coefficient_positive" labelOnTop="0"/>
-    <field name="cul_display_name" labelOnTop="0"/>
-    <field name="cul_dist_calc_points" labelOnTop="0"/>
-    <field name="cul_friction_type" labelOnTop="0"/>
-    <field name="cul_friction_value" labelOnTop="0"/>
-    <field name="cul_id" labelOnTop="0"/>
-    <field name="cul_invert_level_end_point" labelOnTop="0"/>
-    <field name="cul_invert_level_start_point" labelOnTop="0"/>
-    <field name="cul_zoom_category" labelOnTop="0"/>
-    <field name="def_code" labelOnTop="0"/>
-    <field name="def_height" labelOnTop="0"/>
-    <field name="def_id" labelOnTop="0"/>
-    <field name="def_shape" labelOnTop="0"/>
-    <field name="def_width" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="cul_calculation_type"/>
+    <field labelOnTop="0" name="cul_code"/>
+    <field labelOnTop="0" name="cul_connection_node_end_id"/>
+    <field labelOnTop="0" name="cul_connection_node_start_id"/>
+    <field labelOnTop="0" name="cul_cross_section_definition_id"/>
+    <field labelOnTop="0" name="cul_discharge_coefficient_negative"/>
+    <field labelOnTop="0" name="cul_discharge_coefficient_positive"/>
+    <field labelOnTop="0" name="cul_display_name"/>
+    <field labelOnTop="0" name="cul_dist_calc_points"/>
+    <field labelOnTop="0" name="cul_friction_type"/>
+    <field labelOnTop="0" name="cul_friction_value"/>
+    <field labelOnTop="0" name="cul_id"/>
+    <field labelOnTop="0" name="cul_invert_level_end_point"/>
+    <field labelOnTop="0" name="cul_invert_level_start_point"/>
+    <field labelOnTop="0" name="cul_zoom_category"/>
+    <field labelOnTop="0" name="def_code"/>
+    <field labelOnTop="0" name="def_height"/>
+    <field labelOnTop="0" name="def_id"/>
+    <field labelOnTop="0" name="def_shape"/>
+    <field labelOnTop="0" name="def_width"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_global_settings.qml
+++ b/layer_styles/schematisation/v2_global_settings.qml
@@ -1,0 +1,1022 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis maxScale="0" version="3.4.5-Madeira" readOnly="0" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property value="id" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="maximum_sim_time_step">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="nr_timesteps">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dem_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="minimum_sim_time_step">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="table_step_size_volume_2d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="frict_coef_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_groundwater_level_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_waterlevel">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="epsg_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="numerical_settings_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dem_obstacle_detection">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="frict_avg">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_groundwater_level_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="max"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="min"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="water_level_ini_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="max"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="min"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="grid_space">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="advection_2d">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="embedded_cutoff_threshold">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dist_calc_points">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="start_date">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_interception_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="output_time_step">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="interflow_settings_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="table_step_size">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_1d_flow">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="start_time">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd HH:mm:ss" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd HH:mm:ss" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_2d_rain">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_groundwater_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="kmax">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_waterlevel_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="sim_time_step">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="frict_coef">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="guess_dams">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="control_group_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dem_obstacle_height">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="timestep_plus">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="flooding_threshold">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="frict_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: Chèzy"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="2: Manning"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_2d_flow">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_interception">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_angle_1d_advection">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="advection_1d">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option type="QString" value="1" name="CheckedState"/>
+            <Option type="QString" value="0" name="UncheckedState"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="wind_shielding_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="simple_infiltration_settings_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="groundwater_settings_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manhole_storage_area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_0d_inflow">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="0: do not use 0d inflow"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: use v2_impervious_surface"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="2: use v2_surface"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="table_step_size_1d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="maximum_sim_time_step" index="0" name=""/>
+    <alias field="nr_timesteps" index="1" name=""/>
+    <alias field="dem_file" index="2" name=""/>
+    <alias field="minimum_sim_time_step" index="3" name=""/>
+    <alias field="id" index="4" name=""/>
+    <alias field="table_step_size_volume_2d" index="5" name=""/>
+    <alias field="frict_coef_file" index="6" name=""/>
+    <alias field="initial_groundwater_level_file" index="7" name=""/>
+    <alias field="initial_waterlevel" index="8" name=""/>
+    <alias field="epsg_code" index="9" name=""/>
+    <alias field="numerical_settings_id" index="10" name=""/>
+    <alias field="dem_obstacle_detection" index="11" name=""/>
+    <alias field="frict_avg" index="12" name=""/>
+    <alias field="initial_groundwater_level_type" index="13" name=""/>
+    <alias field="water_level_ini_type" index="14" name=""/>
+    <alias field="grid_space" index="15" name=""/>
+    <alias field="advection_2d" index="16" name=""/>
+    <alias field="embedded_cutoff_threshold" index="17" name=""/>
+    <alias field="dist_calc_points" index="18" name=""/>
+    <alias field="start_date" index="19" name=""/>
+    <alias field="max_interception_file" index="20" name=""/>
+    <alias field="output_time_step" index="21" name=""/>
+    <alias field="interflow_settings_id" index="22" name=""/>
+    <alias field="table_step_size" index="23" name=""/>
+    <alias field="use_1d_flow" index="24" name=""/>
+    <alias field="start_time" index="25" name=""/>
+    <alias field="use_2d_rain" index="26" name=""/>
+    <alias field="initial_groundwater_level" index="27" name=""/>
+    <alias field="kmax" index="28" name=""/>
+    <alias field="initial_waterlevel_file" index="29" name=""/>
+    <alias field="sim_time_step" index="30" name=""/>
+    <alias field="frict_coef" index="31" name=""/>
+    <alias field="guess_dams" index="32" name=""/>
+    <alias field="control_group_id" index="33" name=""/>
+    <alias field="dem_obstacle_height" index="34" name=""/>
+    <alias field="timestep_plus" index="35" name=""/>
+    <alias field="name" index="36" name=""/>
+    <alias field="flooding_threshold" index="37" name=""/>
+    <alias field="frict_type" index="38" name=""/>
+    <alias field="use_2d_flow" index="39" name=""/>
+    <alias field="max_interception" index="40" name=""/>
+    <alias field="max_angle_1d_advection" index="41" name=""/>
+    <alias field="advection_1d" index="42" name=""/>
+    <alias field="wind_shielding_file" index="43" name=""/>
+    <alias field="simple_infiltration_settings_id" index="44" name=""/>
+    <alias field="groundwater_settings_id" index="45" name=""/>
+    <alias field="manhole_storage_area" index="46" name=""/>
+    <alias field="use_0d_inflow" index="47" name=""/>
+    <alias field="table_step_size_1d" index="48" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="maximum_sim_time_step" expression="" applyOnUpdate="0"/>
+    <default field="nr_timesteps" expression="" applyOnUpdate="0"/>
+    <default field="dem_file" expression="" applyOnUpdate="0"/>
+    <default field="minimum_sim_time_step" expression="" applyOnUpdate="0"/>
+    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+    <default field="table_step_size_volume_2d" expression="" applyOnUpdate="0"/>
+    <default field="frict_coef_file" expression="" applyOnUpdate="0"/>
+    <default field="initial_groundwater_level_file" expression="" applyOnUpdate="0"/>
+    <default field="initial_waterlevel" expression="-10" applyOnUpdate="0"/>
+    <default field="epsg_code" expression="" applyOnUpdate="0"/>
+    <default field="numerical_settings_id" expression="1" applyOnUpdate="0"/>
+    <default field="dem_obstacle_detection" expression="0" applyOnUpdate="0"/>
+    <default field="frict_avg" expression="0" applyOnUpdate="0"/>
+    <default field="initial_groundwater_level_type" expression="" applyOnUpdate="0"/>
+    <default field="water_level_ini_type" expression="" applyOnUpdate="0"/>
+    <default field="grid_space" expression="" applyOnUpdate="0"/>
+    <default field="advection_2d" expression="" applyOnUpdate="0"/>
+    <default field="embedded_cutoff_threshold" expression="" applyOnUpdate="0"/>
+    <default field="dist_calc_points" expression="10000" applyOnUpdate="0"/>
+    <default field="start_date" expression=" to_date(now() )" applyOnUpdate="0"/>
+    <default field="max_interception_file" expression="" applyOnUpdate="0"/>
+    <default field="output_time_step" expression="" applyOnUpdate="0"/>
+    <default field="interflow_settings_id" expression="" applyOnUpdate="0"/>
+    <default field="table_step_size" expression="0.01" applyOnUpdate="0"/>
+    <default field="use_1d_flow" expression="" applyOnUpdate="0"/>
+    <default field="start_time" expression=" to_date( now() ) ||  ' 00:00:00'" applyOnUpdate="0"/>
+    <default field="use_2d_rain" expression="" applyOnUpdate="0"/>
+    <default field="initial_groundwater_level" expression="" applyOnUpdate="0"/>
+    <default field="kmax" expression="" applyOnUpdate="0"/>
+    <default field="initial_waterlevel_file" expression="" applyOnUpdate="0"/>
+    <default field="sim_time_step" expression="" applyOnUpdate="0"/>
+    <default field="frict_coef" expression="0.026" applyOnUpdate="0"/>
+    <default field="guess_dams" expression="0" applyOnUpdate="0"/>
+    <default field="control_group_id" expression="" applyOnUpdate="0"/>
+    <default field="dem_obstacle_height" expression="" applyOnUpdate="0"/>
+    <default field="timestep_plus" expression="0" applyOnUpdate="0"/>
+    <default field="name" expression="" applyOnUpdate="0"/>
+    <default field="flooding_threshold" expression="0.01" applyOnUpdate="0"/>
+    <default field="frict_type" expression="2" applyOnUpdate="0"/>
+    <default field="use_2d_flow" expression="" applyOnUpdate="0"/>
+    <default field="max_interception" expression="" applyOnUpdate="0"/>
+    <default field="max_angle_1d_advection" expression="" applyOnUpdate="0"/>
+    <default field="advection_1d" expression="" applyOnUpdate="0"/>
+    <default field="wind_shielding_file" expression="" applyOnUpdate="0"/>
+    <default field="simple_infiltration_settings_id" expression="" applyOnUpdate="0"/>
+    <default field="groundwater_settings_id" expression="" applyOnUpdate="0"/>
+    <default field="manhole_storage_area" expression="" applyOnUpdate="0"/>
+    <default field="use_0d_inflow" expression="" applyOnUpdate="0"/>
+    <default field="table_step_size_1d" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="maximum_sim_time_step" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="nr_timesteps" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="dem_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="minimum_sim_time_step" constraints="4" unique_strength="0" exp_strength="2" notnull_strength="0"/>
+    <constraint field="id" constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint field="table_step_size_volume_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="frict_coef_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="initial_groundwater_level_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="initial_waterlevel" constraints="5" unique_strength="0" exp_strength="2" notnull_strength="2"/>
+    <constraint field="epsg_code" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="numerical_settings_id" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="dem_obstacle_detection" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="frict_avg" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="initial_groundwater_level_type" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="water_level_ini_type" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="grid_space" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="advection_2d" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="embedded_cutoff_threshold" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="dist_calc_points" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="start_date" constraints="5" unique_strength="0" exp_strength="2" notnull_strength="2"/>
+    <constraint field="max_interception_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="output_time_step" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="interflow_settings_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="table_step_size" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="use_1d_flow" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="start_time" constraints="5" unique_strength="0" exp_strength="2" notnull_strength="2"/>
+    <constraint field="use_2d_rain" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="initial_groundwater_level" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="kmax" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="initial_waterlevel_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="sim_time_step" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="frict_coef" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="guess_dams" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="control_group_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="dem_obstacle_height" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="timestep_plus" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="name" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="flooding_threshold" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="frict_type" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="use_2d_flow" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="max_interception" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="max_angle_1d_advection" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="advection_1d" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="wind_shielding_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="simple_infiltration_settings_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="groundwater_settings_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="manhole_storage_area" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="use_0d_inflow" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="table_step_size_1d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="maximum_sim_time_step" desc="" exp=""/>
+    <constraint field="nr_timesteps" desc="" exp=""/>
+    <constraint field="dem_file" desc="" exp=""/>
+    <constraint field="minimum_sim_time_step" desc="" exp=" &quot;minimum_sim_time_step&quot; &lt; &quot;sim_time_step&quot; "/>
+    <constraint field="id" desc="" exp=""/>
+    <constraint field="table_step_size_volume_2d" desc="" exp=""/>
+    <constraint field="frict_coef_file" desc="" exp=""/>
+    <constraint field="initial_groundwater_level_file" desc="" exp=""/>
+    <constraint field="initial_waterlevel" desc="" exp="&quot;initial_waterlevel&quot;"/>
+    <constraint field="epsg_code" desc="" exp=""/>
+    <constraint field="numerical_settings_id" desc="" exp=""/>
+    <constraint field="dem_obstacle_detection" desc="" exp=""/>
+    <constraint field="frict_avg" desc="" exp=""/>
+    <constraint field="initial_groundwater_level_type" desc="" exp=""/>
+    <constraint field="water_level_ini_type" desc="" exp=""/>
+    <constraint field="grid_space" desc="" exp=""/>
+    <constraint field="advection_2d" desc="" exp=""/>
+    <constraint field="embedded_cutoff_threshold" desc="" exp=""/>
+    <constraint field="dist_calc_points" desc="" exp=""/>
+    <constraint field="start_date" desc="" exp="&quot;start_date&quot; is not null"/>
+    <constraint field="max_interception_file" desc="" exp=""/>
+    <constraint field="output_time_step" desc="" exp=""/>
+    <constraint field="interflow_settings_id" desc="" exp=""/>
+    <constraint field="table_step_size" desc="" exp=""/>
+    <constraint field="use_1d_flow" desc="" exp=""/>
+    <constraint field="start_time" desc="" exp="&quot;start_time&quot;"/>
+    <constraint field="use_2d_rain" desc="" exp=""/>
+    <constraint field="initial_groundwater_level" desc="" exp=""/>
+    <constraint field="kmax" desc="" exp=""/>
+    <constraint field="initial_waterlevel_file" desc="" exp=""/>
+    <constraint field="sim_time_step" desc="" exp=""/>
+    <constraint field="frict_coef" desc="" exp=""/>
+    <constraint field="guess_dams" desc="" exp=""/>
+    <constraint field="control_group_id" desc="" exp=""/>
+    <constraint field="dem_obstacle_height" desc="" exp=""/>
+    <constraint field="timestep_plus" desc="" exp=""/>
+    <constraint field="name" desc="" exp=""/>
+    <constraint field="flooding_threshold" desc="" exp=""/>
+    <constraint field="frict_type" desc="" exp=""/>
+    <constraint field="use_2d_flow" desc="" exp=""/>
+    <constraint field="max_interception" desc="" exp=""/>
+    <constraint field="max_angle_1d_advection" desc="" exp=""/>
+    <constraint field="advection_1d" desc="" exp=""/>
+    <constraint field="wind_shielding_file" desc="" exp=""/>
+    <constraint field="simple_infiltration_settings_id" desc="" exp=""/>
+    <constraint field="groundwater_settings_id" desc="" exp=""/>
+    <constraint field="manhole_storage_area" desc="" exp=""/>
+    <constraint field="use_0d_inflow" desc="" exp=""/>
+    <constraint field="table_step_size_1d" desc="" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="&quot;maximum_sim_time_step&quot;" actionWidgetStyle="dropDown" sortOrder="0">
+    <columns>
+      <column type="field" hidden="0" name="maximum_sim_time_step" width="116"/>
+      <column type="field" hidden="0" name="nr_timesteps" width="-1"/>
+      <column type="field" hidden="0" name="dem_file" width="-1"/>
+      <column type="field" hidden="0" name="minimum_sim_time_step" width="-1"/>
+      <column type="field" hidden="0" name="id" width="-1"/>
+      <column type="field" hidden="0" name="table_step_size_volume_2d" width="-1"/>
+      <column type="field" hidden="0" name="frict_coef_file" width="-1"/>
+      <column type="field" hidden="0" name="initial_groundwater_level_file" width="-1"/>
+      <column type="field" hidden="0" name="initial_waterlevel" width="-1"/>
+      <column type="field" hidden="0" name="epsg_code" width="-1"/>
+      <column type="field" hidden="0" name="numerical_settings_id" width="-1"/>
+      <column type="field" hidden="0" name="dem_obstacle_detection" width="-1"/>
+      <column type="field" hidden="0" name="frict_avg" width="-1"/>
+      <column type="field" hidden="0" name="initial_groundwater_level_type" width="-1"/>
+      <column type="field" hidden="0" name="water_level_ini_type" width="-1"/>
+      <column type="field" hidden="0" name="grid_space" width="-1"/>
+      <column type="field" hidden="0" name="advection_2d" width="-1"/>
+      <column type="field" hidden="0" name="embedded_cutoff_threshold" width="-1"/>
+      <column type="field" hidden="0" name="dist_calc_points" width="-1"/>
+      <column type="field" hidden="0" name="start_date" width="-1"/>
+      <column type="field" hidden="0" name="initial_groundwater_level" width="-1"/>
+      <column type="field" hidden="0" name="output_time_step" width="-1"/>
+      <column type="field" hidden="0" name="interflow_settings_id" width="-1"/>
+      <column type="field" hidden="0" name="table_step_size" width="-1"/>
+      <column type="field" hidden="0" name="use_1d_flow" width="-1"/>
+      <column type="field" hidden="0" name="start_time" width="-1"/>
+      <column type="field" hidden="0" name="use_2d_rain" width="-1"/>
+      <column type="field" hidden="0" name="kmax" width="-1"/>
+      <column type="field" hidden="0" name="initial_waterlevel_file" width="-1"/>
+      <column type="field" hidden="0" name="sim_time_step" width="-1"/>
+      <column type="field" hidden="0" name="frict_coef" width="-1"/>
+      <column type="field" hidden="0" name="guess_dams" width="-1"/>
+      <column type="field" hidden="0" name="control_group_id" width="-1"/>
+      <column type="field" hidden="0" name="dem_obstacle_height" width="-1"/>
+      <column type="field" hidden="0" name="timestep_plus" width="-1"/>
+      <column type="field" hidden="0" name="name" width="-1"/>
+      <column type="field" hidden="0" name="flooding_threshold" width="-1"/>
+      <column type="field" hidden="0" name="frict_type" width="-1"/>
+      <column type="field" hidden="0" name="use_2d_flow" width="-1"/>
+      <column type="field" hidden="0" name="max_angle_1d_advection" width="-1"/>
+      <column type="field" hidden="0" name="advection_1d" width="-1"/>
+      <column type="field" hidden="0" name="wind_shielding_file" width="-1"/>
+      <column type="field" hidden="0" name="simple_infiltration_settings_id" width="-1"/>
+      <column type="field" hidden="0" name="groundwater_settings_id" width="-1"/>
+      <column type="field" hidden="0" name="manhole_storage_area" width="-1"/>
+      <column type="field" hidden="0" name="use_0d_inflow" width="-1"/>
+      <column type="field" hidden="0" name="table_step_size_1d" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+      <column type="field" hidden="0" name="max_interception_file" width="-1"/>
+      <column type="field" hidden="0" name="max_interception" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General">
+      <attributeEditorField showLabel="1" index="4" name="id"/>
+      <attributeEditorField showLabel="1" index="36" name="name"/>
+      <attributeEditorField showLabel="1" index="47" name="use_0d_inflow"/>
+      <attributeEditorField showLabel="1" index="24" name="use_1d_flow"/>
+      <attributeEditorField showLabel="1" index="26" name="use_2d_rain"/>
+      <attributeEditorField showLabel="1" index="39" name="use_2d_flow"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Grid">
+      <attributeEditorField showLabel="1" index="15" name="grid_space"/>
+      <attributeEditorField showLabel="1" index="28" name="kmax"/>
+      <attributeEditorField showLabel="1" index="23" name="table_step_size"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="&quot;advection_1d&quot;" visibilityExpressionEnabled="0" columnCount="1" name="Terrain information">
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="DEM">
+        <attributeEditorField showLabel="1" index="2" name="dem_file"/>
+        <attributeEditorField showLabel="1" index="9" name="epsg_code"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Friction">
+        <attributeEditorField showLabel="1" index="6" name="frict_coef_file"/>
+        <attributeEditorField showLabel="1" index="31" name="frict_coef"/>
+        <attributeEditorField showLabel="1" index="38" name="frict_type"/>
+        <attributeEditorField showLabel="1" index="12" name="frict_avg"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Groundwater">
+        <attributeEditorField showLabel="1" index="7" name="initial_groundwater_level_file"/>
+        <attributeEditorField showLabel="1" index="27" name="initial_groundwater_level"/>
+        <attributeEditorField showLabel="1" index="13" name="initial_groundwater_level_type"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Initial waterlevel">
+        <attributeEditorField showLabel="1" index="29" name="initial_waterlevel_file"/>
+        <attributeEditorField showLabel="1" index="8" name="initial_waterlevel"/>
+        <attributeEditorField showLabel="1" index="14" name="water_level_ini_type"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Interception">
+        <attributeEditorField showLabel="1" index="-1" name="interception_file"/>
+        <attributeEditorField showLabel="1" index="-1" name="interception_global"/>
+        <attributeEditorField showLabel="1" index="40" name="max_interception"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Wind">
+        <attributeEditorField showLabel="1" index="43" name="wind_shielding_file"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Time">
+      <attributeEditorField showLabel="1" index="19" name="start_date"/>
+      <attributeEditorField showLabel="1" index="25" name="start_time"/>
+      <attributeEditorField showLabel="1" index="30" name="sim_time_step"/>
+      <attributeEditorField showLabel="1" index="35" name="timestep_plus"/>
+      <attributeEditorField showLabel="1" index="3" name="minimum_sim_time_step"/>
+      <attributeEditorField showLabel="1" index="0" name="maximum_sim_time_step"/>
+      <attributeEditorField showLabel="1" index="1" name="nr_timesteps"/>
+      <attributeEditorField showLabel="1" index="21" name="output_time_step"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Settings id's">
+      <attributeEditorField showLabel="1" index="22" name="interflow_settings_id"/>
+      <attributeEditorField showLabel="1" index="45" name="groundwater_settings_id"/>
+      <attributeEditorField showLabel="1" index="10" name="numerical_settings_id"/>
+      <attributeEditorField showLabel="1" index="44" name="simple_infiltration_settings_id"/>
+      <attributeEditorField showLabel="1" index="33" name="control_group_id"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Extra options 1D">
+      <attributeEditorField showLabel="1" index="42" name="advection_1d"/>
+      <attributeEditorField showLabel="1" index="18" name="dist_calc_points"/>
+      <attributeEditorField showLabel="1" index="46" name="manhole_storage_area"/>
+      <attributeEditorField showLabel="1" index="41" name="max_angle_1d_advection"/>
+      <attributeEditorField showLabel="1" index="48" name="table_step_size_1d"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Extra options 2D">
+      <attributeEditorField showLabel="1" index="16" name="advection_2d"/>
+      <attributeEditorField showLabel="1" index="11" name="dem_obstacle_detection"/>
+      <attributeEditorField showLabel="1" index="32" name="guess_dams"/>
+      <attributeEditorField showLabel="1" index="34" name="dem_obstacle_height"/>
+      <attributeEditorField showLabel="1" index="17" name="embedded_cutoff_threshold"/>
+      <attributeEditorField showLabel="1" index="37" name="flooding_threshold"/>
+      <attributeEditorField showLabel="1" index="5" name="table_step_size_volume_2d"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="advection_1d"/>
+    <field editable="1" name="advection_2d"/>
+    <field editable="1" name="control_group_id"/>
+    <field editable="1" name="dem_file"/>
+    <field editable="1" name="dem_obstacle_detection"/>
+    <field editable="1" name="dem_obstacle_height"/>
+    <field editable="1" name="dist_calc_points"/>
+    <field editable="1" name="embedded_cutoff_threshold"/>
+    <field editable="1" name="epsg_code"/>
+    <field editable="1" name="flooding_threshold"/>
+    <field editable="1" name="frict_avg"/>
+    <field editable="1" name="frict_coef"/>
+    <field editable="1" name="frict_coef_file"/>
+    <field editable="1" name="frict_type"/>
+    <field editable="1" name="grid_space"/>
+    <field editable="1" name="groundwater_settings_id"/>
+    <field editable="1" name="guess_dams"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="initial_groundwater_level"/>
+    <field editable="1" name="initial_groundwater_level_file"/>
+    <field editable="1" name="initial_groundwater_level_type"/>
+    <field editable="1" name="initial_waterlevel"/>
+    <field editable="1" name="initial_waterlevel_file"/>
+    <field editable="1" name="interception_file"/>
+    <field editable="1" name="interception_global"/>
+    <field editable="1" name="interflow_settings_id"/>
+    <field editable="1" name="kmax"/>
+    <field editable="1" name="manhole_storage_area"/>
+    <field editable="1" name="max_angle_1d_advection"/>
+    <field editable="1" name="max_interception"/>
+    <field editable="1" name="max_interception_file"/>
+    <field editable="1" name="maximum_sim_time_step"/>
+    <field editable="1" name="minimum_sim_time_step"/>
+    <field editable="1" name="name"/>
+    <field editable="1" name="nr_timesteps"/>
+    <field editable="1" name="numerical_settings_id"/>
+    <field editable="1" name="output_time_step"/>
+    <field editable="1" name="sim_time_step"/>
+    <field editable="1" name="simple_infiltration_settings_id"/>
+    <field editable="1" name="start_date"/>
+    <field editable="1" name="start_time"/>
+    <field editable="1" name="table_step_size"/>
+    <field editable="1" name="table_step_size_1d"/>
+    <field editable="1" name="table_step_size_volume_2d"/>
+    <field editable="1" name="timestep_plus"/>
+    <field editable="1" name="use_0d_inflow"/>
+    <field editable="1" name="use_1d_flow"/>
+    <field editable="1" name="use_2d_flow"/>
+    <field editable="1" name="use_2d_rain"/>
+    <field editable="1" name="water_level_ini_type"/>
+    <field editable="1" name="wind_shielding_file"/>
+  </editable>
+  <labelOnTop>
+    <field name="advection_1d" labelOnTop="0"/>
+    <field name="advection_2d" labelOnTop="0"/>
+    <field name="control_group_id" labelOnTop="0"/>
+    <field name="dem_file" labelOnTop="0"/>
+    <field name="dem_obstacle_detection" labelOnTop="0"/>
+    <field name="dem_obstacle_height" labelOnTop="0"/>
+    <field name="dist_calc_points" labelOnTop="0"/>
+    <field name="embedded_cutoff_threshold" labelOnTop="0"/>
+    <field name="epsg_code" labelOnTop="0"/>
+    <field name="flooding_threshold" labelOnTop="0"/>
+    <field name="frict_avg" labelOnTop="0"/>
+    <field name="frict_coef" labelOnTop="0"/>
+    <field name="frict_coef_file" labelOnTop="0"/>
+    <field name="frict_type" labelOnTop="0"/>
+    <field name="grid_space" labelOnTop="0"/>
+    <field name="groundwater_settings_id" labelOnTop="0"/>
+    <field name="guess_dams" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="initial_groundwater_level" labelOnTop="0"/>
+    <field name="initial_groundwater_level_file" labelOnTop="0"/>
+    <field name="initial_groundwater_level_type" labelOnTop="0"/>
+    <field name="initial_waterlevel" labelOnTop="0"/>
+    <field name="initial_waterlevel_file" labelOnTop="0"/>
+    <field name="interception_file" labelOnTop="0"/>
+    <field name="interception_global" labelOnTop="0"/>
+    <field name="interflow_settings_id" labelOnTop="0"/>
+    <field name="kmax" labelOnTop="0"/>
+    <field name="manhole_storage_area" labelOnTop="0"/>
+    <field name="max_angle_1d_advection" labelOnTop="0"/>
+    <field name="max_interception" labelOnTop="0"/>
+    <field name="max_interception_file" labelOnTop="0"/>
+    <field name="maximum_sim_time_step" labelOnTop="0"/>
+    <field name="minimum_sim_time_step" labelOnTop="0"/>
+    <field name="name" labelOnTop="0"/>
+    <field name="nr_timesteps" labelOnTop="0"/>
+    <field name="numerical_settings_id" labelOnTop="0"/>
+    <field name="output_time_step" labelOnTop="0"/>
+    <field name="sim_time_step" labelOnTop="0"/>
+    <field name="simple_infiltration_settings_id" labelOnTop="0"/>
+    <field name="start_date" labelOnTop="0"/>
+    <field name="start_time" labelOnTop="0"/>
+    <field name="table_step_size" labelOnTop="0"/>
+    <field name="table_step_size_1d" labelOnTop="0"/>
+    <field name="table_step_size_volume_2d" labelOnTop="0"/>
+    <field name="timestep_plus" labelOnTop="0"/>
+    <field name="use_0d_inflow" labelOnTop="0"/>
+    <field name="use_1d_flow" labelOnTop="0"/>
+    <field name="use_2d_flow" labelOnTop="0"/>
+    <field name="use_2d_rain" labelOnTop="0"/>
+    <field name="water_level_ini_type" labelOnTop="0"/>
+    <field name="wind_shielding_file" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_global_settings.qml
+++ b/layer_styles/schematisation/v2_global_settings.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis maxScale="0" version="3.4.5-Madeira" readOnly="0" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -20,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -30,8 +30,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -40,8 +40,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -50,8 +50,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -60,8 +60,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -70,8 +70,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -80,8 +80,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -90,8 +90,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -100,8 +100,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -110,8 +110,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -120,8 +120,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -130,8 +130,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
           </Option>
         </config>
       </editWidget>
@@ -140,8 +140,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
           </Option>
         </config>
       </editWidget>
@@ -150,15 +150,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="0" name="max"/>
+                <Option value="0" name="max" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1" name="min"/>
+                <Option value="1" name="min" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="average"/>
+                <Option value="2" name="average" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -169,15 +169,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="0" name="max"/>
+                <Option value="0" name="max" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1" name="min"/>
+                <Option value="1" name="min" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="average"/>
+                <Option value="2" name="average" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -188,18 +188,24 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
     <field name="advection_2d">
-      <editWidget type="CheckBox">
+      <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="0" name="0: Do not use advection 2d" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1: Use advection 2d" type="QString"/>
+              </Option>
+            </Option>
           </Option>
         </config>
       </editWidget>
@@ -208,8 +214,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -218,8 +224,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -228,81 +234,11 @@
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="allow_null"/>
-            <Option type="bool" value="true" name="calendar_popup"/>
-            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
-            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
-            <Option type="bool" value="false" name="field_iso_format"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="max_interception_file">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="output_time_step">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="interflow_settings_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="table_step_size">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="use_1d_flow">
-      <editWidget type="CheckBox">
-        <config>
-          <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="start_time">
-      <editWidget type="DateTime">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="true" name="allow_null"/>
-            <Option type="bool" value="true" name="calendar_popup"/>
-            <Option type="QString" value="yyyy-MM-dd HH:mm:ss" name="display_format"/>
-            <Option type="QString" value="yyyy-MM-dd HH:mm:ss" name="field_format"/>
-            <Option type="bool" value="false" name="field_iso_format"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="use_2d_rain">
-      <editWidget type="CheckBox">
-        <config>
-          <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option value="true" name="allow_null" type="bool"/>
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="yyyy-MM-dd" name="display_format" type="QString"/>
+            <Option value="yyyy-MM-dd" name="field_format" type="QString"/>
+            <Option value="false" name="field_iso_format" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -311,9 +247,86 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="output_time_step">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="interflow_settings_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="table_step_size">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_1d_flow">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="start_time">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option value="true" name="allow_null" type="bool"/>
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="yyyy-MM-dd HH:mm:ss" name="display_format" type="QString"/>
+            <Option value="yyyy-MM-dd HH:mm:ss" name="field_format" type="QString"/>
+            <Option value="false" name="field_iso_format" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_2d_rain">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="interception_global">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="interception_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
         </config>
       </editWidget>
     </field>
@@ -321,8 +334,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -331,8 +344,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -341,8 +354,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -351,8 +364,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -361,8 +374,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
           </Option>
         </config>
       </editWidget>
@@ -371,8 +384,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -381,8 +394,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -391,8 +404,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
           </Option>
         </config>
       </editWidget>
@@ -401,8 +414,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -411,8 +424,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -421,12 +434,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="1" name="1: Chèzy"/>
+                <Option value="1" name="1: Chèzy" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="2: Manning"/>
+                <Option value="2" name="2: Manning" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -437,16 +450,9 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
           </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="max_interception">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
         </config>
       </editWidget>
     </field>
@@ -454,18 +460,39 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
     <field name="advection_1d">
-      <editWidget type="CheckBox">
+      <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="QString" value="1" name="CheckedState"/>
-            <Option type="QString" value="0" name="UncheckedState"/>
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="0" name="0: Do not use advection 1d" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1: Use advection 1d" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2: Experimental advection 1d" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="3" name="3: Experimental advection 1d" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="4" name="4: Experimental advection 1d" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="5" name="5: Experimental advection 1d" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="6" name="6: Experimental advection 1d" type="QString"/>
+              </Option>
+            </Option>
           </Option>
         </config>
       </editWidget>
@@ -474,8 +501,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -484,8 +511,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -494,8 +521,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -504,8 +531,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -514,15 +541,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="0" name="0: do not use 0d inflow"/>
+                <Option value="0" name="0: do not use 0d inflow" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1" name="1: use v2_impervious_surface"/>
+                <Option value="1" name="1: use v2_impervious_surface" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="2: use v2_surface"/>
+                <Option value="2" name="2: use v2_surface" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -533,275 +560,275 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="maximum_sim_time_step" index="0" name=""/>
-    <alias field="nr_timesteps" index="1" name=""/>
-    <alias field="dem_file" index="2" name=""/>
-    <alias field="minimum_sim_time_step" index="3" name=""/>
-    <alias field="id" index="4" name=""/>
-    <alias field="table_step_size_volume_2d" index="5" name=""/>
-    <alias field="frict_coef_file" index="6" name=""/>
-    <alias field="initial_groundwater_level_file" index="7" name=""/>
-    <alias field="initial_waterlevel" index="8" name=""/>
-    <alias field="epsg_code" index="9" name=""/>
-    <alias field="numerical_settings_id" index="10" name=""/>
-    <alias field="dem_obstacle_detection" index="11" name=""/>
-    <alias field="frict_avg" index="12" name=""/>
-    <alias field="initial_groundwater_level_type" index="13" name=""/>
-    <alias field="water_level_ini_type" index="14" name=""/>
-    <alias field="grid_space" index="15" name=""/>
-    <alias field="advection_2d" index="16" name=""/>
-    <alias field="embedded_cutoff_threshold" index="17" name=""/>
-    <alias field="dist_calc_points" index="18" name=""/>
-    <alias field="start_date" index="19" name=""/>
-    <alias field="max_interception_file" index="20" name=""/>
-    <alias field="output_time_step" index="21" name=""/>
-    <alias field="interflow_settings_id" index="22" name=""/>
-    <alias field="table_step_size" index="23" name=""/>
-    <alias field="use_1d_flow" index="24" name=""/>
-    <alias field="start_time" index="25" name=""/>
-    <alias field="use_2d_rain" index="26" name=""/>
-    <alias field="initial_groundwater_level" index="27" name=""/>
-    <alias field="kmax" index="28" name=""/>
-    <alias field="initial_waterlevel_file" index="29" name=""/>
-    <alias field="sim_time_step" index="30" name=""/>
-    <alias field="frict_coef" index="31" name=""/>
-    <alias field="guess_dams" index="32" name=""/>
-    <alias field="control_group_id" index="33" name=""/>
-    <alias field="dem_obstacle_height" index="34" name=""/>
-    <alias field="timestep_plus" index="35" name=""/>
-    <alias field="name" index="36" name=""/>
-    <alias field="flooding_threshold" index="37" name=""/>
-    <alias field="frict_type" index="38" name=""/>
-    <alias field="use_2d_flow" index="39" name=""/>
-    <alias field="max_interception" index="40" name=""/>
-    <alias field="max_angle_1d_advection" index="41" name=""/>
-    <alias field="advection_1d" index="42" name=""/>
-    <alias field="wind_shielding_file" index="43" name=""/>
-    <alias field="simple_infiltration_settings_id" index="44" name=""/>
-    <alias field="groundwater_settings_id" index="45" name=""/>
-    <alias field="manhole_storage_area" index="46" name=""/>
-    <alias field="use_0d_inflow" index="47" name=""/>
-    <alias field="table_step_size_1d" index="48" name=""/>
+    <alias index="0" name="" field="maximum_sim_time_step"/>
+    <alias index="1" name="" field="nr_timesteps"/>
+    <alias index="2" name="" field="dem_file"/>
+    <alias index="3" name="" field="minimum_sim_time_step"/>
+    <alias index="4" name="" field="id"/>
+    <alias index="5" name="" field="table_step_size_volume_2d"/>
+    <alias index="6" name="" field="frict_coef_file"/>
+    <alias index="7" name="" field="initial_groundwater_level_file"/>
+    <alias index="8" name="" field="initial_waterlevel"/>
+    <alias index="9" name="" field="epsg_code"/>
+    <alias index="10" name="" field="numerical_settings_id"/>
+    <alias index="11" name="" field="dem_obstacle_detection"/>
+    <alias index="12" name="" field="frict_avg"/>
+    <alias index="13" name="" field="initial_groundwater_level_type"/>
+    <alias index="14" name="" field="water_level_ini_type"/>
+    <alias index="15" name="" field="grid_space"/>
+    <alias index="16" name="" field="advection_2d"/>
+    <alias index="17" name="" field="embedded_cutoff_threshold"/>
+    <alias index="18" name="" field="dist_calc_points"/>
+    <alias index="19" name="" field="start_date"/>
+    <alias index="20" name="" field="initial_groundwater_level"/>
+    <alias index="21" name="" field="output_time_step"/>
+    <alias index="22" name="" field="interflow_settings_id"/>
+    <alias index="23" name="" field="table_step_size"/>
+    <alias index="24" name="" field="use_1d_flow"/>
+    <alias index="25" name="" field="start_time"/>
+    <alias index="26" name="" field="use_2d_rain"/>
+    <alias index="27" name="" field="interception_global"/>
+    <alias index="28" name="" field="interception_file"/>
+    <alias index="29" name="" field="kmax"/>
+    <alias index="30" name="" field="initial_waterlevel_file"/>
+    <alias index="31" name="" field="sim_time_step"/>
+    <alias index="32" name="" field="frict_coef"/>
+    <alias index="33" name="" field="guess_dams"/>
+    <alias index="34" name="" field="control_group_id"/>
+    <alias index="35" name="" field="dem_obstacle_height"/>
+    <alias index="36" name="" field="timestep_plus"/>
+    <alias index="37" name="" field="name"/>
+    <alias index="38" name="" field="flooding_threshold"/>
+    <alias index="39" name="" field="frict_type"/>
+    <alias index="40" name="" field="use_2d_flow"/>
+    <alias index="41" name="" field="max_angle_1d_advection"/>
+    <alias index="42" name="" field="advection_1d"/>
+    <alias index="43" name="" field="wind_shielding_file"/>
+    <alias index="44" name="" field="simple_infiltration_settings_id"/>
+    <alias index="45" name="" field="groundwater_settings_id"/>
+    <alias index="46" name="" field="manhole_storage_area"/>
+    <alias index="47" name="" field="use_0d_inflow"/>
+    <alias index="48" name="" field="table_step_size_1d"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="maximum_sim_time_step" expression="" applyOnUpdate="0"/>
-    <default field="nr_timesteps" expression="" applyOnUpdate="0"/>
-    <default field="dem_file" expression="" applyOnUpdate="0"/>
-    <default field="minimum_sim_time_step" expression="" applyOnUpdate="0"/>
-    <default field="id" expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
-    <default field="table_step_size_volume_2d" expression="" applyOnUpdate="0"/>
-    <default field="frict_coef_file" expression="" applyOnUpdate="0"/>
-    <default field="initial_groundwater_level_file" expression="" applyOnUpdate="0"/>
-    <default field="initial_waterlevel" expression="-10" applyOnUpdate="0"/>
-    <default field="epsg_code" expression="" applyOnUpdate="0"/>
-    <default field="numerical_settings_id" expression="1" applyOnUpdate="0"/>
-    <default field="dem_obstacle_detection" expression="0" applyOnUpdate="0"/>
-    <default field="frict_avg" expression="0" applyOnUpdate="0"/>
-    <default field="initial_groundwater_level_type" expression="" applyOnUpdate="0"/>
-    <default field="water_level_ini_type" expression="" applyOnUpdate="0"/>
-    <default field="grid_space" expression="" applyOnUpdate="0"/>
-    <default field="advection_2d" expression="" applyOnUpdate="0"/>
-    <default field="embedded_cutoff_threshold" expression="" applyOnUpdate="0"/>
-    <default field="dist_calc_points" expression="10000" applyOnUpdate="0"/>
-    <default field="start_date" expression=" to_date(now() )" applyOnUpdate="0"/>
-    <default field="max_interception_file" expression="" applyOnUpdate="0"/>
-    <default field="output_time_step" expression="" applyOnUpdate="0"/>
-    <default field="interflow_settings_id" expression="" applyOnUpdate="0"/>
-    <default field="table_step_size" expression="0.01" applyOnUpdate="0"/>
-    <default field="use_1d_flow" expression="" applyOnUpdate="0"/>
-    <default field="start_time" expression=" to_date( now() ) ||  ' 00:00:00'" applyOnUpdate="0"/>
-    <default field="use_2d_rain" expression="" applyOnUpdate="0"/>
-    <default field="initial_groundwater_level" expression="" applyOnUpdate="0"/>
-    <default field="kmax" expression="" applyOnUpdate="0"/>
-    <default field="initial_waterlevel_file" expression="" applyOnUpdate="0"/>
-    <default field="sim_time_step" expression="" applyOnUpdate="0"/>
-    <default field="frict_coef" expression="0.026" applyOnUpdate="0"/>
-    <default field="guess_dams" expression="0" applyOnUpdate="0"/>
-    <default field="control_group_id" expression="" applyOnUpdate="0"/>
-    <default field="dem_obstacle_height" expression="" applyOnUpdate="0"/>
-    <default field="timestep_plus" expression="0" applyOnUpdate="0"/>
-    <default field="name" expression="" applyOnUpdate="0"/>
-    <default field="flooding_threshold" expression="0.01" applyOnUpdate="0"/>
-    <default field="frict_type" expression="2" applyOnUpdate="0"/>
-    <default field="use_2d_flow" expression="" applyOnUpdate="0"/>
-    <default field="max_interception" expression="" applyOnUpdate="0"/>
-    <default field="max_angle_1d_advection" expression="" applyOnUpdate="0"/>
-    <default field="advection_1d" expression="" applyOnUpdate="0"/>
-    <default field="wind_shielding_file" expression="" applyOnUpdate="0"/>
-    <default field="simple_infiltration_settings_id" expression="" applyOnUpdate="0"/>
-    <default field="groundwater_settings_id" expression="" applyOnUpdate="0"/>
-    <default field="manhole_storage_area" expression="" applyOnUpdate="0"/>
-    <default field="use_0d_inflow" expression="" applyOnUpdate="0"/>
-    <default field="table_step_size_1d" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" expression="" field="maximum_sim_time_step"/>
+    <default applyOnUpdate="0" expression="" field="nr_timesteps"/>
+    <default applyOnUpdate="0" expression="" field="dem_file"/>
+    <default applyOnUpdate="0" expression="" field="minimum_sim_time_step"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="" field="table_step_size_volume_2d"/>
+    <default applyOnUpdate="0" expression="" field="frict_coef_file"/>
+    <default applyOnUpdate="0" expression="" field="initial_groundwater_level_file"/>
+    <default applyOnUpdate="0" expression="" field="initial_waterlevel"/>
+    <default applyOnUpdate="0" expression="" field="epsg_code"/>
+    <default applyOnUpdate="0" expression="1" field="numerical_settings_id"/>
+    <default applyOnUpdate="0" expression="0" field="dem_obstacle_detection"/>
+    <default applyOnUpdate="0" expression="0" field="frict_avg"/>
+    <default applyOnUpdate="0" expression="" field="initial_groundwater_level_type"/>
+    <default applyOnUpdate="0" expression="" field="water_level_ini_type"/>
+    <default applyOnUpdate="0" expression="" field="grid_space"/>
+    <default applyOnUpdate="0" expression="" field="advection_2d"/>
+    <default applyOnUpdate="0" expression="" field="embedded_cutoff_threshold"/>
+    <default applyOnUpdate="0" expression="10000" field="dist_calc_points"/>
+    <default applyOnUpdate="0" expression=" to_date(now() )" field="start_date"/>
+    <default applyOnUpdate="0" expression="" field="initial_groundwater_level"/>
+    <default applyOnUpdate="0" expression="" field="output_time_step"/>
+    <default applyOnUpdate="0" expression="" field="interflow_settings_id"/>
+    <default applyOnUpdate="0" expression="0.01" field="table_step_size"/>
+    <default applyOnUpdate="0" expression="" field="use_1d_flow"/>
+    <default applyOnUpdate="0" expression=" to_date( now() ) ||  ' 00:00:00'" field="start_time"/>
+    <default applyOnUpdate="0" expression="" field="use_2d_rain"/>
+    <default applyOnUpdate="0" expression="" field="interception_global"/>
+    <default applyOnUpdate="0" expression="" field="interception_file"/>
+    <default applyOnUpdate="0" expression="" field="kmax"/>
+    <default applyOnUpdate="0" expression="" field="initial_waterlevel_file"/>
+    <default applyOnUpdate="0" expression="" field="sim_time_step"/>
+    <default applyOnUpdate="0" expression="" field="frict_coef"/>
+    <default applyOnUpdate="0" expression="0" field="guess_dams"/>
+    <default applyOnUpdate="0" expression="" field="control_group_id"/>
+    <default applyOnUpdate="0" expression="" field="dem_obstacle_height"/>
+    <default applyOnUpdate="0" expression="0" field="timestep_plus"/>
+    <default applyOnUpdate="0" expression="" field="name"/>
+    <default applyOnUpdate="0" expression="0.001" field="flooding_threshold"/>
+    <default applyOnUpdate="0" expression="2" field="frict_type"/>
+    <default applyOnUpdate="0" expression="" field="use_2d_flow"/>
+    <default applyOnUpdate="0" expression="" field="max_angle_1d_advection"/>
+    <default applyOnUpdate="0" expression="" field="advection_1d"/>
+    <default applyOnUpdate="0" expression="" field="wind_shielding_file"/>
+    <default applyOnUpdate="0" expression="" field="simple_infiltration_settings_id"/>
+    <default applyOnUpdate="0" expression="" field="groundwater_settings_id"/>
+    <default applyOnUpdate="0" expression="" field="manhole_storage_area"/>
+    <default applyOnUpdate="0" expression="" field="use_0d_inflow"/>
+    <default applyOnUpdate="0" expression="" field="table_step_size_1d"/>
   </defaults>
   <constraints>
-    <constraint field="maximum_sim_time_step" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="nr_timesteps" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="dem_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="minimum_sim_time_step" constraints="4" unique_strength="0" exp_strength="2" notnull_strength="0"/>
-    <constraint field="id" constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1"/>
-    <constraint field="table_step_size_volume_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="frict_coef_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="initial_groundwater_level_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="initial_waterlevel" constraints="5" unique_strength="0" exp_strength="2" notnull_strength="2"/>
-    <constraint field="epsg_code" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="numerical_settings_id" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="dem_obstacle_detection" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="frict_avg" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="initial_groundwater_level_type" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="water_level_ini_type" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="grid_space" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="advection_2d" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="embedded_cutoff_threshold" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="dist_calc_points" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="start_date" constraints="5" unique_strength="0" exp_strength="2" notnull_strength="2"/>
-    <constraint field="max_interception_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="output_time_step" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="interflow_settings_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="table_step_size" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="use_1d_flow" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="start_time" constraints="5" unique_strength="0" exp_strength="2" notnull_strength="2"/>
-    <constraint field="use_2d_rain" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="initial_groundwater_level" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="kmax" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="initial_waterlevel_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="sim_time_step" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="frict_coef" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="guess_dams" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="control_group_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="dem_obstacle_height" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="timestep_plus" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="name" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="flooding_threshold" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="frict_type" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="use_2d_flow" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="max_interception" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="max_angle_1d_advection" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="advection_1d" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="wind_shielding_file" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="simple_infiltration_settings_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="groundwater_settings_id" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="manhole_storage_area" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="use_0d_inflow" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="table_step_size_1d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="maximum_sim_time_step" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="nr_timesteps" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="dem_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="0" field="minimum_sim_time_step" constraints="4" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="0" field="table_step_size_volume_2d" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="frict_coef_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="initial_groundwater_level_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="initial_waterlevel" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="epsg_code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="numerical_settings_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="dem_obstacle_detection" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="frict_avg" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="initial_groundwater_level_type" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="water_level_ini_type" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="grid_space" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="advection_2d" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="embedded_cutoff_threshold" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="dist_calc_points" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="2" field="start_date" constraints="5" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="initial_groundwater_level" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="output_time_step" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="interflow_settings_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="table_step_size" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="use_1d_flow" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="2" field="start_time" constraints="5" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="use_2d_rain" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="interception_global" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="interception_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="kmax" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="initial_waterlevel_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="sim_time_step" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="frict_coef" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="guess_dams" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="control_group_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="dem_obstacle_height" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="timestep_plus" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="flooding_threshold" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="frict_type" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="use_2d_flow" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="max_angle_1d_advection" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="advection_1d" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="wind_shielding_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="simple_infiltration_settings_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="groundwater_settings_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="manhole_storage_area" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="use_0d_inflow" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="table_step_size_1d" constraints="0" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="maximum_sim_time_step" desc="" exp=""/>
-    <constraint field="nr_timesteps" desc="" exp=""/>
-    <constraint field="dem_file" desc="" exp=""/>
-    <constraint field="minimum_sim_time_step" desc="" exp=" &quot;minimum_sim_time_step&quot; &lt; &quot;sim_time_step&quot; "/>
-    <constraint field="id" desc="" exp=""/>
-    <constraint field="table_step_size_volume_2d" desc="" exp=""/>
-    <constraint field="frict_coef_file" desc="" exp=""/>
-    <constraint field="initial_groundwater_level_file" desc="" exp=""/>
-    <constraint field="initial_waterlevel" desc="" exp="&quot;initial_waterlevel&quot;"/>
-    <constraint field="epsg_code" desc="" exp=""/>
-    <constraint field="numerical_settings_id" desc="" exp=""/>
-    <constraint field="dem_obstacle_detection" desc="" exp=""/>
-    <constraint field="frict_avg" desc="" exp=""/>
-    <constraint field="initial_groundwater_level_type" desc="" exp=""/>
-    <constraint field="water_level_ini_type" desc="" exp=""/>
-    <constraint field="grid_space" desc="" exp=""/>
-    <constraint field="advection_2d" desc="" exp=""/>
-    <constraint field="embedded_cutoff_threshold" desc="" exp=""/>
-    <constraint field="dist_calc_points" desc="" exp=""/>
-    <constraint field="start_date" desc="" exp="&quot;start_date&quot; is not null"/>
-    <constraint field="max_interception_file" desc="" exp=""/>
-    <constraint field="output_time_step" desc="" exp=""/>
-    <constraint field="interflow_settings_id" desc="" exp=""/>
-    <constraint field="table_step_size" desc="" exp=""/>
-    <constraint field="use_1d_flow" desc="" exp=""/>
-    <constraint field="start_time" desc="" exp="&quot;start_time&quot;"/>
-    <constraint field="use_2d_rain" desc="" exp=""/>
-    <constraint field="initial_groundwater_level" desc="" exp=""/>
-    <constraint field="kmax" desc="" exp=""/>
-    <constraint field="initial_waterlevel_file" desc="" exp=""/>
-    <constraint field="sim_time_step" desc="" exp=""/>
-    <constraint field="frict_coef" desc="" exp=""/>
-    <constraint field="guess_dams" desc="" exp=""/>
-    <constraint field="control_group_id" desc="" exp=""/>
-    <constraint field="dem_obstacle_height" desc="" exp=""/>
-    <constraint field="timestep_plus" desc="" exp=""/>
-    <constraint field="name" desc="" exp=""/>
-    <constraint field="flooding_threshold" desc="" exp=""/>
-    <constraint field="frict_type" desc="" exp=""/>
-    <constraint field="use_2d_flow" desc="" exp=""/>
-    <constraint field="max_interception" desc="" exp=""/>
-    <constraint field="max_angle_1d_advection" desc="" exp=""/>
-    <constraint field="advection_1d" desc="" exp=""/>
-    <constraint field="wind_shielding_file" desc="" exp=""/>
-    <constraint field="simple_infiltration_settings_id" desc="" exp=""/>
-    <constraint field="groundwater_settings_id" desc="" exp=""/>
-    <constraint field="manhole_storage_area" desc="" exp=""/>
-    <constraint field="use_0d_inflow" desc="" exp=""/>
-    <constraint field="table_step_size_1d" desc="" exp=""/>
+    <constraint exp="" desc="" field="maximum_sim_time_step"/>
+    <constraint exp="" desc="" field="nr_timesteps"/>
+    <constraint exp="" desc="" field="dem_file"/>
+    <constraint exp=" &quot;minimum_sim_time_step&quot; &lt; &quot;sim_time_step&quot; " desc="" field="minimum_sim_time_step"/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="table_step_size_volume_2d"/>
+    <constraint exp="" desc="" field="frict_coef_file"/>
+    <constraint exp="" desc="" field="initial_groundwater_level_file"/>
+    <constraint exp="" desc="" field="initial_waterlevel"/>
+    <constraint exp="" desc="" field="epsg_code"/>
+    <constraint exp="" desc="" field="numerical_settings_id"/>
+    <constraint exp="" desc="" field="dem_obstacle_detection"/>
+    <constraint exp="" desc="" field="frict_avg"/>
+    <constraint exp="" desc="" field="initial_groundwater_level_type"/>
+    <constraint exp="" desc="" field="water_level_ini_type"/>
+    <constraint exp="" desc="" field="grid_space"/>
+    <constraint exp="" desc="" field="advection_2d"/>
+    <constraint exp="" desc="" field="embedded_cutoff_threshold"/>
+    <constraint exp="" desc="" field="dist_calc_points"/>
+    <constraint exp="&quot;start_date&quot; is not null" desc="" field="start_date"/>
+    <constraint exp="" desc="" field="initial_groundwater_level"/>
+    <constraint exp="" desc="" field="output_time_step"/>
+    <constraint exp="" desc="" field="interflow_settings_id"/>
+    <constraint exp="" desc="" field="table_step_size"/>
+    <constraint exp="" desc="" field="use_1d_flow"/>
+    <constraint exp="&quot;start_time&quot;" desc="" field="start_time"/>
+    <constraint exp="" desc="" field="use_2d_rain"/>
+    <constraint exp="" desc="" field="interception_global"/>
+    <constraint exp="" desc="" field="interception_file"/>
+    <constraint exp="" desc="" field="kmax"/>
+    <constraint exp="" desc="" field="initial_waterlevel_file"/>
+    <constraint exp="" desc="" field="sim_time_step"/>
+    <constraint exp="" desc="" field="frict_coef"/>
+    <constraint exp="" desc="" field="guess_dams"/>
+    <constraint exp="" desc="" field="control_group_id"/>
+    <constraint exp="" desc="" field="dem_obstacle_height"/>
+    <constraint exp="" desc="" field="timestep_plus"/>
+    <constraint exp="" desc="" field="name"/>
+    <constraint exp="" desc="" field="flooding_threshold"/>
+    <constraint exp="" desc="" field="frict_type"/>
+    <constraint exp="" desc="" field="use_2d_flow"/>
+    <constraint exp="" desc="" field="max_angle_1d_advection"/>
+    <constraint exp="" desc="" field="advection_1d"/>
+    <constraint exp="" desc="" field="wind_shielding_file"/>
+    <constraint exp="" desc="" field="simple_infiltration_settings_id"/>
+    <constraint exp="" desc="" field="groundwater_settings_id"/>
+    <constraint exp="" desc="" field="manhole_storage_area"/>
+    <constraint exp="" desc="" field="use_0d_inflow"/>
+    <constraint exp="" desc="" field="table_step_size_1d"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="&quot;maximum_sim_time_step&quot;" actionWidgetStyle="dropDown" sortOrder="0">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;maximum_sim_time_step&quot;" sortOrder="0">
     <columns>
-      <column type="field" hidden="0" name="maximum_sim_time_step" width="116"/>
-      <column type="field" hidden="0" name="nr_timesteps" width="-1"/>
-      <column type="field" hidden="0" name="dem_file" width="-1"/>
-      <column type="field" hidden="0" name="minimum_sim_time_step" width="-1"/>
-      <column type="field" hidden="0" name="id" width="-1"/>
-      <column type="field" hidden="0" name="table_step_size_volume_2d" width="-1"/>
-      <column type="field" hidden="0" name="frict_coef_file" width="-1"/>
-      <column type="field" hidden="0" name="initial_groundwater_level_file" width="-1"/>
-      <column type="field" hidden="0" name="initial_waterlevel" width="-1"/>
-      <column type="field" hidden="0" name="epsg_code" width="-1"/>
-      <column type="field" hidden="0" name="numerical_settings_id" width="-1"/>
-      <column type="field" hidden="0" name="dem_obstacle_detection" width="-1"/>
-      <column type="field" hidden="0" name="frict_avg" width="-1"/>
-      <column type="field" hidden="0" name="initial_groundwater_level_type" width="-1"/>
-      <column type="field" hidden="0" name="water_level_ini_type" width="-1"/>
-      <column type="field" hidden="0" name="grid_space" width="-1"/>
-      <column type="field" hidden="0" name="advection_2d" width="-1"/>
-      <column type="field" hidden="0" name="embedded_cutoff_threshold" width="-1"/>
-      <column type="field" hidden="0" name="dist_calc_points" width="-1"/>
-      <column type="field" hidden="0" name="start_date" width="-1"/>
-      <column type="field" hidden="0" name="initial_groundwater_level" width="-1"/>
-      <column type="field" hidden="0" name="output_time_step" width="-1"/>
-      <column type="field" hidden="0" name="interflow_settings_id" width="-1"/>
-      <column type="field" hidden="0" name="table_step_size" width="-1"/>
-      <column type="field" hidden="0" name="use_1d_flow" width="-1"/>
-      <column type="field" hidden="0" name="start_time" width="-1"/>
-      <column type="field" hidden="0" name="use_2d_rain" width="-1"/>
-      <column type="field" hidden="0" name="kmax" width="-1"/>
-      <column type="field" hidden="0" name="initial_waterlevel_file" width="-1"/>
-      <column type="field" hidden="0" name="sim_time_step" width="-1"/>
-      <column type="field" hidden="0" name="frict_coef" width="-1"/>
-      <column type="field" hidden="0" name="guess_dams" width="-1"/>
-      <column type="field" hidden="0" name="control_group_id" width="-1"/>
-      <column type="field" hidden="0" name="dem_obstacle_height" width="-1"/>
-      <column type="field" hidden="0" name="timestep_plus" width="-1"/>
-      <column type="field" hidden="0" name="name" width="-1"/>
-      <column type="field" hidden="0" name="flooding_threshold" width="-1"/>
-      <column type="field" hidden="0" name="frict_type" width="-1"/>
-      <column type="field" hidden="0" name="use_2d_flow" width="-1"/>
-      <column type="field" hidden="0" name="max_angle_1d_advection" width="-1"/>
-      <column type="field" hidden="0" name="advection_1d" width="-1"/>
-      <column type="field" hidden="0" name="wind_shielding_file" width="-1"/>
-      <column type="field" hidden="0" name="simple_infiltration_settings_id" width="-1"/>
-      <column type="field" hidden="0" name="groundwater_settings_id" width="-1"/>
-      <column type="field" hidden="0" name="manhole_storage_area" width="-1"/>
-      <column type="field" hidden="0" name="use_0d_inflow" width="-1"/>
-      <column type="field" hidden="0" name="table_step_size_1d" width="-1"/>
-      <column type="actions" hidden="1" width="-1"/>
-      <column type="field" hidden="0" name="max_interception_file" width="-1"/>
-      <column type="field" hidden="0" name="max_interception" width="-1"/>
+      <column width="116" hidden="0" name="maximum_sim_time_step" type="field"/>
+      <column width="-1" hidden="0" name="nr_timesteps" type="field"/>
+      <column width="-1" hidden="0" name="dem_file" type="field"/>
+      <column width="-1" hidden="0" name="minimum_sim_time_step" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="table_step_size_volume_2d" type="field"/>
+      <column width="-1" hidden="0" name="frict_coef_file" type="field"/>
+      <column width="-1" hidden="0" name="initial_groundwater_level_file" type="field"/>
+      <column width="-1" hidden="0" name="initial_waterlevel" type="field"/>
+      <column width="-1" hidden="0" name="epsg_code" type="field"/>
+      <column width="-1" hidden="0" name="numerical_settings_id" type="field"/>
+      <column width="-1" hidden="0" name="dem_obstacle_detection" type="field"/>
+      <column width="-1" hidden="0" name="frict_avg" type="field"/>
+      <column width="-1" hidden="0" name="initial_groundwater_level_type" type="field"/>
+      <column width="-1" hidden="0" name="water_level_ini_type" type="field"/>
+      <column width="-1" hidden="0" name="grid_space" type="field"/>
+      <column width="-1" hidden="0" name="advection_2d" type="field"/>
+      <column width="-1" hidden="0" name="embedded_cutoff_threshold" type="field"/>
+      <column width="-1" hidden="0" name="dist_calc_points" type="field"/>
+      <column width="-1" hidden="0" name="start_date" type="field"/>
+      <column width="-1" hidden="0" name="initial_groundwater_level" type="field"/>
+      <column width="-1" hidden="0" name="output_time_step" type="field"/>
+      <column width="-1" hidden="0" name="interflow_settings_id" type="field"/>
+      <column width="-1" hidden="0" name="table_step_size" type="field"/>
+      <column width="-1" hidden="0" name="use_1d_flow" type="field"/>
+      <column width="-1" hidden="0" name="start_time" type="field"/>
+      <column width="-1" hidden="0" name="use_2d_rain" type="field"/>
+      <column width="-1" hidden="0" name="kmax" type="field"/>
+      <column width="-1" hidden="0" name="initial_waterlevel_file" type="field"/>
+      <column width="-1" hidden="0" name="sim_time_step" type="field"/>
+      <column width="-1" hidden="0" name="frict_coef" type="field"/>
+      <column width="-1" hidden="0" name="guess_dams" type="field"/>
+      <column width="-1" hidden="0" name="control_group_id" type="field"/>
+      <column width="-1" hidden="0" name="dem_obstacle_height" type="field"/>
+      <column width="-1" hidden="0" name="timestep_plus" type="field"/>
+      <column width="-1" hidden="0" name="name" type="field"/>
+      <column width="-1" hidden="0" name="flooding_threshold" type="field"/>
+      <column width="-1" hidden="0" name="frict_type" type="field"/>
+      <column width="-1" hidden="0" name="use_2d_flow" type="field"/>
+      <column width="-1" hidden="0" name="max_angle_1d_advection" type="field"/>
+      <column width="-1" hidden="0" name="advection_1d" type="field"/>
+      <column width="-1" hidden="0" name="wind_shielding_file" type="field"/>
+      <column width="-1" hidden="0" name="simple_infiltration_settings_id" type="field"/>
+      <column width="-1" hidden="0" name="groundwater_settings_id" type="field"/>
+      <column width="-1" hidden="0" name="manhole_storage_area" type="field"/>
+      <column width="-1" hidden="0" name="use_0d_inflow" type="field"/>
+      <column width="-1" hidden="0" name="table_step_size_1d" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
+      <column width="-1" hidden="0" name="interception_global" type="field"/>
+      <column width="-1" hidden="0" name="interception_file" type="field"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -832,80 +859,80 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="4" name="id"/>
-      <attributeEditorField showLabel="1" index="36" name="name"/>
+      <attributeEditorField showLabel="1" index="37" name="name"/>
       <attributeEditorField showLabel="1" index="47" name="use_0d_inflow"/>
       <attributeEditorField showLabel="1" index="24" name="use_1d_flow"/>
       <attributeEditorField showLabel="1" index="26" name="use_2d_rain"/>
-      <attributeEditorField showLabel="1" index="39" name="use_2d_flow"/>
+      <attributeEditorField showLabel="1" index="40" name="use_2d_flow"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Grid">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Grid" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="15" name="grid_space"/>
-      <attributeEditorField showLabel="1" index="28" name="kmax"/>
+      <attributeEditorField showLabel="1" index="29" name="kmax"/>
       <attributeEditorField showLabel="1" index="23" name="table_step_size"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="&quot;advection_1d&quot;" visibilityExpressionEnabled="0" columnCount="1" name="Terrain information">
-      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="DEM">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="&quot;advection_1d&quot;" name="Terrain information" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="DEM" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="2" name="dem_file"/>
         <attributeEditorField showLabel="1" index="9" name="epsg_code"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Friction">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Friction" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="6" name="frict_coef_file"/>
-        <attributeEditorField showLabel="1" index="31" name="frict_coef"/>
-        <attributeEditorField showLabel="1" index="38" name="frict_type"/>
+        <attributeEditorField showLabel="1" index="32" name="frict_coef"/>
+        <attributeEditorField showLabel="1" index="39" name="frict_type"/>
         <attributeEditorField showLabel="1" index="12" name="frict_avg"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Groundwater">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Groundwater" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="7" name="initial_groundwater_level_file"/>
-        <attributeEditorField showLabel="1" index="27" name="initial_groundwater_level"/>
+        <attributeEditorField showLabel="1" index="20" name="initial_groundwater_level"/>
         <attributeEditorField showLabel="1" index="13" name="initial_groundwater_level_type"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Initial waterlevel">
-        <attributeEditorField showLabel="1" index="29" name="initial_waterlevel_file"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Initial waterlevel" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="30" name="initial_waterlevel_file"/>
         <attributeEditorField showLabel="1" index="8" name="initial_waterlevel"/>
         <attributeEditorField showLabel="1" index="14" name="water_level_ini_type"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Interception">
-        <attributeEditorField showLabel="1" index="-1" name="interception_file"/>
-        <attributeEditorField showLabel="1" index="-1" name="interception_global"/>
-        <attributeEditorField showLabel="1" index="40" name="max_interception"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Interception" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="28" name="interception_file"/>
+        <attributeEditorField showLabel="1" index="27" name="interception_global"/>
+        <attributeEditorField showLabel="1" index="-1" name="max_interception"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Wind">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Wind" groupBox="1" visibilityExpressionEnabled="0">
         <attributeEditorField showLabel="1" index="43" name="wind_shielding_file"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Time">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Time" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="19" name="start_date"/>
       <attributeEditorField showLabel="1" index="25" name="start_time"/>
-      <attributeEditorField showLabel="1" index="30" name="sim_time_step"/>
-      <attributeEditorField showLabel="1" index="35" name="timestep_plus"/>
+      <attributeEditorField showLabel="1" index="31" name="sim_time_step"/>
+      <attributeEditorField showLabel="1" index="36" name="timestep_plus"/>
       <attributeEditorField showLabel="1" index="3" name="minimum_sim_time_step"/>
       <attributeEditorField showLabel="1" index="0" name="maximum_sim_time_step"/>
       <attributeEditorField showLabel="1" index="1" name="nr_timesteps"/>
       <attributeEditorField showLabel="1" index="21" name="output_time_step"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Settings id's">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Settings id's" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="22" name="interflow_settings_id"/>
       <attributeEditorField showLabel="1" index="45" name="groundwater_settings_id"/>
       <attributeEditorField showLabel="1" index="10" name="numerical_settings_id"/>
       <attributeEditorField showLabel="1" index="44" name="simple_infiltration_settings_id"/>
-      <attributeEditorField showLabel="1" index="33" name="control_group_id"/>
+      <attributeEditorField showLabel="1" index="34" name="control_group_id"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Extra options 1D">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Extra options 1D" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="42" name="advection_1d"/>
       <attributeEditorField showLabel="1" index="18" name="dist_calc_points"/>
       <attributeEditorField showLabel="1" index="46" name="manhole_storage_area"/>
       <attributeEditorField showLabel="1" index="41" name="max_angle_1d_advection"/>
       <attributeEditorField showLabel="1" index="48" name="table_step_size_1d"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Extra options 2D">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Extra options 2D" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="16" name="advection_2d"/>
       <attributeEditorField showLabel="1" index="11" name="dem_obstacle_detection"/>
-      <attributeEditorField showLabel="1" index="32" name="guess_dams"/>
-      <attributeEditorField showLabel="1" index="34" name="dem_obstacle_height"/>
+      <attributeEditorField showLabel="1" index="33" name="guess_dams"/>
+      <attributeEditorField showLabel="1" index="35" name="dem_obstacle_height"/>
       <attributeEditorField showLabel="1" index="17" name="embedded_cutoff_threshold"/>
-      <attributeEditorField showLabel="1" index="37" name="flooding_threshold"/>
+      <attributeEditorField showLabel="1" index="38" name="flooding_threshold"/>
       <attributeEditorField showLabel="1" index="5" name="table_step_size_volume_2d"/>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -963,57 +990,57 @@ def my_form_open(dialog, layer, feature):
     <field editable="1" name="wind_shielding_file"/>
   </editable>
   <labelOnTop>
-    <field name="advection_1d" labelOnTop="0"/>
-    <field name="advection_2d" labelOnTop="0"/>
-    <field name="control_group_id" labelOnTop="0"/>
-    <field name="dem_file" labelOnTop="0"/>
-    <field name="dem_obstacle_detection" labelOnTop="0"/>
-    <field name="dem_obstacle_height" labelOnTop="0"/>
-    <field name="dist_calc_points" labelOnTop="0"/>
-    <field name="embedded_cutoff_threshold" labelOnTop="0"/>
-    <field name="epsg_code" labelOnTop="0"/>
-    <field name="flooding_threshold" labelOnTop="0"/>
-    <field name="frict_avg" labelOnTop="0"/>
-    <field name="frict_coef" labelOnTop="0"/>
-    <field name="frict_coef_file" labelOnTop="0"/>
-    <field name="frict_type" labelOnTop="0"/>
-    <field name="grid_space" labelOnTop="0"/>
-    <field name="groundwater_settings_id" labelOnTop="0"/>
-    <field name="guess_dams" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="initial_groundwater_level" labelOnTop="0"/>
-    <field name="initial_groundwater_level_file" labelOnTop="0"/>
-    <field name="initial_groundwater_level_type" labelOnTop="0"/>
-    <field name="initial_waterlevel" labelOnTop="0"/>
-    <field name="initial_waterlevel_file" labelOnTop="0"/>
-    <field name="interception_file" labelOnTop="0"/>
-    <field name="interception_global" labelOnTop="0"/>
-    <field name="interflow_settings_id" labelOnTop="0"/>
-    <field name="kmax" labelOnTop="0"/>
-    <field name="manhole_storage_area" labelOnTop="0"/>
-    <field name="max_angle_1d_advection" labelOnTop="0"/>
-    <field name="max_interception" labelOnTop="0"/>
-    <field name="max_interception_file" labelOnTop="0"/>
-    <field name="maximum_sim_time_step" labelOnTop="0"/>
-    <field name="minimum_sim_time_step" labelOnTop="0"/>
-    <field name="name" labelOnTop="0"/>
-    <field name="nr_timesteps" labelOnTop="0"/>
-    <field name="numerical_settings_id" labelOnTop="0"/>
-    <field name="output_time_step" labelOnTop="0"/>
-    <field name="sim_time_step" labelOnTop="0"/>
-    <field name="simple_infiltration_settings_id" labelOnTop="0"/>
-    <field name="start_date" labelOnTop="0"/>
-    <field name="start_time" labelOnTop="0"/>
-    <field name="table_step_size" labelOnTop="0"/>
-    <field name="table_step_size_1d" labelOnTop="0"/>
-    <field name="table_step_size_volume_2d" labelOnTop="0"/>
-    <field name="timestep_plus" labelOnTop="0"/>
-    <field name="use_0d_inflow" labelOnTop="0"/>
-    <field name="use_1d_flow" labelOnTop="0"/>
-    <field name="use_2d_flow" labelOnTop="0"/>
-    <field name="use_2d_rain" labelOnTop="0"/>
-    <field name="water_level_ini_type" labelOnTop="0"/>
-    <field name="wind_shielding_file" labelOnTop="0"/>
+    <field labelOnTop="0" name="advection_1d"/>
+    <field labelOnTop="0" name="advection_2d"/>
+    <field labelOnTop="0" name="control_group_id"/>
+    <field labelOnTop="0" name="dem_file"/>
+    <field labelOnTop="0" name="dem_obstacle_detection"/>
+    <field labelOnTop="0" name="dem_obstacle_height"/>
+    <field labelOnTop="0" name="dist_calc_points"/>
+    <field labelOnTop="0" name="embedded_cutoff_threshold"/>
+    <field labelOnTop="0" name="epsg_code"/>
+    <field labelOnTop="0" name="flooding_threshold"/>
+    <field labelOnTop="0" name="frict_avg"/>
+    <field labelOnTop="0" name="frict_coef"/>
+    <field labelOnTop="0" name="frict_coef_file"/>
+    <field labelOnTop="0" name="frict_type"/>
+    <field labelOnTop="0" name="grid_space"/>
+    <field labelOnTop="0" name="groundwater_settings_id"/>
+    <field labelOnTop="0" name="guess_dams"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="initial_groundwater_level"/>
+    <field labelOnTop="0" name="initial_groundwater_level_file"/>
+    <field labelOnTop="0" name="initial_groundwater_level_type"/>
+    <field labelOnTop="0" name="initial_waterlevel"/>
+    <field labelOnTop="0" name="initial_waterlevel_file"/>
+    <field labelOnTop="0" name="interception_file"/>
+    <field labelOnTop="0" name="interception_global"/>
+    <field labelOnTop="0" name="interflow_settings_id"/>
+    <field labelOnTop="0" name="kmax"/>
+    <field labelOnTop="0" name="manhole_storage_area"/>
+    <field labelOnTop="0" name="max_angle_1d_advection"/>
+    <field labelOnTop="0" name="max_interception"/>
+    <field labelOnTop="0" name="max_interception_file"/>
+    <field labelOnTop="0" name="maximum_sim_time_step"/>
+    <field labelOnTop="0" name="minimum_sim_time_step"/>
+    <field labelOnTop="0" name="name"/>
+    <field labelOnTop="0" name="nr_timesteps"/>
+    <field labelOnTop="0" name="numerical_settings_id"/>
+    <field labelOnTop="0" name="output_time_step"/>
+    <field labelOnTop="0" name="sim_time_step"/>
+    <field labelOnTop="0" name="simple_infiltration_settings_id"/>
+    <field labelOnTop="0" name="start_date"/>
+    <field labelOnTop="0" name="start_time"/>
+    <field labelOnTop="0" name="table_step_size"/>
+    <field labelOnTop="0" name="table_step_size_1d"/>
+    <field labelOnTop="0" name="table_step_size_volume_2d"/>
+    <field labelOnTop="0" name="timestep_plus"/>
+    <field labelOnTop="0" name="use_0d_inflow"/>
+    <field labelOnTop="0" name="use_1d_flow"/>
+    <field labelOnTop="0" name="use_2d_flow"/>
+    <field labelOnTop="0" name="use_2d_rain"/>
+    <field labelOnTop="0" name="water_level_ini_type"/>
+    <field labelOnTop="0" name="wind_shielding_file"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>id</previewExpression>

--- a/layer_styles/schematisation/v2_grid_refinement.qml
+++ b/layer_styles/schematisation/v2_grid_refinement.qml
@@ -1,26 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="refinement_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -29,215 +20,99 @@
           <prop k="line_width" v="0.46"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
     <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="11"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="Ubuntu"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
-      <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="2" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option type="Map" name="properties">
+          <Option type="Map" name="show">
+            <Option type="bool" value="true" name="active"/>
+            <Option type="QString" value="refinement_level" name="field"/>
+            <Option type="int" value="2" name="type"/>
+          </Option>
+        </Option>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="refinement_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
     <alias field="refinement_level" index="0" name=""/>
     <alias field="code" index="1" name=""/>
@@ -246,8 +121,29 @@
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <defaults>
+    <default expression="1" applyOnUpdate="0" field="refinement_level"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="refinement_level" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="code" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="display_name" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="refinement_level" exp=""/>
+    <constraint desc="" field="code" exp=""/>
+    <constraint desc="" field="display_name" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
       <column width="-1" hidden="0" type="field" name="refinement_level"/>
       <column width="-1" hidden="0" type="field" name="code"/>
@@ -256,7 +152,11 @@
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform></editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -278,18 +178,29 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="3" name="id" showLabel="1"/>
+      <attributeEditorField index="2" name="display_name" showLabel="1"/>
+      <attributeEditorField index="1" name="code" showLabel="1"/>
+      <attributeEditorField index="0" name="refinement_level" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="code"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="refinement_level"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="refinement_level"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="refinement_level" expression=""/>
-    <default field="code" expression=""/>
-    <default field="display_name" expression=""/>
-    <default field="id" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_grid_refinement_area.qml
+++ b/layer_styles/schematisation/v2_grid_refinement_area.qml
@@ -1,238 +1,107 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="refinement_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="0">
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+      <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleFill">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="121,191,130,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="17,94,46,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0.46"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="dense5"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
     <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="128"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="25"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-25"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="4294967295"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="1"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>30</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+  <layerOpacity>0.7</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="-1" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="0" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="refinement_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
     <alias field="id" index="0" name=""/>
     <alias field="display_name" index="1" name=""/>
@@ -241,8 +110,29 @@
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="12451840">
+  <defaults>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="1" applyOnUpdate="0" field="refinement_level"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="display_name" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="refinement_level" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="code" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="display_name" exp=""/>
+    <constraint desc="" field="refinement_level" exp=""/>
+    <constraint desc="" field="code" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
       <column width="-1" hidden="0" type="field" name="id"/>
       <column width="-1" hidden="0" type="field" name="display_name"/>
@@ -251,7 +141,11 @@
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform></editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -273,18 +167,29 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="display_name" showLabel="1"/>
+      <attributeEditorField index="3" name="code" showLabel="1"/>
+      <attributeEditorField index="2" name="refinement_level" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="code"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="refinement_level"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="refinement_level"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="id" expression=""/>
-    <default field="display_name" expression=""/>
-    <default field="refinement_level" expression=""/>
-    <default field="code" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_groundwater.qml
+++ b/layer_styles/schematisation/v2_groundwater.qml
@@ -1,0 +1,531 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="dualview/previewExpressions">
+      <value>id</value>
+      <value>"id"</value>
+      <value>id</value>
+    </property>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="phreatic_storage_capacity_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="groundwater_hydro_connectivity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_infiltration_rate">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="groundwater_hydro_connectivity_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="equilibrium_infiltration_rate_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="maximum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="minimum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="equilibrium_infiltration_rate">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_decay_period_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_decay_period_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="maximum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="minimum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="leakage">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="groundwater_impervious_layer_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_decay_period">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="groundwater_hydro_connectivity_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="maximum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="minimum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="phreatic_storage_capacity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="groundwater_impervious_layer_level_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="maximum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="minimum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_infiltration_rate_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="maximum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="minimum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="leakage_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="phreatic_storage_capacity_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="maximum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="minimum"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="average"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initial_infiltration_rate_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="groundwater_impervious_layer_level_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="equilibrium_infiltration_rate_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="phreatic_storage_capacity_file" index="0" name=""/>
+    <alias field="groundwater_hydro_connectivity" index="1" name=""/>
+    <alias field="initial_infiltration_rate" index="2" name=""/>
+    <alias field="groundwater_hydro_connectivity_file" index="3" name=""/>
+    <alias field="equilibrium_infiltration_rate_type" index="4" name=""/>
+    <alias field="equilibrium_infiltration_rate" index="5" name=""/>
+    <alias field="id" index="6" name=""/>
+    <alias field="infiltration_decay_period_file" index="7" name=""/>
+    <alias field="display_name" index="8" name=""/>
+    <alias field="infiltration_decay_period_type" index="9" name=""/>
+    <alias field="leakage" index="10" name=""/>
+    <alias field="groundwater_impervious_layer_level" index="11" name=""/>
+    <alias field="infiltration_decay_period" index="12" name=""/>
+    <alias field="groundwater_hydro_connectivity_type" index="13" name=""/>
+    <alias field="phreatic_storage_capacity" index="14" name=""/>
+    <alias field="groundwater_impervious_layer_level_type" index="15" name=""/>
+    <alias field="initial_infiltration_rate_type" index="16" name=""/>
+    <alias field="leakage_file" index="17" name=""/>
+    <alias field="phreatic_storage_capacity_type" index="18" name=""/>
+    <alias field="initial_infiltration_rate_file" index="19" name=""/>
+    <alias field="groundwater_impervious_layer_level_file" index="20" name=""/>
+    <alias field="equilibrium_infiltration_rate_file" index="21" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="phreatic_storage_capacity_file"/>
+    <default expression="" applyOnUpdate="0" field="groundwater_hydro_connectivity"/>
+    <default expression="" applyOnUpdate="0" field="initial_infiltration_rate"/>
+    <default expression="" applyOnUpdate="0" field="groundwater_hydro_connectivity_file"/>
+    <default expression="" applyOnUpdate="0" field="equilibrium_infiltration_rate_type"/>
+    <default expression="" applyOnUpdate="0" field="equilibrium_infiltration_rate"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="infiltration_decay_period_file"/>
+    <default expression="" applyOnUpdate="0" field="display_name"/>
+    <default expression="" applyOnUpdate="0" field="infiltration_decay_period_type"/>
+    <default expression="" applyOnUpdate="0" field="leakage"/>
+    <default expression="" applyOnUpdate="0" field="groundwater_impervious_layer_level"/>
+    <default expression="" applyOnUpdate="0" field="infiltration_decay_period"/>
+    <default expression="" applyOnUpdate="0" field="groundwater_hydro_connectivity_type"/>
+    <default expression="" applyOnUpdate="0" field="phreatic_storage_capacity"/>
+    <default expression="" applyOnUpdate="0" field="groundwater_impervious_layer_level_type"/>
+    <default expression="" applyOnUpdate="0" field="initial_infiltration_rate_type"/>
+    <default expression="" applyOnUpdate="0" field="leakage_file"/>
+    <default expression="" applyOnUpdate="0" field="phreatic_storage_capacity_type"/>
+    <default expression="" applyOnUpdate="0" field="initial_infiltration_rate_file"/>
+    <default expression="" applyOnUpdate="0" field="groundwater_impervious_layer_level_file"/>
+    <default expression="" applyOnUpdate="0" field="equilibrium_infiltration_rate_file"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="phreatic_storage_capacity_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="groundwater_hydro_connectivity" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="initial_infiltration_rate" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="groundwater_hydro_connectivity_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="equilibrium_infiltration_rate_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="equilibrium_infiltration_rate" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="infiltration_decay_period_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="display_name" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="infiltration_decay_period_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="leakage" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="groundwater_impervious_layer_level" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="infiltration_decay_period" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="groundwater_hydro_connectivity_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="phreatic_storage_capacity" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="groundwater_impervious_layer_level_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="initial_infiltration_rate_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="leakage_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="phreatic_storage_capacity_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="initial_infiltration_rate_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="groundwater_impervious_layer_level_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="equilibrium_infiltration_rate_file" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="phreatic_storage_capacity_file" exp=""/>
+    <constraint desc="" field="groundwater_hydro_connectivity" exp=""/>
+    <constraint desc="" field="initial_infiltration_rate" exp=""/>
+    <constraint desc="" field="groundwater_hydro_connectivity_file" exp=""/>
+    <constraint desc="" field="equilibrium_infiltration_rate_type" exp=""/>
+    <constraint desc="" field="equilibrium_infiltration_rate" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="infiltration_decay_period_file" exp=""/>
+    <constraint desc="" field="display_name" exp=""/>
+    <constraint desc="" field="infiltration_decay_period_type" exp=""/>
+    <constraint desc="" field="leakage" exp=""/>
+    <constraint desc="" field="groundwater_impervious_layer_level" exp=""/>
+    <constraint desc="" field="infiltration_decay_period" exp=""/>
+    <constraint desc="" field="groundwater_hydro_connectivity_type" exp=""/>
+    <constraint desc="" field="phreatic_storage_capacity" exp=""/>
+    <constraint desc="" field="groundwater_impervious_layer_level_type" exp=""/>
+    <constraint desc="" field="initial_infiltration_rate_type" exp=""/>
+    <constraint desc="" field="leakage_file" exp=""/>
+    <constraint desc="" field="phreatic_storage_capacity_type" exp=""/>
+    <constraint desc="" field="initial_infiltration_rate_file" exp=""/>
+    <constraint desc="" field="groundwater_impervious_layer_level_file" exp=""/>
+    <constraint desc="" field="equilibrium_infiltration_rate_file" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="phreatic_storage_capacity_file"/>
+      <column width="-1" hidden="0" type="field" name="groundwater_hydro_connectivity"/>
+      <column width="-1" hidden="0" type="field" name="initial_infiltration_rate"/>
+      <column width="-1" hidden="0" type="field" name="groundwater_hydro_connectivity_file"/>
+      <column width="-1" hidden="0" type="field" name="equilibrium_infiltration_rate_type"/>
+      <column width="-1" hidden="0" type="field" name="equilibrium_infiltration_rate"/>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="infiltration_decay_period_file"/>
+      <column width="-1" hidden="0" type="field" name="display_name"/>
+      <column width="-1" hidden="0" type="field" name="infiltration_decay_period_type"/>
+      <column width="-1" hidden="0" type="field" name="leakage"/>
+      <column width="-1" hidden="0" type="field" name="groundwater_impervious_layer_level"/>
+      <column width="-1" hidden="0" type="field" name="infiltration_decay_period"/>
+      <column width="-1" hidden="0" type="field" name="groundwater_hydro_connectivity_type"/>
+      <column width="-1" hidden="0" type="field" name="phreatic_storage_capacity"/>
+      <column width="-1" hidden="0" type="field" name="groundwater_impervious_layer_level_type"/>
+      <column width="-1" hidden="0" type="field" name="initial_infiltration_rate_type"/>
+      <column width="-1" hidden="0" type="field" name="leakage_file"/>
+      <column width="-1" hidden="0" type="field" name="phreatic_storage_capacity_type"/>
+      <column width="-1" hidden="0" type="field" name="initial_infiltration_rate_file"/>
+      <column width="-1" hidden="0" type="field" name="groundwater_impervious_layer_level_file"/>
+      <column width="-1" hidden="0" type="field" name="equilibrium_infiltration_rate_file"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="6" name="id" showLabel="1"/>
+      <attributeEditorField index="8" name="display_name" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Equilibrium infiltration" showLabel="1" groupBox="0">
+      <attributeEditorField index="5" name="equilibrium_infiltration_rate" showLabel="1"/>
+      <attributeEditorField index="21" name="equilibrium_infiltration_rate_file" showLabel="1"/>
+      <attributeEditorField index="4" name="equilibrium_infiltration_rate_type" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Hydro connectivity" showLabel="1" groupBox="0">
+      <attributeEditorField index="1" name="groundwater_hydro_connectivity" showLabel="1"/>
+      <attributeEditorField index="3" name="groundwater_hydro_connectivity_file" showLabel="1"/>
+      <attributeEditorField index="13" name="groundwater_hydro_connectivity_type" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Impervious layer level" showLabel="1" groupBox="0">
+      <attributeEditorField index="11" name="groundwater_impervious_layer_level" showLabel="1"/>
+      <attributeEditorField index="20" name="groundwater_impervious_layer_level_file" showLabel="1"/>
+      <attributeEditorField index="15" name="groundwater_impervious_layer_level_type" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Initial infiltration" showLabel="1" groupBox="0">
+      <attributeEditorField index="2" name="initial_infiltration_rate" showLabel="1"/>
+      <attributeEditorField index="19" name="initial_infiltration_rate_file" showLabel="1"/>
+      <attributeEditorField index="16" name="initial_infiltration_rate_type" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Infiltration decay" showLabel="1" groupBox="0">
+      <attributeEditorField index="12" name="infiltration_decay_period" showLabel="1"/>
+      <attributeEditorField index="7" name="infiltration_decay_period_file" showLabel="1"/>
+      <attributeEditorField index="9" name="infiltration_decay_period_type" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Leakage" showLabel="1" groupBox="0">
+      <attributeEditorField index="10" name="leakage" showLabel="1"/>
+      <attributeEditorField index="17" name="leakage_file" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Phreatic storage capacity" showLabel="1" groupBox="0">
+      <attributeEditorField index="14" name="phreatic_storage_capacity" showLabel="1"/>
+      <attributeEditorField index="0" name="phreatic_storage_capacity_file" showLabel="1"/>
+      <attributeEditorField index="18" name="phreatic_storage_capacity_type" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="equilibrium_infiltration_rate"/>
+    <field editable="1" name="equilibrium_infiltration_rate_file"/>
+    <field editable="1" name="equilibrium_infiltration_rate_type"/>
+    <field editable="1" name="groundwater_hydro_connectivity"/>
+    <field editable="1" name="groundwater_hydro_connectivity_file"/>
+    <field editable="1" name="groundwater_hydro_connectivity_type"/>
+    <field editable="1" name="groundwater_impervious_layer_level"/>
+    <field editable="1" name="groundwater_impervious_layer_level_file"/>
+    <field editable="1" name="groundwater_impervious_layer_level_type"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="infiltration_decay_period"/>
+    <field editable="1" name="infiltration_decay_period_file"/>
+    <field editable="1" name="infiltration_decay_period_type"/>
+    <field editable="1" name="initial_infiltration_rate"/>
+    <field editable="1" name="initial_infiltration_rate_file"/>
+    <field editable="1" name="initial_infiltration_rate_type"/>
+    <field editable="1" name="leakage"/>
+    <field editable="1" name="leakage_file"/>
+    <field editable="1" name="phreatic_storage_capacity"/>
+    <field editable="1" name="phreatic_storage_capacity_file"/>
+    <field editable="1" name="phreatic_storage_capacity_type"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="equilibrium_infiltration_rate"/>
+    <field labelOnTop="0" name="equilibrium_infiltration_rate_file"/>
+    <field labelOnTop="0" name="equilibrium_infiltration_rate_type"/>
+    <field labelOnTop="0" name="groundwater_hydro_connectivity"/>
+    <field labelOnTop="0" name="groundwater_hydro_connectivity_file"/>
+    <field labelOnTop="0" name="groundwater_hydro_connectivity_type"/>
+    <field labelOnTop="0" name="groundwater_impervious_layer_level"/>
+    <field labelOnTop="0" name="groundwater_impervious_layer_level_file"/>
+    <field labelOnTop="0" name="groundwater_impervious_layer_level_type"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="infiltration_decay_period"/>
+    <field labelOnTop="0" name="infiltration_decay_period_file"/>
+    <field labelOnTop="0" name="infiltration_decay_period_type"/>
+    <field labelOnTop="0" name="initial_infiltration_rate"/>
+    <field labelOnTop="0" name="initial_infiltration_rate_file"/>
+    <field labelOnTop="0" name="initial_infiltration_rate_type"/>
+    <field labelOnTop="0" name="leakage"/>
+    <field labelOnTop="0" name="leakage_file"/>
+    <field labelOnTop="0" name="phreatic_storage_capacity"/>
+    <field labelOnTop="0" name="phreatic_storage_capacity_file"/>
+    <field labelOnTop="0" name="phreatic_storage_capacity_type"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_impervious_surface.qml
+++ b/layer_styles/schematisation/v2_impervious_surface.qml
@@ -1,226 +1,226 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+<qgis labelsEnabled="0" simplifyDrawingHints="1" simplifyAlgorithm="0" maxScale="0" simplifyMaxScale="1" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" minScale="1e+08" version="3.4.5-Madeira" styleCategories="AllStyleCategories" readOnly="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" forceraster="0">
     <rules key="{ef7b6218-5639-4216-a577-db0c96e2a759}">
-      <rule label="hellend" filter="surface_inclination = 'hellend'" symbol="0" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}"/>
-      <rule label="vlak" filter="surface_inclination = 'vlak'" symbol="1" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}"/>
-      <rule label="uitgestrekt" filter="surface_inclination = 'uitgestrekt'" symbol="2" key="{1dde8d91-4769-421d-bad7-5aa700191647}"/>
-      <rule label="gesloten verharding" filter="surface_class = 'gesloten verharding'" symbol="3" key="{9c187ace-e49a-4660-8aed-a23359e3828d}"/>
-      <rule label="open verharding" filter="surface_class = 'open verharding'" symbol="4" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}"/>
-      <rule label="onverhard" filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" symbol="5" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}"/>
-      <rule label="pand" filter="surface_class = 'pand'" symbol="6" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}"/>
+      <rule label="hellend" symbol="0" filter="surface_inclination = 'hellend'" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}"/>
+      <rule label="vlak" symbol="1" filter="surface_inclination = 'vlak'" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}"/>
+      <rule label="uitgestrekt" symbol="2" filter="surface_inclination = 'uitgestrekt'" key="{1dde8d91-4769-421d-bad7-5aa700191647}"/>
+      <rule label="gesloten verharding" symbol="3" filter="surface_class = 'gesloten verharding'" key="{9c187ace-e49a-4660-8aed-a23359e3828d}"/>
+      <rule label="open verharding" symbol="4" filter="surface_class = 'open verharding'" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}"/>
+      <rule label="onverhard" symbol="5" filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}"/>
+      <rule label="pand" symbol="6" filter="surface_class = 'pand'" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}"/>
     </rules>
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="128,152,72,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.26"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="128,152,72,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.26" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="128,128,128,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="no"/>
-          <prop k="outline_width" v="1"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="no"/>
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="128,128,128,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="no" k="outline_style"/>
+          <prop v="1" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="no" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-      <symbol name="1" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="0,0,0,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.26"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="175,179,138,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.26"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" name="1" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0,0,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.26" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="128,128,128,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="no"/>
-          <prop k="outline_width" v="1"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="no"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="117,117,117,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="117,117,117,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol force_rhr="0" name="2" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="175,179,138,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.26" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="128,128,128,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="no" k="outline_style"/>
+          <prop v="1" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="no" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="182,182,182,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="182,182,182,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol force_rhr="0" name="3" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="117,117,117,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="117,117,117,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="186,221,105,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="186,221,105,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol force_rhr="0" name="4" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="182,182,182,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="182,182,182,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="170,85,255,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="170,85,255,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol force_rhr="0" name="5" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="186,221,105,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="186,221,105,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" name="6" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="170,85,255,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="170,85,255,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -228,36 +228,36 @@
     </symbols>
   </renderer-v2>
   <customproperties>
-    <property value="display_name" key="dualview/previewExpressions"/>
-    <property value="0" key="embeddedWidgets/count"/>
+    <property key="dualview/previewExpressions" value="display_name"/>
+    <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" penAlpha="255" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" penColor="#000000" opacity="1" enabled="0" labelPlacementMethod="XHeight" penWidth="0" rotationOffset="270" lineSizeType="MM" backgroundColor="#ffffff" height="15" sizeType="MM" minScaleDenominator="0" minimumSize="0" scaleBasedVisibility="0" width="15">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
       <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings placement="0" dist="0" showAll="1" priority="0" obstacle="0" zIndex="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties" type="Map">
           <Option name="show" type="Map">
-            <Option name="active" value="true" type="bool"/>
-            <Option name="field" value="function" type="QString"/>
-            <Option name="type" value="2" type="int"/>
+            <Option name="active" type="bool" value="true"/>
+            <Option name="field" type="QString" value="function"/>
+            <Option name="type" type="int" value="2"/>
           </Option>
         </Option>
-        <Option name="type" value="collection" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -266,8 +266,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -278,19 +278,19 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="gesloten verharding" value="gesloten verharding" type="QString"/>
+                <Option name="gesloten verharding" type="QString" value="gesloten verharding"/>
               </Option>
               <Option type="Map">
-                <Option name="open verharding" value="open verharding" type="QString"/>
+                <Option name="open verharding" type="QString" value="open verharding"/>
               </Option>
               <Option type="Map">
-                <Option name="half verhard" value="half verhard" type="QString"/>
+                <Option name="half verhard" type="QString" value="half verhard"/>
               </Option>
               <Option type="Map">
-                <Option name="onverhard" value="onverhard" type="QString"/>
+                <Option name="onverhard" type="QString" value="onverhard"/>
               </Option>
               <Option type="Map">
-                <Option name="pand" value="pand" type="QString"/>
+                <Option name="pand" type="QString" value="pand"/>
               </Option>
             </Option>
           </Option>
@@ -301,8 +301,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -311,8 +311,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -321,8 +321,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -333,25 +333,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option name="-1" type="QString" value="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option name="0" type="QString" value="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option name="1" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option name="2" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option name="3" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option name="4" type="QString" value="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option name="5" type="QString" value="5"/>
               </Option>
             </Option>
           </Option>
@@ -362,8 +362,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -372,8 +372,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -382,8 +382,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -394,13 +394,13 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="vlak" value="vlak" type="QString"/>
+                <Option name="vlak" type="QString" value="vlak"/>
               </Option>
               <Option type="Map">
-                <Option name="hellend" value="hellend" type="QString"/>
+                <Option name="hellend" type="QString" value="hellend"/>
               </Option>
               <Option type="Map">
-                <Option name="uitgestrekt" value="uitgestrekt" type="QString"/>
+                <Option name="uitgestrekt" type="QString" value="uitgestrekt"/>
               </Option>
             </Option>
           </Option>
@@ -411,85 +411,85 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="function"/>
-    <alias name="" index="1" field="surface_class"/>
-    <alias name="" index="2" field="code"/>
-    <alias name="" index="3" field="display_name"/>
-    <alias name="" index="4" field="surface_sub_class"/>
-    <alias name="" index="5" field="zoom_category"/>
-    <alias name="" index="6" field="nr_of_inhabitants"/>
-    <alias name="" index="7" field="area"/>
-    <alias name="" index="8" field="dry_weather_flow"/>
-    <alias name="" index="9" field="surface_inclination"/>
-    <alias name="" index="10" field="id"/>
+    <alias index="0" name="" field="function"/>
+    <alias index="1" name="" field="surface_class"/>
+    <alias index="2" name="" field="code"/>
+    <alias index="3" name="" field="display_name"/>
+    <alias index="4" name="" field="surface_sub_class"/>
+    <alias index="5" name="" field="zoom_category"/>
+    <alias index="6" name="" field="nr_of_inhabitants"/>
+    <alias index="7" name="" field="area"/>
+    <alias index="8" name="" field="dry_weather_flow"/>
+    <alias index="9" name="" field="surface_inclination"/>
+    <alias index="10" name="" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="function" expression=""/>
-    <default applyOnUpdate="0" field="surface_class" expression=""/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="surface_sub_class" expression=""/>
-    <default applyOnUpdate="0" field="zoom_category" expression="-1"/>
-    <default applyOnUpdate="0" field="nr_of_inhabitants" expression="0"/>
-    <default applyOnUpdate="0" field="area" expression="$area"/>
-    <default applyOnUpdate="0" field="dry_weather_flow" expression=""/>
-    <default applyOnUpdate="0" field="surface_inclination" expression=""/>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default expression="" applyOnUpdate="0" field="function"/>
+    <default expression="" applyOnUpdate="0" field="surface_class"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="" applyOnUpdate="0" field="surface_sub_class"/>
+    <default expression="-1" applyOnUpdate="0" field="zoom_category"/>
+    <default expression="0" applyOnUpdate="0" field="nr_of_inhabitants"/>
+    <default expression="round($area,1)" applyOnUpdate="0" field="area"/>
+    <default expression="" applyOnUpdate="0" field="dry_weather_flow"/>
+    <default expression="" applyOnUpdate="0" field="surface_inclination"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="function" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_class" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="surface_sub_class" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="nr_of_inhabitants" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="area" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dry_weather_flow" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_inclination" unique_strength="0"/>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint unique_strength="0" field="function" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="surface_class" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="code" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="display_name" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="surface_sub_class" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="zoom_category" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="nr_of_inhabitants" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="area" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="dry_weather_flow" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="surface_inclination" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="1" field="id" exp_strength="0" notnull_strength="1" constraints="3"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="function" desc=""/>
-    <constraint exp="" field="surface_class" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="surface_sub_class" desc=""/>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="nr_of_inhabitants" desc=""/>
-    <constraint exp="" field="area" desc=""/>
-    <constraint exp="" field="dry_weather_flow" desc=""/>
-    <constraint exp="" field="surface_inclination" desc=""/>
-    <constraint exp="" field="id" desc=""/>
+    <constraint field="function" exp="" desc=""/>
+    <constraint field="surface_class" exp="" desc=""/>
+    <constraint field="code" exp="" desc=""/>
+    <constraint field="display_name" exp="" desc=""/>
+    <constraint field="surface_sub_class" exp="" desc=""/>
+    <constraint field="zoom_category" exp="" desc=""/>
+    <constraint field="nr_of_inhabitants" exp="" desc=""/>
+    <constraint field="area" exp="" desc=""/>
+    <constraint field="dry_weather_flow" exp="" desc=""/>
+    <constraint field="surface_inclination" exp="" desc=""/>
+    <constraint field="id" exp="" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
-      <column name="function" hidden="0" width="-1" type="field"/>
-      <column name="surface_class" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="surface_sub_class" hidden="0" width="-1" type="field"/>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="nr_of_inhabitants" hidden="0" width="-1" type="field"/>
-      <column name="area" hidden="0" width="-1" type="field"/>
-      <column name="dry_weather_flow" hidden="0" width="-1" type="field"/>
-      <column name="surface_inclination" hidden="0" width="-1" type="field"/>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column hidden="0" name="function" type="field" width="-1"/>
+      <column hidden="0" name="surface_class" type="field" width="-1"/>
+      <column hidden="0" name="code" type="field" width="-1"/>
+      <column hidden="0" name="display_name" type="field" width="-1"/>
+      <column hidden="0" name="surface_sub_class" type="field" width="-1"/>
+      <column hidden="0" name="zoom_category" type="field" width="-1"/>
+      <column hidden="0" name="nr_of_inhabitants" type="field" width="-1"/>
+      <column hidden="0" name="area" type="field" width="-1"/>
+      <column hidden="0" name="dry_weather_flow" type="field" width="-1"/>
+      <column hidden="0" name="surface_inclination" type="field" width="-1"/>
+      <column hidden="0" name="id" type="field" width="-1"/>
+      <column hidden="1" type="actions" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -518,27 +518,27 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Impervious surface" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="10" showLabel="1"/>
-        <attributeEditorField name="display_name" index="3" showLabel="1"/>
-        <attributeEditorField name="code" index="2" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" name="Impervious surface" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+        <attributeEditorField showLabel="1" index="10" name="id"/>
+        <attributeEditorField showLabel="1" index="3" name="display_name"/>
+        <attributeEditorField showLabel="1" index="2" name="code"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorContainer name="Storm water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-          <attributeEditorField name="surface_class" index="1" showLabel="1"/>
-          <attributeEditorField name="surface_sub_class" index="4" showLabel="1"/>
-          <attributeEditorField name="surface_inclination" index="9" showLabel="1"/>
-          <attributeEditorField name="area" index="7" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+        <attributeEditorContainer showLabel="1" name="Storm water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+          <attributeEditorField showLabel="1" index="1" name="surface_class"/>
+          <attributeEditorField showLabel="1" index="4" name="surface_sub_class"/>
+          <attributeEditorField showLabel="1" index="9" name="surface_inclination"/>
+          <attributeEditorField showLabel="1" index="7" name="area"/>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Municipal water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-          <attributeEditorField name="dry_weather_flow" index="8" showLabel="1"/>
-          <attributeEditorField name="nr_of_inhabitants" index="6" showLabel="1"/>
+        <attributeEditorContainer showLabel="1" name="Municipal water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+          <attributeEditorField showLabel="1" index="8" name="dry_weather_flow"/>
+          <attributeEditorField showLabel="1" index="6" name="nr_of_inhabitants"/>
         </attributeEditorContainer>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="5" showLabel="1"/>
-        <attributeEditorField name="function" index="0" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+        <attributeEditorField showLabel="1" index="5" name="zoom_category"/>
+        <attributeEditorField showLabel="1" index="0" name="function"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_impervious_surface.qml
+++ b/layer_styles/schematisation/v2_impervious_surface.qml
@@ -1,23 +1,23 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+<qgis maxScale="0" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="RuleRenderer">
     <rules key="{ef7b6218-5639-4216-a577-db0c96e2a759}">
-      <rule label="hellend" filter="surface_inclination = 'hellend'" symbol="0" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}"/>
-      <rule label="vlak" filter="surface_inclination = 'vlak'" symbol="1" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}"/>
-      <rule label="uitgestrekt" filter="surface_inclination = 'uitgestrekt'" symbol="2" key="{1dde8d91-4769-421d-bad7-5aa700191647}"/>
-      <rule label="gesloten verharding" filter="surface_class = 'gesloten verharding'" symbol="3" key="{9c187ace-e49a-4660-8aed-a23359e3828d}"/>
-      <rule label="open verharding" filter="surface_class = 'open verharding'" symbol="4" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}"/>
-      <rule label="onverhard" filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" symbol="5" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}"/>
-      <rule label="pand" filter="surface_class = 'pand'" symbol="6" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}"/>
+      <rule filter="surface_inclination = 'hellend'" label="hellend" symbol="0" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}"/>
+      <rule filter="surface_inclination = 'vlak'" label="vlak" symbol="1" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}"/>
+      <rule filter="surface_inclination = 'uitgestrekt'" label="uitgestrekt" symbol="2" key="{1dde8d91-4769-421d-bad7-5aa700191647}"/>
+      <rule filter="surface_class = 'gesloten verharding'" label="gesloten verharding" symbol="3" key="{9c187ace-e49a-4660-8aed-a23359e3828d}"/>
+      <rule filter="surface_class = 'open verharding'" label="open verharding" symbol="4" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}"/>
+      <rule filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" label="onverhard" symbol="5" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}"/>
+      <rule filter="surface_class = 'pand'" label="pand" symbol="6" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}"/>
     </rules>
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="0" type="fill" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -36,13 +36,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="128,128,128,255"/>
           <prop k="joinstyle" v="bevel"/>
@@ -56,15 +56,15 @@
           <prop k="style" v="no"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="1" type="fill" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -83,15 +83,15 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="2" type="fill" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -110,13 +110,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="128,128,128,255"/>
           <prop k="joinstyle" v="bevel"/>
@@ -130,15 +130,15 @@
           <prop k="style" v="no"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="3" type="fill" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="117,117,117,255"/>
           <prop k="joinstyle" v="bevel"/>
@@ -152,15 +152,15 @@
           <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="4" type="fill" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="182,182,182,255"/>
           <prop k="joinstyle" v="bevel"/>
@@ -174,15 +174,15 @@
           <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="5" type="fill" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="186,221,105,255"/>
           <prop k="joinstyle" v="bevel"/>
@@ -196,15 +196,15 @@
           <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" alpha="1" name="6" type="fill" force_rhr="0">
+        <layer enabled="1" locked="0" pass="0" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="170,85,255,255"/>
           <prop k="joinstyle" v="bevel"/>
@@ -218,9 +218,9 @@
           <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -236,28 +236,28 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="0" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties" type="Map">
           <Option name="show" type="Map">
-            <Option name="active" value="true" type="bool"/>
-            <Option name="field" value="function" type="QString"/>
-            <Option name="type" value="2" type="int"/>
+            <Option value="true" name="active" type="bool"/>
+            <Option value="function" name="field" type="QString"/>
+            <Option value="2" name="type" type="int"/>
           </Option>
         </Option>
-        <Option name="type" value="collection" type="QString"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -266,8 +266,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -278,19 +278,19 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="gesloten verharding" value="gesloten verharding" type="QString"/>
+                <Option value="gesloten verharding" name="gesloten verharding" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="open verharding" value="open verharding" type="QString"/>
+                <Option value="open verharding" name="open verharding" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="half verhard" value="half verhard" type="QString"/>
+                <Option value="half verhard" name="half verhard" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="onverhard" value="onverhard" type="QString"/>
+                <Option value="onverhard" name="onverhard" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="pand" value="pand" type="QString"/>
+                <Option value="pand" name="pand" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -301,8 +301,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -311,8 +311,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -321,8 +321,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -333,25 +333,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" name="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" name="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" name="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" name="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" name="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" name="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" name="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -362,8 +362,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -372,8 +372,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -382,8 +382,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -394,13 +394,13 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="vlak" value="vlak" type="QString"/>
+                <Option value="vlak" name="vlak" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="hellend" value="hellend" type="QString"/>
+                <Option value="hellend" name="hellend" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="uitgestrekt" value="uitgestrekt" type="QString"/>
+                <Option value="uitgestrekt" name="uitgestrekt" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -411,85 +411,85 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="function"/>
-    <alias name="" index="1" field="surface_class"/>
-    <alias name="" index="2" field="code"/>
-    <alias name="" index="3" field="display_name"/>
-    <alias name="" index="4" field="surface_sub_class"/>
-    <alias name="" index="5" field="zoom_category"/>
-    <alias name="" index="6" field="nr_of_inhabitants"/>
-    <alias name="" index="7" field="area"/>
-    <alias name="" index="8" field="dry_weather_flow"/>
-    <alias name="" index="9" field="surface_inclination"/>
-    <alias name="" index="10" field="id"/>
+    <alias index="0" name="" field="function"/>
+    <alias index="1" name="" field="surface_class"/>
+    <alias index="2" name="" field="code"/>
+    <alias index="3" name="" field="display_name"/>
+    <alias index="4" name="" field="surface_sub_class"/>
+    <alias index="5" name="" field="zoom_category"/>
+    <alias index="6" name="" field="nr_of_inhabitants"/>
+    <alias index="7" name="" field="area"/>
+    <alias index="8" name="" field="dry_weather_flow"/>
+    <alias index="9" name="" field="surface_inclination"/>
+    <alias index="10" name="" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="function" expression=""/>
-    <default applyOnUpdate="0" field="surface_class" expression=""/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="surface_sub_class" expression=""/>
-    <default applyOnUpdate="0" field="zoom_category" expression="-1"/>
-    <default applyOnUpdate="0" field="nr_of_inhabitants" expression="0"/>
-    <default applyOnUpdate="0" field="area" expression="$area"/>
-    <default applyOnUpdate="0" field="dry_weather_flow" expression=""/>
-    <default applyOnUpdate="0" field="surface_inclination" expression=""/>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default applyOnUpdate="0" expression="" field="function"/>
+    <default applyOnUpdate="0" expression="" field="surface_class"/>
+    <default applyOnUpdate="0" expression="'new'" field="code"/>
+    <default applyOnUpdate="0" expression="'new'" field="display_name"/>
+    <default applyOnUpdate="0" expression="" field="surface_sub_class"/>
+    <default applyOnUpdate="0" expression="-1" field="zoom_category"/>
+    <default applyOnUpdate="0" expression="" field="nr_of_inhabitants"/>
+    <default applyOnUpdate="0" expression="$area" field="area"/>
+    <default applyOnUpdate="0" expression="" field="dry_weather_flow"/>
+    <default applyOnUpdate="0" expression="" field="surface_inclination"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="function" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_class" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="surface_sub_class" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="nr_of_inhabitants" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="area" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dry_weather_flow" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_inclination" unique_strength="0"/>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="0" field="function" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="surface_class" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="display_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="surface_sub_class" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="zoom_category" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="nr_of_inhabitants" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="area" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="dry_weather_flow" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="surface_inclination" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="function" desc=""/>
-    <constraint exp="" field="surface_class" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="surface_sub_class" desc=""/>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="nr_of_inhabitants" desc=""/>
-    <constraint exp="" field="area" desc=""/>
-    <constraint exp="" field="dry_weather_flow" desc=""/>
-    <constraint exp="" field="surface_inclination" desc=""/>
-    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" desc="" field="function"/>
+    <constraint exp="" desc="" field="surface_class"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="surface_sub_class"/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="nr_of_inhabitants"/>
+    <constraint exp="" desc="" field="area"/>
+    <constraint exp="" desc="" field="dry_weather_flow"/>
+    <constraint exp="" desc="" field="surface_inclination"/>
+    <constraint exp="" desc="" field="id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column name="function" hidden="0" width="-1" type="field"/>
-      <column name="surface_class" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="surface_sub_class" hidden="0" width="-1" type="field"/>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="nr_of_inhabitants" hidden="0" width="-1" type="field"/>
-      <column name="area" hidden="0" width="-1" type="field"/>
-      <column name="dry_weather_flow" hidden="0" width="-1" type="field"/>
-      <column name="surface_inclination" hidden="0" width="-1" type="field"/>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" hidden="0" name="function" type="field"/>
+      <column width="-1" hidden="0" name="surface_class" type="field"/>
+      <column width="-1" hidden="0" name="code" type="field"/>
+      <column width="-1" hidden="0" name="display_name" type="field"/>
+      <column width="-1" hidden="0" name="surface_sub_class" type="field"/>
+      <column width="-1" hidden="0" name="zoom_category" type="field"/>
+      <column width="-1" hidden="0" name="nr_of_inhabitants" type="field"/>
+      <column width="-1" hidden="0" name="area" type="field"/>
+      <column width="-1" hidden="0" name="dry_weather_flow" type="field"/>
+      <column width="-1" hidden="0" name="surface_inclination" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -518,55 +518,55 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Impervious surface" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="10" showLabel="1"/>
-        <attributeEditorField name="display_name" index="3" showLabel="1"/>
-        <attributeEditorField name="code" index="2" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Impervious surface" groupBox="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="10" name="id"/>
+        <attributeEditorField showLabel="1" index="3" name="display_name"/>
+        <attributeEditorField showLabel="1" index="2" name="code"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorContainer name="Storm water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-          <attributeEditorField name="surface_class" index="1" showLabel="1"/>
-          <attributeEditorField name="surface_sub_class" index="4" showLabel="1"/>
-          <attributeEditorField name="surface_inclination" index="9" showLabel="1"/>
-          <attributeEditorField name="area" index="7" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Storm water" groupBox="1" visibilityExpressionEnabled="0">
+          <attributeEditorField showLabel="1" index="1" name="surface_class"/>
+          <attributeEditorField showLabel="1" index="4" name="surface_sub_class"/>
+          <attributeEditorField showLabel="1" index="9" name="surface_inclination"/>
+          <attributeEditorField showLabel="1" index="7" name="area"/>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Municipal water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-          <attributeEditorField name="dry_weather_flow" index="8" showLabel="1"/>
-          <attributeEditorField name="nr_of_inhabitants" index="6" showLabel="1"/>
+        <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Municipal water" groupBox="1" visibilityExpressionEnabled="0">
+          <attributeEditorField showLabel="1" index="8" name="dry_weather_flow"/>
+          <attributeEditorField showLabel="1" index="6" name="nr_of_inhabitants"/>
         </attributeEditorContainer>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="5" showLabel="1"/>
-        <attributeEditorField name="function" index="0" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="5" name="zoom_category"/>
+        <attributeEditorField showLabel="1" index="0" name="function"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="area" editable="1"/>
-    <field name="code" editable="1"/>
-    <field name="display_name" editable="1"/>
-    <field name="dry_weather_flow" editable="1"/>
-    <field name="function" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="nr_of_inhabitants" editable="1"/>
-    <field name="surface_class" editable="1"/>
-    <field name="surface_inclination" editable="1"/>
-    <field name="surface_sub_class" editable="1"/>
-    <field name="zoom_category" editable="1"/>
+    <field editable="1" name="area"/>
+    <field editable="1" name="code"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="dry_weather_flow"/>
+    <field editable="1" name="function"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="nr_of_inhabitants"/>
+    <field editable="1" name="surface_class"/>
+    <field editable="1" name="surface_inclination"/>
+    <field editable="1" name="surface_sub_class"/>
+    <field editable="1" name="zoom_category"/>
   </editable>
   <labelOnTop>
-    <field name="area" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="dry_weather_flow" labelOnTop="0"/>
-    <field name="function" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="nr_of_inhabitants" labelOnTop="0"/>
-    <field name="surface_class" labelOnTop="0"/>
-    <field name="surface_inclination" labelOnTop="0"/>
-    <field name="surface_sub_class" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="area"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="dry_weather_flow"/>
+    <field labelOnTop="0" name="function"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="nr_of_inhabitants"/>
+    <field labelOnTop="0" name="surface_class"/>
+    <field labelOnTop="0" name="surface_inclination"/>
+    <field labelOnTop="0" name="surface_sub_class"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_impervious_surface.qml
+++ b/layer_styles/schematisation/v2_impervious_surface.qml
@@ -1,56 +1,26 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.20" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="function">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="surface_class">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="surface_sub_class">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="nr_of_inhabitants">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="area">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="dry_weather_flow">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="surface_inclination">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" symbollevels="0">
     <rules key="{ef7b6218-5639-4216-a577-db0c96e2a759}">
-      <rule filter="surface_inclination = 'hellend'" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}" symbol="0" label="hellend"/>
-      <rule filter="surface_inclination = 'vlak'" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}" symbol="1" label="vlak"/>
-      <rule filter="surface_inclination = 'uitgestrekt'" key="{1dde8d91-4769-421d-bad7-5aa700191647}" symbol="2" label="uitgestrekt"/>
-      <rule filter="surface_class = 'gesloten verharding'" key="{9c187ace-e49a-4660-8aed-a23359e3828d}" symbol="3" label="gesloten verharding"/>
-      <rule filter="surface_class = 'open verharding'" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}" symbol="4" label="open verharding"/>
-      <rule filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}" symbol="5" label="onverhard"/>
-      <rule filter="surface_class = 'pand'" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}" symbol="6" label="pand"/>
+      <rule label="hellend" filter="surface_inclination = 'hellend'" symbol="0" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}"/>
+      <rule label="vlak" filter="surface_inclination = 'vlak'" symbol="1" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}"/>
+      <rule label="uitgestrekt" filter="surface_inclination = 'uitgestrekt'" symbol="2" key="{1dde8d91-4769-421d-bad7-5aa700191647}"/>
+      <rule label="gesloten verharding" filter="surface_class = 'gesloten verharding'" symbol="3" key="{9c187ace-e49a-4660-8aed-a23359e3828d}"/>
+      <rule label="open verharding" filter="surface_class = 'open verharding'" symbol="4" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}"/>
+      <rule label="onverhard" filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" symbol="5" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}"/>
+      <rule label="pand" filter="surface_class = 'pand'" symbol="6" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}"/>
     </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="0" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -59,30 +29,45 @@
           <prop k="line_width" v="0.26"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="128,128,128,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="no"/>
           <prop k="outline_width" v="1"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="no"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="1">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="1" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -91,17 +76,25 @@
           <prop k="line_width" v="0.26"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="2">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="2" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -110,342 +103,400 @@
           <prop k="line_width" v="0.26"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="128,128,128,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="no"/>
           <prop k="outline_width" v="1"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="no"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="3">
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+      <symbol name="3" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="117,117,117,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="117,117,117,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0.26"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="4">
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+      <symbol name="4" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="182,182,182,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="182,182,182,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0.26"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="5">
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+      <symbol name="5" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="186,221,105,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="186,221,105,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0.26"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="6">
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+      <symbol name="6" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="170,85,255,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="170,85,255,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0.26"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="Ubuntu"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Medium Italic"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="1"/>
-    <property key="labeling/placementFlags" value="0"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
+    <property value="display_name" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings placement="0" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties" type="Map">
+          <Option name="show" type="Map">
+            <Option name="active" value="true" type="bool"/>
+            <Option name="field" value="function" type="QString"/>
+            <Option name="type" value="2" type="int"/>
+          </Option>
+        </Option>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="function">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_class">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="gesloten verharding" value="gesloten verharding" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="open verharding" value="open verharding" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="half verhard" value="half verhard" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="onverhard" value="onverhard" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="pand" value="pand" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_sub_class">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="nr_of_inhabitants">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dry_weather_flow">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_inclination">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="vlak" value="vlak" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="hellend" value="hellend" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="uitgestrekt" value="uitgestrekt" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
-    <alias field="function" index="0" name=""/>
-    <alias field="surface_class" index="1" name=""/>
-    <alias field="code" index="2" name=""/>
-    <alias field="display_name" index="3" name=""/>
-    <alias field="surface_sub_class" index="4" name=""/>
-    <alias field="zoom_category" index="5" name=""/>
-    <alias field="nr_of_inhabitants" index="6" name=""/>
-    <alias field="area" index="7" name=""/>
-    <alias field="dry_weather_flow" index="8" name=""/>
-    <alias field="surface_inclination" index="9" name=""/>
-    <alias field="id" index="10" name=""/>
+    <alias name="" index="0" field="function"/>
+    <alias name="" index="1" field="surface_class"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="display_name"/>
+    <alias name="" index="4" field="surface_sub_class"/>
+    <alias name="" index="5" field="zoom_category"/>
+    <alias name="" index="6" field="nr_of_inhabitants"/>
+    <alias name="" index="7" field="area"/>
+    <alias name="" index="8" field="dry_weather_flow"/>
+    <alias name="" index="9" field="surface_inclination"/>
+    <alias name="" index="10" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <defaults>
+    <default applyOnUpdate="0" field="function" expression=""/>
+    <default applyOnUpdate="0" field="surface_class" expression=""/>
+    <default applyOnUpdate="0" field="code" expression="'new'"/>
+    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="surface_sub_class" expression=""/>
+    <default applyOnUpdate="0" field="zoom_category" expression="-1"/>
+    <default applyOnUpdate="0" field="nr_of_inhabitants" expression="0"/>
+    <default applyOnUpdate="0" field="area" expression="$area"/>
+    <default applyOnUpdate="0" field="dry_weather_flow" expression=""/>
+    <default applyOnUpdate="0" field="surface_inclination" expression=""/>
+    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="function" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_class" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="surface_sub_class" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="nr_of_inhabitants" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="area" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dry_weather_flow" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_inclination" unique_strength="0"/>
+    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="function" desc=""/>
+    <constraint exp="" field="surface_class" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="surface_sub_class" desc=""/>
+    <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" field="nr_of_inhabitants" desc=""/>
+    <constraint exp="" field="area" desc=""/>
+    <constraint exp="" field="dry_weather_flow" desc=""/>
+    <constraint exp="" field="surface_inclination" desc=""/>
+    <constraint exp="" field="id" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
-      <column width="-1" hidden="0" type="field" name="function"/>
-      <column width="-1" hidden="0" type="field" name="surface_class"/>
-      <column width="-1" hidden="0" type="field" name="code"/>
-      <column width="-1" hidden="0" type="field" name="display_name"/>
-      <column width="-1" hidden="0" type="field" name="surface_sub_class"/>
-      <column width="-1" hidden="0" type="field" name="zoom_category"/>
-      <column width="-1" hidden="0" type="field" name="nr_of_inhabitants"/>
-      <column width="-1" hidden="0" type="field" name="area"/>
-      <column width="-1" hidden="0" type="field" name="dry_weather_flow"/>
-      <column width="-1" hidden="0" type="field" name="surface_inclination"/>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="1" type="actions"/>
+      <column name="function" hidden="0" width="-1" type="field"/>
+      <column name="surface_class" hidden="0" width="-1" type="field"/>
+      <column name="code" hidden="0" width="-1" type="field"/>
+      <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="surface_sub_class" hidden="0" width="-1" type="field"/>
+      <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="nr_of_inhabitants" hidden="0" width="-1" type="field"/>
+      <column name="area" hidden="0" width="-1" type="field"/>
+      <column name="dry_weather_flow" hidden="0" width="-1" type="field"/>
+      <column name="surface_inclination" hidden="0" width="-1" type="field"/>
+      <column name="id" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform>.</editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -465,25 +516,60 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Impervious surface" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="id" index="10" showLabel="1"/>
+        <attributeEditorField name="display_name" index="3" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorContainer name="Storm water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="surface_class" index="1" showLabel="1"/>
+          <attributeEditorField name="surface_sub_class" index="4" showLabel="1"/>
+          <attributeEditorField name="surface_inclination" index="9" showLabel="1"/>
+          <attributeEditorField name="area" index="7" showLabel="1"/>
+        </attributeEditorContainer>
+        <attributeEditorContainer name="Municipal water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="dry_weather_flow" index="8" showLabel="1"/>
+          <attributeEditorField name="nr_of_inhabitants" index="6" showLabel="1"/>
+        </attributeEditorContainer>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="zoom_category" index="5" showLabel="1"/>
+        <attributeEditorField name="function" index="0" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="area" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="display_name" editable="1"/>
+    <field name="dry_weather_flow" editable="1"/>
+    <field name="function" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="nr_of_inhabitants" editable="1"/>
+    <field name="surface_class" editable="1"/>
+    <field name="surface_inclination" editable="1"/>
+    <field name="surface_sub_class" editable="1"/>
+    <field name="zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="area" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="display_name" labelOnTop="0"/>
+    <field name="dry_weather_flow" labelOnTop="0"/>
+    <field name="function" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="nr_of_inhabitants" labelOnTop="0"/>
+    <field name="surface_class" labelOnTop="0"/>
+    <field name="surface_inclination" labelOnTop="0"/>
+    <field name="surface_sub_class" labelOnTop="0"/>
+    <field name="zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="function" expression=""/>
-    <default field="surface_class" expression=""/>
-    <default field="code" expression=""/>
-    <default field="display_name" expression=""/>
-    <default field="surface_sub_class" expression=""/>
-    <default field="zoom_category" expression=""/>
-    <default field="nr_of_inhabitants" expression=""/>
-    <default field="area" expression=""/>
-    <default field="dry_weather_flow" expression=""/>
-    <default field="surface_inclination" expression=""/>
-    <default field="id" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_impervious_surface.qml
+++ b/layer_styles/schematisation/v2_impervious_surface.qml
@@ -278,19 +278,19 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option value="gesloten verharding" name="gesloten verharding" type="QString"/>
+                <Option value="gesloten verharding" name="impervious paving (gesloten verharding)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="open verharding" name="open verharding" type="QString"/>
+                <Option value="open verharding" name="pervious paving (open verharding)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="half verhard" name="half verhard" type="QString"/>
+                <Option value="half verhard" name="semi-pervious paving (half verhard)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="onverhard" name="onverhard" type="QString"/>
+                <Option value="onverhard" name="unpaved (onverhard)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="pand" name="pand" type="QString"/>
+                <Option value="pand" name="building (pand)" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -394,13 +394,13 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option value="vlak" name="vlak" type="QString"/>
+                <Option value="vlak" name="level (vlak)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="hellend" name="hellend" type="QString"/>
+                <Option value="hellend" name="inclined (hellend)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="uitgestrekt" name="uitgestrekt" type="QString"/>
+                <Option value="uitgestrekt" name="elongated&#xa; (uitgestrekt)" type="QString"/>
               </Option>
             </Option>
           </Option>

--- a/layer_styles/schematisation/v2_impervious_surface.qml
+++ b/layer_styles/schematisation/v2_impervious_surface.qml
@@ -1,226 +1,226 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" simplifyDrawingHints="1" simplifyAlgorithm="0" maxScale="0" simplifyMaxScale="1" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" minScale="1e+08" version="3.4.5-Madeira" styleCategories="AllStyleCategories" readOnly="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" forceraster="0">
+  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" symbollevels="0">
     <rules key="{ef7b6218-5639-4216-a577-db0c96e2a759}">
-      <rule label="hellend" symbol="0" filter="surface_inclination = 'hellend'" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}"/>
-      <rule label="vlak" symbol="1" filter="surface_inclination = 'vlak'" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}"/>
-      <rule label="uitgestrekt" symbol="2" filter="surface_inclination = 'uitgestrekt'" key="{1dde8d91-4769-421d-bad7-5aa700191647}"/>
-      <rule label="gesloten verharding" symbol="3" filter="surface_class = 'gesloten verharding'" key="{9c187ace-e49a-4660-8aed-a23359e3828d}"/>
-      <rule label="open verharding" symbol="4" filter="surface_class = 'open verharding'" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}"/>
-      <rule label="onverhard" symbol="5" filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}"/>
-      <rule label="pand" symbol="6" filter="surface_class = 'pand'" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}"/>
+      <rule label="hellend" filter="surface_inclination = 'hellend'" symbol="0" key="{68cb011a-8a27-4aa2-a23d-858ba251f42b}"/>
+      <rule label="vlak" filter="surface_inclination = 'vlak'" symbol="1" key="{91463b0e-a824-4df0-a0bd-8dcb0b5f2094}"/>
+      <rule label="uitgestrekt" filter="surface_inclination = 'uitgestrekt'" symbol="2" key="{1dde8d91-4769-421d-bad7-5aa700191647}"/>
+      <rule label="gesloten verharding" filter="surface_class = 'gesloten verharding'" symbol="3" key="{9c187ace-e49a-4660-8aed-a23359e3828d}"/>
+      <rule label="open verharding" filter="surface_class = 'open verharding'" symbol="4" key="{bfb69c3c-b9b3-4865-94cb-7ea349f429dc}"/>
+      <rule label="onverhard" filter="surface_class = 'half verhard' OR surface_class = 'onverhard'" symbol="5" key="{1ee7fc0c-ce99-4a36-83c1-10163a3ae8b3}"/>
+      <rule label="pand" filter="surface_class = 'pand'" symbol="6" key="{32d556c3-f4d6-49ff-808b-ebc499c1f5f1}"/>
     </rules>
     <symbols>
-      <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="128,152,72,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.26" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="0" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="128,152,72,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="128,128,128,255" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="no" k="outline_style"/>
-          <prop v="1" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="no" k="style"/>
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="128,128,128,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="no"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-      <symbol force_rhr="0" name="1" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0,0,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.26" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" type="QString" value=""/>
-              <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" name="2" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="175,179,138,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.26" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="1" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="128,128,128,255" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="no" k="outline_style"/>
-          <prop v="1" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="no" k="style"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" type="QString" value=""/>
-              <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" name="3" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="117,117,117,255" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="117,117,117,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.26" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+      <symbol name="2" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="175,179,138,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="128,128,128,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="no"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" name="4" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="182,182,182,255" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="182,182,182,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.26" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+      <symbol name="3" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="117,117,117,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="117,117,117,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" name="5" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="186,221,105,255" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="186,221,105,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.26" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+      <symbol name="4" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="182,182,182,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="182,182,182,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" name="6" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="170,85,255,255" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="170,85,255,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.26" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+      <symbol name="5" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="186,221,105,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="186,221,105,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="6" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="170,85,255,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="170,85,255,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -228,36 +228,36 @@
     </symbols>
   </renderer-v2>
   <customproperties>
-    <property key="dualview/previewExpressions" value="display_name"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="display_name" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" penAlpha="255" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" penColor="#000000" opacity="1" enabled="0" labelPlacementMethod="XHeight" penWidth="0" rotationOffset="270" lineSizeType="MM" backgroundColor="#ffffff" height="15" sizeType="MM" minScaleDenominator="0" minimumSize="0" scaleBasedVisibility="0" width="15">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
       <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" dist="0" showAll="1" priority="0" obstacle="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings placement="0" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option name="name" value="" type="QString"/>
         <Option name="properties" type="Map">
           <Option name="show" type="Map">
-            <Option name="active" type="bool" value="true"/>
-            <Option name="field" type="QString" value="function"/>
-            <Option name="type" type="int" value="2"/>
+            <Option name="active" value="true" type="bool"/>
+            <Option name="field" value="function" type="QString"/>
+            <Option name="type" value="2" type="int"/>
           </Option>
         </Option>
-        <Option name="type" type="QString" value="collection"/>
+        <Option name="type" value="collection" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -266,8 +266,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -278,19 +278,19 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="gesloten verharding" type="QString" value="gesloten verharding"/>
+                <Option name="gesloten verharding" value="gesloten verharding" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="open verharding" type="QString" value="open verharding"/>
+                <Option name="open verharding" value="open verharding" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="half verhard" type="QString" value="half verhard"/>
+                <Option name="half verhard" value="half verhard" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="onverhard" type="QString" value="onverhard"/>
+                <Option name="onverhard" value="onverhard" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="pand" type="QString" value="pand"/>
+                <Option name="pand" value="pand" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -301,8 +301,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -311,8 +311,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -321,8 +321,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -333,25 +333,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" type="QString" value="-1"/>
+                <Option name="-1" value="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="0" type="QString" value="0"/>
+                <Option name="0" value="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1" type="QString" value="1"/>
+                <Option name="1" value="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2" type="QString" value="2"/>
+                <Option name="2" value="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="3" type="QString" value="3"/>
+                <Option name="3" value="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="4" type="QString" value="4"/>
+                <Option name="4" value="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="5" type="QString" value="5"/>
+                <Option name="5" value="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -362,8 +362,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -372,8 +372,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -382,8 +382,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -394,13 +394,13 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="vlak" type="QString" value="vlak"/>
+                <Option name="vlak" value="vlak" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="hellend" type="QString" value="hellend"/>
+                <Option name="hellend" value="hellend" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="uitgestrekt" type="QString" value="uitgestrekt"/>
+                <Option name="uitgestrekt" value="uitgestrekt" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -411,85 +411,85 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="function"/>
-    <alias index="1" name="" field="surface_class"/>
-    <alias index="2" name="" field="code"/>
-    <alias index="3" name="" field="display_name"/>
-    <alias index="4" name="" field="surface_sub_class"/>
-    <alias index="5" name="" field="zoom_category"/>
-    <alias index="6" name="" field="nr_of_inhabitants"/>
-    <alias index="7" name="" field="area"/>
-    <alias index="8" name="" field="dry_weather_flow"/>
-    <alias index="9" name="" field="surface_inclination"/>
-    <alias index="10" name="" field="id"/>
+    <alias name="" index="0" field="function"/>
+    <alias name="" index="1" field="surface_class"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="display_name"/>
+    <alias name="" index="4" field="surface_sub_class"/>
+    <alias name="" index="5" field="zoom_category"/>
+    <alias name="" index="6" field="nr_of_inhabitants"/>
+    <alias name="" index="7" field="area"/>
+    <alias name="" index="8" field="dry_weather_flow"/>
+    <alias name="" index="9" field="surface_inclination"/>
+    <alias name="" index="10" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="function"/>
-    <default expression="" applyOnUpdate="0" field="surface_class"/>
-    <default expression="'new'" applyOnUpdate="0" field="code"/>
-    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
-    <default expression="" applyOnUpdate="0" field="surface_sub_class"/>
-    <default expression="-1" applyOnUpdate="0" field="zoom_category"/>
-    <default expression="0" applyOnUpdate="0" field="nr_of_inhabitants"/>
-    <default expression="round($area,1)" applyOnUpdate="0" field="area"/>
-    <default expression="" applyOnUpdate="0" field="dry_weather_flow"/>
-    <default expression="" applyOnUpdate="0" field="surface_inclination"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default applyOnUpdate="0" field="function" expression=""/>
+    <default applyOnUpdate="0" field="surface_class" expression=""/>
+    <default applyOnUpdate="0" field="code" expression="'new'"/>
+    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="surface_sub_class" expression=""/>
+    <default applyOnUpdate="0" field="zoom_category" expression="-1"/>
+    <default applyOnUpdate="0" field="nr_of_inhabitants" expression="0"/>
+    <default applyOnUpdate="0" field="area" expression="$area"/>
+    <default applyOnUpdate="0" field="dry_weather_flow" expression=""/>
+    <default applyOnUpdate="0" field="surface_inclination" expression=""/>
+    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" field="function" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="surface_class" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="code" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="display_name" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="surface_sub_class" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="zoom_category" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="nr_of_inhabitants" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="area" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="dry_weather_flow" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="surface_inclination" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="1" field="id" exp_strength="0" notnull_strength="1" constraints="3"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="function" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_class" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="surface_sub_class" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="nr_of_inhabitants" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="area" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dry_weather_flow" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_inclination" unique_strength="0"/>
+    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="function" exp="" desc=""/>
-    <constraint field="surface_class" exp="" desc=""/>
-    <constraint field="code" exp="" desc=""/>
-    <constraint field="display_name" exp="" desc=""/>
-    <constraint field="surface_sub_class" exp="" desc=""/>
-    <constraint field="zoom_category" exp="" desc=""/>
-    <constraint field="nr_of_inhabitants" exp="" desc=""/>
-    <constraint field="area" exp="" desc=""/>
-    <constraint field="dry_weather_flow" exp="" desc=""/>
-    <constraint field="surface_inclination" exp="" desc=""/>
-    <constraint field="id" exp="" desc=""/>
+    <constraint exp="" field="function" desc=""/>
+    <constraint exp="" field="surface_class" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="surface_sub_class" desc=""/>
+    <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" field="nr_of_inhabitants" desc=""/>
+    <constraint exp="" field="area" desc=""/>
+    <constraint exp="" field="dry_weather_flow" desc=""/>
+    <constraint exp="" field="surface_inclination" desc=""/>
+    <constraint exp="" field="id" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
-      <column hidden="0" name="function" type="field" width="-1"/>
-      <column hidden="0" name="surface_class" type="field" width="-1"/>
-      <column hidden="0" name="code" type="field" width="-1"/>
-      <column hidden="0" name="display_name" type="field" width="-1"/>
-      <column hidden="0" name="surface_sub_class" type="field" width="-1"/>
-      <column hidden="0" name="zoom_category" type="field" width="-1"/>
-      <column hidden="0" name="nr_of_inhabitants" type="field" width="-1"/>
-      <column hidden="0" name="area" type="field" width="-1"/>
-      <column hidden="0" name="dry_weather_flow" type="field" width="-1"/>
-      <column hidden="0" name="surface_inclination" type="field" width="-1"/>
-      <column hidden="0" name="id" type="field" width="-1"/>
-      <column hidden="1" type="actions" width="-1"/>
+      <column name="function" hidden="0" width="-1" type="field"/>
+      <column name="surface_class" hidden="0" width="-1" type="field"/>
+      <column name="code" hidden="0" width="-1" type="field"/>
+      <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="surface_sub_class" hidden="0" width="-1" type="field"/>
+      <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="nr_of_inhabitants" hidden="0" width="-1" type="field"/>
+      <column name="area" hidden="0" width="-1" type="field"/>
+      <column name="dry_weather_flow" hidden="0" width="-1" type="field"/>
+      <column name="surface_inclination" hidden="0" width="-1" type="field"/>
+      <column name="id" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -518,27 +518,27 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="Impervious surface" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-        <attributeEditorField showLabel="1" index="10" name="id"/>
-        <attributeEditorField showLabel="1" index="3" name="display_name"/>
-        <attributeEditorField showLabel="1" index="2" name="code"/>
+    <attributeEditorContainer name="Impervious surface" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="id" index="10" showLabel="1"/>
+        <attributeEditorField name="display_name" index="3" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-        <attributeEditorContainer showLabel="1" name="Storm water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-          <attributeEditorField showLabel="1" index="1" name="surface_class"/>
-          <attributeEditorField showLabel="1" index="4" name="surface_sub_class"/>
-          <attributeEditorField showLabel="1" index="9" name="surface_inclination"/>
-          <attributeEditorField showLabel="1" index="7" name="area"/>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorContainer name="Storm water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="surface_class" index="1" showLabel="1"/>
+          <attributeEditorField name="surface_sub_class" index="4" showLabel="1"/>
+          <attributeEditorField name="surface_inclination" index="9" showLabel="1"/>
+          <attributeEditorField name="area" index="7" showLabel="1"/>
         </attributeEditorContainer>
-        <attributeEditorContainer showLabel="1" name="Municipal water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-          <attributeEditorField showLabel="1" index="8" name="dry_weather_flow"/>
-          <attributeEditorField showLabel="1" index="6" name="nr_of_inhabitants"/>
+        <attributeEditorContainer name="Municipal water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="dry_weather_flow" index="8" showLabel="1"/>
+          <attributeEditorField name="nr_of_inhabitants" index="6" showLabel="1"/>
         </attributeEditorContainer>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-        <attributeEditorField showLabel="1" index="5" name="zoom_category"/>
-        <attributeEditorField showLabel="1" index="0" name="function"/>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="zoom_category" index="5" showLabel="1"/>
+        <attributeEditorField name="function" index="0" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_impervious_surface_map.qml
+++ b/layer_styles/schematisation/v2_impervious_surface_map.qml
@@ -1,0 +1,149 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="impervious_surface_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="percentage">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="id" index="0" name=""/>
+    <alias field="impervious_surface_id" index="1" name=""/>
+    <alias field="connection_node_id" index="2" name=""/>
+    <alias field="percentage" index="3" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="impervious_surface_id"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
+    <default expression="" applyOnUpdate="0" field="percentage"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="impervious_surface_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="percentage" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="impervious_surface_id" exp=""/>
+    <constraint desc="" field="connection_node_id" exp=""/>
+    <constraint desc="" field="percentage" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="impervious_surface_id"/>
+      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
+      <column width="-1" hidden="0" type="field" name="percentage"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="impervious_surface_id" showLabel="1"/>
+      <attributeEditorField index="2" name="connection_node_id" showLabel="1"/>
+      <attributeEditorField index="3" name="percentage" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="connection_node_id"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="impervious_surface_id"/>
+    <field editable="1" name="percentage"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="connection_node_id"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="impervious_surface_id"/>
+    <field labelOnTop="0" name="percentage"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_interflow.qml
+++ b/layer_styles/schematisation/v2_interflow.qml
@@ -1,0 +1,243 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="dualview/previewExpressions" value="id"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="interflow_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="No interflow"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="porosity rescaled to lowest pixel per cell"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="porosity rescaled to lowest pixel in whole model"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="3" name="porosity constant over entire model, interflow depends on impervious layer elevation below lowest pixel in cell"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="4" name="porosity constant over entire model, interflow depends on impervious layer elevation below lowest pixel in model"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="porosity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="porosity_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="porosity_layer_thickness">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="impervious_layer_elevation">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="hydraulic_conductivity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="hydraulic_conductivity_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="id" index="0" name=""/>
+    <alias field="interflow_type" index="1" name=""/>
+    <alias field="porosity" index="2" name=""/>
+    <alias field="porosity_file" index="3" name=""/>
+    <alias field="porosity_layer_thickness" index="4" name=""/>
+    <alias field="impervious_layer_elevation" index="5" name=""/>
+    <alias field="hydraulic_conductivity" index="6" name=""/>
+    <alias field="hydraulic_conductivity_file" index="7" name=""/>
+    <alias field="display_name" index="8" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="interflow_type"/>
+    <default expression="" applyOnUpdate="0" field="porosity"/>
+    <default expression="" applyOnUpdate="0" field="porosity_file"/>
+    <default expression="" applyOnUpdate="0" field="porosity_layer_thickness"/>
+    <default expression="" applyOnUpdate="0" field="impervious_layer_elevation"/>
+    <default expression="" applyOnUpdate="0" field="hydraulic_conductivity"/>
+    <default expression="" applyOnUpdate="0" field="hydraulic_conductivity_file"/>
+    <default expression="" applyOnUpdate="0" field="display_name"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="interflow_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="porosity" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="porosity_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="porosity_layer_thickness" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="impervious_layer_elevation" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="hydraulic_conductivity" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="hydraulic_conductivity_file" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="display_name" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="interflow_type" exp=""/>
+    <constraint desc="" field="porosity" exp=""/>
+    <constraint desc="" field="porosity_file" exp=""/>
+    <constraint desc="" field="porosity_layer_thickness" exp=""/>
+    <constraint desc="" field="impervious_layer_elevation" exp=""/>
+    <constraint desc="" field="hydraulic_conductivity" exp=""/>
+    <constraint desc="" field="hydraulic_conductivity_file" exp=""/>
+    <constraint desc="" field="display_name" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="interflow_type"/>
+      <column width="-1" hidden="0" type="field" name="porosity"/>
+      <column width="-1" hidden="0" type="field" name="porosity_file"/>
+      <column width="-1" hidden="0" type="field" name="porosity_layer_thickness"/>
+      <column width="-1" hidden="0" type="field" name="impervious_layer_elevation"/>
+      <column width="-1" hidden="0" type="field" name="hydraulic_conductivity"/>
+      <column width="-1" hidden="0" type="field" name="hydraulic_conductivity_file"/>
+      <column width="-1" hidden="0" type="field" name="display_name"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="8" name="display_name" showLabel="1"/>
+      <attributeEditorField index="1" name="interflow_type" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Porosity" showLabel="1" groupBox="0">
+      <attributeEditorField index="2" name="porosity" showLabel="1"/>
+      <attributeEditorField index="3" name="porosity_file" showLabel="1"/>
+      <attributeEditorField index="4" name="porosity_layer_thickness" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Hydraulic conductivity" showLabel="1" groupBox="0">
+      <attributeEditorField index="7" name="hydraulic_conductivity_file" showLabel="1"/>
+      <attributeEditorField index="6" name="hydraulic_conductivity" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Impervious layer" showLabel="1" groupBox="0">
+      <attributeEditorField index="5" name="impervious_layer_elevation" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="hydraulic_conductivity"/>
+    <field editable="1" name="hydraulic_conductivity_file"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="impervious_layer_elevation"/>
+    <field editable="1" name="interflow_type"/>
+    <field editable="1" name="porosity"/>
+    <field editable="1" name="porosity_file"/>
+    <field editable="1" name="porosity_layer_thickness"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="hydraulic_conductivity"/>
+    <field labelOnTop="0" name="hydraulic_conductivity_file"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="impervious_layer_elevation"/>
+    <field labelOnTop="0" name="interflow_type"/>
+    <field labelOnTop="0" name="porosity"/>
+    <field labelOnTop="0" name="porosity_file"/>
+    <field labelOnTop="0" name="porosity_layer_thickness"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_interflow.qml
+++ b/layer_styles/schematisation/v2_interflow.qml
@@ -1,17 +1,19 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property key="dualview/previewExpressions" value="id"/>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property key="dualview/previewExpressions">
+      <value>id</value>
+    </property>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -20,8 +22,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -30,21 +32,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="0" name="No interflow"/>
+                <Option value="0" name="0: No interflow" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1" name="porosity rescaled to lowest pixel per cell"/>
+                <Option value="1" name="1: Porosity is rescaled per computational cell with respect to the deepest surface level in that cell. (Defining the porosity_layer_thickness is mandatory)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2" name="porosity rescaled to lowest pixel in whole model"/>
+                <Option value="2" name="2: Porosity is rescaled per computational cell with respect to the deepest surface level in the 2D surface domain. (Defining the porosity_layer_thickness is mandatory)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="3" name="porosity constant over entire model, interflow depends on impervious layer elevation below lowest pixel in cell"/>
+                <Option value="3" name="3: The impervious layer thickness is uniform in the 2D surface domain and is based on the impervious_layer_elevation and the deepest surface level in that cell." type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="4" name="porosity constant over entire model, interflow depends on impervious layer elevation below lowest pixel in model"/>
+                <Option value="4" name="4: The impervious layer thickness is non-uniform in the 2D surface domain and is based on the impervious_layer_elevation with respect to the deepest surface level in the 2D surface domain." type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -97,74 +99,74 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="id" index="0" name=""/>
-    <alias field="interflow_type" index="1" name=""/>
-    <alias field="porosity" index="2" name=""/>
-    <alias field="porosity_file" index="3" name=""/>
-    <alias field="porosity_layer_thickness" index="4" name=""/>
-    <alias field="impervious_layer_elevation" index="5" name=""/>
-    <alias field="hydraulic_conductivity" index="6" name=""/>
-    <alias field="hydraulic_conductivity_file" index="7" name=""/>
-    <alias field="display_name" index="8" name=""/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="interflow_type"/>
+    <alias index="2" name="" field="porosity"/>
+    <alias index="3" name="" field="porosity_file"/>
+    <alias index="4" name="" field="porosity_layer_thickness"/>
+    <alias index="5" name="" field="impervious_layer_elevation"/>
+    <alias index="6" name="" field="hydraulic_conductivity"/>
+    <alias index="7" name="" field="hydraulic_conductivity_file"/>
+    <alias index="8" name="" field="display_name"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="" applyOnUpdate="0" field="interflow_type"/>
-    <default expression="" applyOnUpdate="0" field="porosity"/>
-    <default expression="" applyOnUpdate="0" field="porosity_file"/>
-    <default expression="" applyOnUpdate="0" field="porosity_layer_thickness"/>
-    <default expression="" applyOnUpdate="0" field="impervious_layer_elevation"/>
-    <default expression="" applyOnUpdate="0" field="hydraulic_conductivity"/>
-    <default expression="" applyOnUpdate="0" field="hydraulic_conductivity_file"/>
-    <default expression="" applyOnUpdate="0" field="display_name"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="" field="interflow_type"/>
+    <default applyOnUpdate="0" expression="" field="porosity"/>
+    <default applyOnUpdate="0" expression="" field="porosity_file"/>
+    <default applyOnUpdate="0" expression="" field="porosity_layer_thickness"/>
+    <default applyOnUpdate="0" expression="" field="impervious_layer_elevation"/>
+    <default applyOnUpdate="0" expression="" field="hydraulic_conductivity"/>
+    <default applyOnUpdate="0" expression="" field="hydraulic_conductivity_file"/>
+    <default applyOnUpdate="0" expression="" field="display_name"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="interflow_type" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="porosity" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="porosity_file" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="porosity_layer_thickness" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="impervious_layer_elevation" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="hydraulic_conductivity" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="hydraulic_conductivity_file" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="display_name" exp_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="2" field="interflow_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="porosity" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="porosity_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="porosity_layer_thickness" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="impervious_layer_elevation" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="hydraulic_conductivity" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="hydraulic_conductivity_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="display_name" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="id" exp=""/>
-    <constraint desc="" field="interflow_type" exp=""/>
-    <constraint desc="" field="porosity" exp=""/>
-    <constraint desc="" field="porosity_file" exp=""/>
-    <constraint desc="" field="porosity_layer_thickness" exp=""/>
-    <constraint desc="" field="impervious_layer_elevation" exp=""/>
-    <constraint desc="" field="hydraulic_conductivity" exp=""/>
-    <constraint desc="" field="hydraulic_conductivity_file" exp=""/>
-    <constraint desc="" field="display_name" exp=""/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="interflow_type"/>
+    <constraint exp="" desc="" field="porosity"/>
+    <constraint exp="" desc="" field="porosity_file"/>
+    <constraint exp="" desc="" field="porosity_layer_thickness"/>
+    <constraint exp="" desc="" field="impervious_layer_elevation"/>
+    <constraint exp="" desc="" field="hydraulic_conductivity"/>
+    <constraint exp="" desc="" field="hydraulic_conductivity_file"/>
+    <constraint exp="" desc="" field="display_name"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="interflow_type"/>
-      <column width="-1" hidden="0" type="field" name="porosity"/>
-      <column width="-1" hidden="0" type="field" name="porosity_file"/>
-      <column width="-1" hidden="0" type="field" name="porosity_layer_thickness"/>
-      <column width="-1" hidden="0" type="field" name="impervious_layer_elevation"/>
-      <column width="-1" hidden="0" type="field" name="hydraulic_conductivity"/>
-      <column width="-1" hidden="0" type="field" name="hydraulic_conductivity_file"/>
-      <column width="-1" hidden="0" type="field" name="display_name"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="interflow_type" type="field"/>
+      <column width="-1" hidden="0" name="porosity" type="field"/>
+      <column width="-1" hidden="0" name="porosity_file" type="field"/>
+      <column width="-1" hidden="0" name="porosity_layer_thickness" type="field"/>
+      <column width="-1" hidden="0" name="impervious_layer_elevation" type="field"/>
+      <column width="-1" hidden="0" name="hydraulic_conductivity" type="field"/>
+      <column width="-1" hidden="0" name="hydraulic_conductivity_file" type="field"/>
+      <column width="-1" hidden="0" name="display_name" type="field"/>
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -196,22 +198,22 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
-      <attributeEditorField index="0" name="id" showLabel="1"/>
-      <attributeEditorField index="8" name="display_name" showLabel="1"/>
-      <attributeEditorField index="1" name="interflow_type" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="0" name="id"/>
+      <attributeEditorField showLabel="1" index="8" name="display_name"/>
+      <attributeEditorField showLabel="1" index="1" name="interflow_type"/>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Porosity" showLabel="1" groupBox="0">
-      <attributeEditorField index="2" name="porosity" showLabel="1"/>
-      <attributeEditorField index="3" name="porosity_file" showLabel="1"/>
-      <attributeEditorField index="4" name="porosity_layer_thickness" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Porosity" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="2" name="porosity"/>
+      <attributeEditorField showLabel="1" index="3" name="porosity_file"/>
+      <attributeEditorField showLabel="1" index="4" name="porosity_layer_thickness"/>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Hydraulic conductivity" showLabel="1" groupBox="0">
-      <attributeEditorField index="7" name="hydraulic_conductivity_file" showLabel="1"/>
-      <attributeEditorField index="6" name="hydraulic_conductivity" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Hydraulic conductivity" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="7" name="hydraulic_conductivity_file"/>
+      <attributeEditorField showLabel="1" index="6" name="hydraulic_conductivity"/>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Impervious layer" showLabel="1" groupBox="0">
-      <attributeEditorField index="5" name="impervious_layer_elevation" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Impervious layer" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="5" name="impervious_layer_elevation"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>

--- a/layer_styles/schematisation/v2_levee.qml
+++ b/layer_styles/schematisation/v2_levee.qml
@@ -1,29 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="material">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="crest_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="max_breach_depth">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -32,215 +20,115 @@
           <prop k="line_width" v="0.46"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
     <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="11"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>id</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="Ubuntu"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
-      <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="2" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option type="Map" name="properties">
+          <Option type="Map" name="show">
+            <Option type="bool" value="true" name="active"/>
+            <Option type="QString" value="code" name="field"/>
+            <Option type="int" value="2" name="type"/>
+          </Option>
+        </Option>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="material">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: sand"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2" name="2: clay"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="crest_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_breach_depth">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
     <alias field="code" index="0" name=""/>
     <alias field="material" index="1" name=""/>
@@ -250,8 +138,32 @@
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <defaults>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="" applyOnUpdate="0" field="material"/>
+    <default expression="" applyOnUpdate="0" field="crest_level"/>
+    <default expression="" applyOnUpdate="0" field="max_breach_depth"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="code" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="material" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="crest_level" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="max_breach_depth" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="code" exp=""/>
+    <constraint desc="" field="material" exp=""/>
+    <constraint desc="" field="crest_level" exp=""/>
+    <constraint desc="" field="max_breach_depth" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
       <column width="-1" hidden="0" type="field" name="code"/>
       <column width="-1" hidden="0" type="field" name="material"/>
@@ -261,7 +173,11 @@
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform></editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -283,19 +199,32 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="4" name="id" showLabel="1"/>
+      <attributeEditorField index="0" name="code" showLabel="1"/>
+      <attributeEditorField index="2" name="crest_level" showLabel="1"/>
+      <attributeEditorField index="1" name="material" showLabel="1"/>
+      <attributeEditorField index="3" name="max_breach_depth" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="code"/>
+    <field editable="1" name="crest_level"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="material"/>
+    <field editable="1" name="max_breach_depth"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="crest_level"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="material"/>
+    <field labelOnTop="0" name="max_breach_depth"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="code" expression=""/>
-    <default field="material" expression=""/>
-    <default field="crest_level" expression=""/>
-    <default field="max_breach_depth" expression=""/>
-    <default field="id" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_manhole.qml
+++ b/layer_styles/schematisation/v2_manhole.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -11,7 +11,7 @@
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -20,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -30,8 +30,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -40,8 +40,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -50,8 +50,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -62,13 +62,13 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="00: square" value="00" type="QString"/>
+                <Option value="00" name="00: square" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="01: round" value="01" type="QString"/>
+                <Option value="01" name="01: round" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="02: rectangle" value="02" type="QString"/>
+                <Option value="02" name="02: rectangle" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -79,8 +79,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -89,8 +89,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -101,13 +101,13 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="0: inspection" value="0" type="QString"/>
+                <Option value="0" name="0: inspection" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1: outlet" value="1" type="QString"/>
+                <Option value="1" name="1: outlet" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2: pumpstation" value="2" type="QString"/>
+                <Option value="2" name="2: pumpstation" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -120,13 +120,13 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="0: embedded" value="0" type="QString"/>
+                <Option value="0" name="0: embedded" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1: isolated" value="1" type="QString"/>
+                <Option value="1" name="1: isolated" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2: connected" value="2" type="QString"/>
+                <Option value="2" name="2: connected" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -137,8 +137,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -147,8 +147,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -157,8 +157,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -167,8 +167,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -179,25 +179,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" name="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" name="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" name="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" name="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" name="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" name="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" name="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -206,92 +206,92 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="id"/>
-    <alias name="" index="1" field="display_name"/>
-    <alias name="" index="2" field="code"/>
-    <alias name="" index="3" field="connection_node_id"/>
-    <alias name="" index="4" field="shape"/>
-    <alias name="" index="5" field="width"/>
-    <alias name="" index="6" field="length"/>
-    <alias name="" index="7" field="manhole_indicator"/>
-    <alias name="" index="8" field="calculation_type"/>
-    <alias name="" index="9" field="bottom_level"/>
-    <alias name="" index="10" field="surface_level"/>
-    <alias name="" index="11" field="drain_level"/>
-    <alias name="" index="12" field="sediment_level"/>
-    <alias name="" index="13" field="zoom_category"/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="display_name"/>
+    <alias index="2" name="" field="code"/>
+    <alias index="3" name="" field="connection_node_id"/>
+    <alias index="4" name="" field="shape"/>
+    <alias index="5" name="" field="width"/>
+    <alias index="6" name="" field="length"/>
+    <alias index="7" name="" field="manhole_indicator"/>
+    <alias index="8" name="" field="calculation_type"/>
+    <alias index="9" name="" field="bottom_level"/>
+    <alias index="10" name="" field="surface_level"/>
+    <alias index="11" name="" field="drain_level"/>
+    <alias index="12" name="" field="sediment_level"/>
+    <alias index="13" name="" field="zoom_category"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="connection_node_id" expression=""/>
-    <default applyOnUpdate="0" field="shape" expression="'00'"/>
-    <default applyOnUpdate="0" field="width" expression="0.8"/>
-    <default applyOnUpdate="0" field="length" expression="0.8"/>
-    <default applyOnUpdate="0" field="manhole_indicator" expression="0"/>
-    <default applyOnUpdate="0" field="calculation_type" expression=""/>
-    <default applyOnUpdate="0" field="bottom_level" expression=""/>
-    <default applyOnUpdate="0" field="surface_level" expression=""/>
-    <default applyOnUpdate="0" field="drain_level" expression=""/>
-    <default applyOnUpdate="0" field="sediment_level" expression=""/>
-    <default applyOnUpdate="0" field="zoom_category" expression="1"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="'new'" field="display_name"/>
+    <default applyOnUpdate="0" expression="'new'" field="code"/>
+    <default applyOnUpdate="0" expression="" field="connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="shape"/>
+    <default applyOnUpdate="0" expression="" field="width"/>
+    <default applyOnUpdate="0" expression="" field="length"/>
+    <default applyOnUpdate="0" expression="0" field="manhole_indicator"/>
+    <default applyOnUpdate="0" expression="" field="calculation_type"/>
+    <default applyOnUpdate="0" expression="" field="bottom_level"/>
+    <default applyOnUpdate="0" expression="" field="surface_level"/>
+    <default applyOnUpdate="0" expression="" field="drain_level"/>
+    <default applyOnUpdate="0" expression="" field="sediment_level"/>
+    <default applyOnUpdate="0" expression="1" field="zoom_category"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="shape" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="width" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="length" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="manhole_indicator" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="bottom_level" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_level" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="drain_level" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sediment_level" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="0" field="display_name" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="code" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="connection_node_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="shape" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="width" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="length" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manhole_indicator" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="calculation_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="bottom_level" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="surface_level" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="drain_level" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="sediment_level" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="zoom_category" constraints="0" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="id" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="connection_node_id" desc=""/>
-    <constraint exp="" field="shape" desc=""/>
-    <constraint exp="" field="width" desc=""/>
-    <constraint exp="" field="length" desc=""/>
-    <constraint exp="" field="manhole_indicator" desc=""/>
-    <constraint exp="" field="calculation_type" desc=""/>
-    <constraint exp="" field="bottom_level" desc=""/>
-    <constraint exp="" field="surface_level" desc=""/>
-    <constraint exp="" field="drain_level" desc=""/>
-    <constraint exp="" field="sediment_level" desc=""/>
-    <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="connection_node_id"/>
+    <constraint exp="" desc="" field="shape"/>
+    <constraint exp="" desc="" field="width"/>
+    <constraint exp="" desc="" field="length"/>
+    <constraint exp="" desc="" field="manhole_indicator"/>
+    <constraint exp="" desc="" field="calculation_type"/>
+    <constraint exp="" desc="" field="bottom_level"/>
+    <constraint exp="" desc="" field="surface_level"/>
+    <constraint exp="" desc="" field="drain_level"/>
+    <constraint exp="" desc="" field="sediment_level"/>
+    <constraint exp="" desc="" field="zoom_category"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_id" hidden="0" width="-1" type="field"/>
-      <column name="shape" hidden="0" width="-1" type="field"/>
-      <column name="width" hidden="0" width="-1" type="field"/>
-      <column name="length" hidden="0" width="-1" type="field"/>
-      <column name="manhole_indicator" hidden="0" width="-1" type="field"/>
-      <column name="calculation_type" hidden="0" width="-1" type="field"/>
-      <column name="bottom_level" hidden="0" width="-1" type="field"/>
-      <column name="surface_level" hidden="0" width="-1" type="field"/>
-      <column name="drain_level" hidden="0" width="-1" type="field"/>
-      <column name="sediment_level" hidden="0" width="-1" type="field"/>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="display_name" type="field"/>
+      <column width="-1" hidden="0" name="code" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_id" type="field"/>
+      <column width="-1" hidden="0" name="shape" type="field"/>
+      <column width="-1" hidden="0" name="width" type="field"/>
+      <column width="-1" hidden="0" name="length" type="field"/>
+      <column width="-1" hidden="0" name="manhole_indicator" type="field"/>
+      <column width="-1" hidden="0" name="calculation_type" type="field"/>
+      <column width="-1" hidden="0" name="bottom_level" type="field"/>
+      <column width="-1" hidden="0" name="surface_level" type="field"/>
+      <column width="-1" hidden="0" name="drain_level" type="field"/>
+      <column width="-1" hidden="0" name="sediment_level" type="field"/>
+      <column width="-1" hidden="0" name="zoom_category" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -322,59 +322,59 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Manhole" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="0" showLabel="1"/>
-        <attributeEditorField name="display_name" index="1" showLabel="1"/>
-        <attributeEditorField name="code" index="2" showLabel="1"/>
-        <attributeEditorField name="connection_node_id" index="3" showLabel="1"/>
-        <attributeEditorField name="calculation_type" index="8" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Manhole" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="0" name="id"/>
+        <attributeEditorField showLabel="1" index="1" name="display_name"/>
+        <attributeEditorField showLabel="1" index="2" name="code"/>
+        <attributeEditorField showLabel="1" index="3" name="connection_node_id"/>
+        <attributeEditorField showLabel="1" index="8" name="calculation_type"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="shape" index="4" showLabel="1"/>
-        <attributeEditorField name="width" index="5" showLabel="1"/>
-        <attributeEditorField name="length" index="6" showLabel="1"/>
-        <attributeEditorField name="surface_level" index="10" showLabel="1"/>
-        <attributeEditorField name="drain_level" index="11" showLabel="1"/>
-        <attributeEditorField name="bottom_level" index="9" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="4" name="shape"/>
+        <attributeEditorField showLabel="1" index="5" name="width"/>
+        <attributeEditorField showLabel="1" index="6" name="length"/>
+        <attributeEditorField showLabel="1" index="10" name="surface_level"/>
+        <attributeEditorField showLabel="1" index="11" name="drain_level"/>
+        <attributeEditorField showLabel="1" index="9" name="bottom_level"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="13" showLabel="1"/>
-        <attributeEditorField name="manhole_indicator" index="7" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="13" name="zoom_category"/>
+        <attributeEditorField showLabel="1" index="7" name="manhole_indicator"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="bottom_level" editable="1"/>
-    <field name="calculation_type" editable="1"/>
-    <field name="code" editable="1"/>
-    <field name="connection_node_id" editable="1"/>
-    <field name="display_name" editable="1"/>
-    <field name="drain_level" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="length" editable="1"/>
-    <field name="manhole_indicator" editable="1"/>
-    <field name="sediment_level" editable="1"/>
-    <field name="shape" editable="1"/>
-    <field name="surface_level" editable="1"/>
-    <field name="width" editable="1"/>
-    <field name="zoom_category" editable="1"/>
+    <field editable="1" name="bottom_level"/>
+    <field editable="1" name="calculation_type"/>
+    <field editable="1" name="code"/>
+    <field editable="1" name="connection_node_id"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="drain_level"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="length"/>
+    <field editable="1" name="manhole_indicator"/>
+    <field editable="1" name="sediment_level"/>
+    <field editable="1" name="shape"/>
+    <field editable="1" name="surface_level"/>
+    <field editable="1" name="width"/>
+    <field editable="1" name="zoom_category"/>
   </editable>
   <labelOnTop>
-    <field name="bottom_level" labelOnTop="0"/>
-    <field name="calculation_type" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_id" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="drain_level" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="length" labelOnTop="0"/>
-    <field name="manhole_indicator" labelOnTop="0"/>
-    <field name="sediment_level" labelOnTop="0"/>
-    <field name="shape" labelOnTop="0"/>
-    <field name="surface_level" labelOnTop="0"/>
-    <field name="width" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="bottom_level"/>
+    <field labelOnTop="0" name="calculation_type"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_id"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="drain_level"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="length"/>
+    <field labelOnTop="0" name="manhole_indicator"/>
+    <field labelOnTop="0" name="sediment_level"/>
+    <field labelOnTop="0" name="shape"/>
+    <field labelOnTop="0" name="surface_level"/>
+    <field labelOnTop="0" name="width"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>id</previewExpression>

--- a/layer_styles/schematisation/v2_manhole.qml
+++ b/layer_styles/schematisation/v2_manhole.qml
@@ -1,0 +1,383 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property value="id" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="00: square" value="00" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="01: round" value="01" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="02: rectangle" value="02" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="length">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manhole_indicator">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="0: inspection" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1: outlet" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: pumpstation" value="2" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="calculation_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="0: embedded" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1: isolated" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: connected" value="2" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bottom_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="drain_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="sediment_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="id"/>
+    <alias name="" index="1" field="display_name"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="connection_node_id"/>
+    <alias name="" index="4" field="shape"/>
+    <alias name="" index="5" field="width"/>
+    <alias name="" index="6" field="length"/>
+    <alias name="" index="7" field="manhole_indicator"/>
+    <alias name="" index="8" field="calculation_type"/>
+    <alias name="" index="9" field="bottom_level"/>
+    <alias name="" index="10" field="surface_level"/>
+    <alias name="" index="11" field="drain_level"/>
+    <alias name="" index="12" field="sediment_level"/>
+    <alias name="" index="13" field="zoom_category"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="code" expression="'new'"/>
+    <default applyOnUpdate="0" field="connection_node_id" expression=""/>
+    <default applyOnUpdate="0" field="shape" expression="'00'"/>
+    <default applyOnUpdate="0" field="width" expression="0.8"/>
+    <default applyOnUpdate="0" field="length" expression="0.8"/>
+    <default applyOnUpdate="0" field="manhole_indicator" expression="0"/>
+    <default applyOnUpdate="0" field="calculation_type" expression=""/>
+    <default applyOnUpdate="0" field="bottom_level" expression=""/>
+    <default applyOnUpdate="0" field="surface_level" expression=""/>
+    <default applyOnUpdate="0" field="drain_level" expression=""/>
+    <default applyOnUpdate="0" field="sediment_level" expression=""/>
+    <default applyOnUpdate="0" field="zoom_category" expression="1"/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="shape" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="width" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="length" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="manhole_indicator" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="bottom_level" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_level" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="drain_level" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sediment_level" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="zoom_category" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="connection_node_id" desc=""/>
+    <constraint exp="" field="shape" desc=""/>
+    <constraint exp="" field="width" desc=""/>
+    <constraint exp="" field="length" desc=""/>
+    <constraint exp="" field="manhole_indicator" desc=""/>
+    <constraint exp="" field="calculation_type" desc=""/>
+    <constraint exp="" field="bottom_level" desc=""/>
+    <constraint exp="" field="surface_level" desc=""/>
+    <constraint exp="" field="drain_level" desc=""/>
+    <constraint exp="" field="sediment_level" desc=""/>
+    <constraint exp="" field="zoom_category" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+    <columns>
+      <column name="id" hidden="0" width="-1" type="field"/>
+      <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="code" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_id" hidden="0" width="-1" type="field"/>
+      <column name="shape" hidden="0" width="-1" type="field"/>
+      <column name="width" hidden="0" width="-1" type="field"/>
+      <column name="length" hidden="0" width="-1" type="field"/>
+      <column name="manhole_indicator" hidden="0" width="-1" type="field"/>
+      <column name="calculation_type" hidden="0" width="-1" type="field"/>
+      <column name="bottom_level" hidden="0" width="-1" type="field"/>
+      <column name="surface_level" hidden="0" width="-1" type="field"/>
+      <column name="drain_level" hidden="0" width="-1" type="field"/>
+      <column name="sediment_level" hidden="0" width="-1" type="field"/>
+      <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Manhole" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="id" index="0" showLabel="1"/>
+        <attributeEditorField name="display_name" index="1" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
+        <attributeEditorField name="connection_node_id" index="3" showLabel="1"/>
+        <attributeEditorField name="calculation_type" index="8" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="shape" index="4" showLabel="1"/>
+        <attributeEditorField name="width" index="5" showLabel="1"/>
+        <attributeEditorField name="length" index="6" showLabel="1"/>
+        <attributeEditorField name="surface_level" index="10" showLabel="1"/>
+        <attributeEditorField name="drain_level" index="11" showLabel="1"/>
+        <attributeEditorField name="bottom_level" index="9" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="zoom_category" index="13" showLabel="1"/>
+        <attributeEditorField name="manhole_indicator" index="7" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="bottom_level" editable="1"/>
+    <field name="calculation_type" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="connection_node_id" editable="1"/>
+    <field name="display_name" editable="1"/>
+    <field name="drain_level" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="length" editable="1"/>
+    <field name="manhole_indicator" editable="1"/>
+    <field name="sediment_level" editable="1"/>
+    <field name="shape" editable="1"/>
+    <field name="surface_level" editable="1"/>
+    <field name="width" editable="1"/>
+    <field name="zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="bottom_level" labelOnTop="0"/>
+    <field name="calculation_type" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="connection_node_id" labelOnTop="0"/>
+    <field name="display_name" labelOnTop="0"/>
+    <field name="drain_level" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="length" labelOnTop="0"/>
+    <field name="manhole_indicator" labelOnTop="0"/>
+    <field name="sediment_level" labelOnTop="0"/>
+    <field name="shape" labelOnTop="0"/>
+    <field name="surface_level" labelOnTop="0"/>
+    <field name="width" labelOnTop="0"/>
+    <field name="zoom_category" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_manhole_view.qml
+++ b/layer_styles/schematisation/v2_manhole_view.qml
@@ -1,21 +1,21 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.4.5-Madeira" labelsEnabled="0" styleCategories="AllStyleCategories" simplifyLocal="1" simplifyMaxScale="1" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" maxScale="-4.65661e-10" readOnly="0" minScale="1e+08">
+<qgis maxScale="-4.65661e-10" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="0" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 type="RuleRenderer" forceraster="0" symbollevels="0" enableorderby="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="RuleRenderer">
     <rules key="{4fbba513-a3b1-4a92-97bc-3d44735ac986}">
-      <rule scalemaxdenom="2500" label="Inspectieput" symbol="0" filter="manh_manhole_indicator = 0" key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}"/>
-      <rule scalemaxdenom="15000" label="Uitlaat - boundary" symbol="1" filter="manh_manhole_indicator = 1" key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}"/>
-      <rule scalemaxdenom="15000" label="Uitlaat - connectie met 2d" symbol="2" filter="manh_calculation_type = 0" key="{bb971e07-f3e6-48c3-b84b-12496560a739}"/>
-      <rule label="Gemaalkelder" symbol="3" filter="manh_manhole_indicator = 2" key="{a1d98efc-8098-4201-a75e-93dc7c47f076}"/>
-      <rule label="Inprikpunt" symbol="4" filter="manh_manhole_indicator = 3" key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}"/>
-      <rule label="RWZI" symbol="5" filter="manh_manhole_indicator = 4" key="{c3de3024-005b-42ac-9705-3bae1dc13053}"/>
+      <rule filter="manh_manhole_indicator = 0" scalemaxdenom="2500" label="Inspectieput" symbol="0" key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}"/>
+      <rule filter="manh_manhole_indicator = 1" scalemaxdenom="15000" label="Uitlaat - boundary" symbol="1" key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}"/>
+      <rule filter="manh_calculation_type = 0" scalemaxdenom="15000" label="Uitlaat - connectie met 2d" symbol="2" key="{bb971e07-f3e6-48c3-b84b-12496560a739}"/>
+      <rule filter="manh_manhole_indicator = 2" label="Gemaalkelder" symbol="3" key="{a1d98efc-8098-4201-a75e-93dc7c47f076}"/>
+      <rule filter="manh_manhole_indicator = 3" label="Inprikpunt" symbol="4" key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}"/>
+      <rule filter="manh_manhole_indicator = 4" label="RWZI" symbol="5" key="{c3de3024-005b-42ac-9705-3bae1dc13053}"/>
     </rules>
     <symbols>
-      <symbol type="marker" name="0" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol clip_to_extent="1" alpha="1" name="0" type="marker" force_rhr="0">
         <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,255,127,255"/>
@@ -37,14 +37,14 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" name="1" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol clip_to_extent="1" alpha="1" name="1" type="marker" force_rhr="0">
         <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="170,0,255,255"/>
@@ -66,14 +66,14 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" name="2" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol clip_to_extent="1" alpha="1" name="2" type="marker" force_rhr="0">
         <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="254,0,199,255"/>
@@ -95,14 +95,14 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" name="3" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol clip_to_extent="1" alpha="1" name="3" type="marker" force_rhr="0">
         <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,170,0,255"/>
@@ -124,14 +124,14 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" name="4" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol clip_to_extent="1" alpha="1" name="4" type="marker" force_rhr="0">
         <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,255,0,255"/>
@@ -153,14 +153,14 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" name="5" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol clip_to_extent="1" alpha="1" name="5" type="marker" force_rhr="0">
         <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,170,255,255"/>
@@ -182,9 +182,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -200,22 +200,22 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory scaleBasedVisibility="0" sizeType="MM" lineSizeType="MM" diagramOrientation="Up" barWidth="5" maxScaleDenominator="1e+08" labelPlacementMethod="XHeight" width="15" penAlpha="255" backgroundAlpha="255" penColor="#000000" penWidth="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" minimumSize="0" rotationOffset="270" minScaleDenominator="-4.65661e-10" opacity="1" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0" enabled="0" height="15">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="-4.65661e-10" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings zIndex="0" obstacle="0" showAll="1" priority="0" placement="0" dist="0" linePlacementFlags="2">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="0" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option type="QString" name="name" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option type="QString" name="type" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -224,38 +224,18 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="node_id">
+    <field name="manh_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_bottom_level">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_surface_level">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -264,8 +244,28 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -274,15 +274,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" name="00: square" value="00"/>
+                <Option value="00" name="00: square" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="01: round" value="01"/>
+                <Option value="01" name="01: round" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="02: rectangle" value="02"/>
+                <Option value="02" name="02: rectangle" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -293,8 +293,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -303,8 +303,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -313,15 +313,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" name="0: inspection" value="0"/>
+                <Option value="0" name="0: inspection" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="1: outlet" value="1"/>
+                <Option value="1" name="1: outlet" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="2: pump" value="2"/>
+                <Option value="2" name="2: pump" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -332,17 +332,37 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" name="0: embedded" value="0"/>
+                <Option value="0" name="0: embedded" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="1: isolated" value="1"/>
+                <Option value="1" name="1: isolated" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="2: connected" value="2"/>
+                <Option value="2" name="2: connected" type="QString"/>
               </Option>
             </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_bottom_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_surface_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -351,109 +371,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_zoom_category">
-      <editWidget type="ValueMap">
-        <config>
-          <Option type="Map">
-            <Option type="List" name="map">
-              <Option type="Map">
-                <Option type="QString" name="-1" value="-1"/>
-              </Option>
-              <Option type="Map">
-                <Option type="QString" name="0" value="0"/>
-              </Option>
-              <Option type="Map">
-                <Option type="QString" name="1" value="1"/>
-              </Option>
-              <Option type="Map">
-                <Option type="QString" name="2" value="2"/>
-              </Option>
-              <Option type="Map">
-                <Option type="QString" name="3" value="3"/>
-              </Option>
-              <Option type="Map">
-                <Option type="QString" name="4" value="4"/>
-              </Option>
-              <Option type="Map">
-                <Option type="QString" name="5" value="5"/>
-              </Option>
-            </Option>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="node_initial_waterlevel">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_connection_node_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="node_storage_area">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_code">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="node_code">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="node_the_geom_linestring">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -462,102 +381,183 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="-1" name="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="0" name="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="3" name="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="4" name="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="5" name="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="node_storage_area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="node_initial_waterlevel">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="node_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="node_the_geom_linestring">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="ROWID" index="0"/>
-    <alias name="" field="node_id" index="1"/>
-    <alias name="bottom_level" field="manh_bottom_level" index="2"/>
-    <alias name="surface_level" field="manh_surface_level" index="3"/>
-    <alias name="display_name" field="manh_display_name" index="4"/>
-    <alias name="shape" field="manh_shape" index="5"/>
-    <alias name="width" field="manh_width" index="6"/>
-    <alias name="length" field="manh_length" index="7"/>
-    <alias name="manhole_indicator" field="manh_manhole_indicator" index="8"/>
-    <alias name="calculation_type" field="manh_calculation_type" index="9"/>
-    <alias name="drain_level" field="manh_drain_level" index="10"/>
-    <alias name="zoom_category" field="manh_zoom_category" index="11"/>
-    <alias name="" field="node_initial_waterlevel" index="12"/>
-    <alias name="id" field="manh_id" index="13"/>
-    <alias name="connection_node_id" field="manh_connection_node_id" index="14"/>
-    <alias name="" field="node_storage_area" index="15"/>
-    <alias name="code" field="manh_code" index="16"/>
-    <alias name="" field="node_code" index="17"/>
-    <alias name="the_geom_linestring" field="node_the_geom_linestring" index="18"/>
-    <alias name="sediment_level" field="manh_sediment_level" index="19"/>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="id" field="manh_id"/>
+    <alias index="2" name="display_name" field="manh_display_name"/>
+    <alias index="3" name="code" field="manh_code"/>
+    <alias index="4" name="connection_node_id" field="manh_connection_node_id"/>
+    <alias index="5" name="shape" field="manh_shape"/>
+    <alias index="6" name="width" field="manh_width"/>
+    <alias index="7" name="length" field="manh_length"/>
+    <alias index="8" name="manhole_indicator" field="manh_manhole_indicator"/>
+    <alias index="9" name="calculation_type" field="manh_calculation_type"/>
+    <alias index="10" name="bottom_level" field="manh_bottom_level"/>
+    <alias index="11" name="surface_level" field="manh_surface_level"/>
+    <alias index="12" name="drain_level" field="manh_drain_level"/>
+    <alias index="13" name="sediment_level" field="manh_sediment_level"/>
+    <alias index="14" name="zoom_category" field="manh_zoom_category"/>
+    <alias index="15" name="" field="node_id"/>
+    <alias index="16" name="" field="node_storage_area"/>
+    <alias index="17" name="" field="node_initial_waterlevel"/>
+    <alias index="18" name="" field="node_code"/>
+    <alias index="19" name="the_geom_linestring" field="node_the_geom_linestring"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="ROWID" applyOnUpdate="0" expression=""/>
-    <default field="node_id" applyOnUpdate="0" expression="'filled automatically'"/>
-    <default field="manh_bottom_level" applyOnUpdate="0" expression="&quot;manh_bottom_level&quot;&lt;&quot;manh_surface_level&quot;"/>
-    <default field="manh_surface_level" applyOnUpdate="0" expression=""/>
-    <default field="manh_display_name" applyOnUpdate="0" expression="'new'"/>
-    <default field="manh_shape" applyOnUpdate="0" expression="'00'"/>
-    <default field="manh_width" applyOnUpdate="0" expression="0.8"/>
-    <default field="manh_length" applyOnUpdate="0" expression=""/>
-    <default field="manh_manhole_indicator" applyOnUpdate="0" expression="'0'"/>
-    <default field="manh_calculation_type" applyOnUpdate="0" expression=""/>
-    <default field="manh_drain_level" applyOnUpdate="0" expression=""/>
-    <default field="manh_zoom_category" applyOnUpdate="0" expression="1"/>
-    <default field="node_initial_waterlevel" applyOnUpdate="0" expression=""/>
-    <default field="manh_id" applyOnUpdate="0" expression="if(maximum(manh_id) is null,1, maximum(manh_id)+1)"/>
-    <default field="manh_connection_node_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))"/>
-    <default field="node_storage_area" applyOnUpdate="0" expression=""/>
-    <default field="manh_code" applyOnUpdate="0" expression="'new'"/>
-    <default field="node_code" applyOnUpdate="0" expression="'new'"/>
-    <default field="node_the_geom_linestring" applyOnUpdate="0" expression=""/>
-    <default field="manh_sediment_level" applyOnUpdate="0" expression=""/>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="if(maximum(manh_id) is null,1, maximum(manh_id)+1)" field="manh_id"/>
+    <default applyOnUpdate="0" expression="'new'" field="manh_display_name"/>
+    <default applyOnUpdate="0" expression="'new'" field="manh_code"/>
+    <default applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))" field="manh_connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="manh_shape"/>
+    <default applyOnUpdate="0" expression="" field="manh_width"/>
+    <default applyOnUpdate="0" expression="" field="manh_length"/>
+    <default applyOnUpdate="0" expression="'0'" field="manh_manhole_indicator"/>
+    <default applyOnUpdate="0" expression="" field="manh_calculation_type"/>
+    <default applyOnUpdate="0" expression="&quot;manh_bottom_level&quot;&lt;&quot;manh_surface_level&quot;" field="manh_bottom_level"/>
+    <default applyOnUpdate="0" expression="" field="manh_surface_level"/>
+    <default applyOnUpdate="0" expression="" field="manh_drain_level"/>
+    <default applyOnUpdate="0" expression="" field="manh_sediment_level"/>
+    <default applyOnUpdate="0" expression="1" field="manh_zoom_category"/>
+    <default applyOnUpdate="0" expression="'filled automatically'" field="node_id"/>
+    <default applyOnUpdate="0" expression="" field="node_storage_area"/>
+    <default applyOnUpdate="0" expression="" field="node_initial_waterlevel"/>
+    <default applyOnUpdate="0" expression="'new'" field="node_code"/>
+    <default applyOnUpdate="0" expression="" field="node_the_geom_linestring"/>
   </defaults>
   <constraints>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_id" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_bottom_level" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_surface_level" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_display_name" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_shape" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_width" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_length" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_manhole_indicator" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_calculation_type" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_drain_level" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_zoom_category" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_initial_waterlevel" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_id" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_connection_node_id" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_storage_area" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_code" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="node_code" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_the_geom_linestring" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_sediment_level" exp_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="ROWID" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="manh_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_display_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_connection_node_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_shape" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_width" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="manh_length" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_manhole_indicator" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_calculation_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_bottom_level" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_surface_level" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="manh_drain_level" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="manh_sediment_level" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="manh_zoom_category" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="node_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="node_storage_area" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="node_initial_waterlevel" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="node_code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="node_the_geom_linestring" constraints="0" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="ROWID" desc=""/>
-    <constraint exp="" field="node_id" desc=""/>
-    <constraint exp="" field="manh_bottom_level" desc=""/>
-    <constraint exp="" field="manh_surface_level" desc=""/>
-    <constraint exp="" field="manh_display_name" desc=""/>
-    <constraint exp="" field="manh_shape" desc=""/>
-    <constraint exp="" field="manh_width" desc=""/>
-    <constraint exp="" field="manh_length" desc=""/>
-    <constraint exp="" field="manh_manhole_indicator" desc=""/>
-    <constraint exp="" field="manh_calculation_type" desc=""/>
-    <constraint exp="" field="manh_drain_level" desc=""/>
-    <constraint exp="" field="manh_zoom_category" desc=""/>
-    <constraint exp="" field="node_initial_waterlevel" desc=""/>
-    <constraint exp="" field="manh_id" desc=""/>
-    <constraint exp="" field="manh_connection_node_id" desc=""/>
-    <constraint exp="" field="node_storage_area" desc=""/>
-    <constraint exp="" field="manh_code" desc=""/>
-    <constraint exp="" field="node_code" desc=""/>
-    <constraint exp="" field="node_the_geom_linestring" desc=""/>
-    <constraint exp="" field="manh_sediment_level" desc=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="manh_id"/>
+    <constraint exp="" desc="" field="manh_display_name"/>
+    <constraint exp="" desc="" field="manh_code"/>
+    <constraint exp="" desc="" field="manh_connection_node_id"/>
+    <constraint exp="" desc="" field="manh_shape"/>
+    <constraint exp="" desc="" field="manh_width"/>
+    <constraint exp="" desc="" field="manh_length"/>
+    <constraint exp="" desc="" field="manh_manhole_indicator"/>
+    <constraint exp="" desc="" field="manh_calculation_type"/>
+    <constraint exp="" desc="" field="manh_bottom_level"/>
+    <constraint exp="" desc="" field="manh_surface_level"/>
+    <constraint exp="" desc="" field="manh_drain_level"/>
+    <constraint exp="" desc="" field="manh_sediment_level"/>
+    <constraint exp="" desc="" field="manh_zoom_category"/>
+    <constraint exp="" desc="" field="node_id"/>
+    <constraint exp="" desc="" field="node_storage_area"/>
+    <constraint exp="" desc="" field="node_initial_waterlevel"/>
+    <constraint exp="" desc="" field="node_code"/>
+    <constraint exp="" desc="" field="node_the_geom_linestring"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
@@ -565,27 +565,27 @@
   </attributeactions>
   <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;manh_id&quot;" sortOrder="0">
     <columns>
-      <column type="field" name="ROWID" width="-1" hidden="0"/>
-      <column type="field" name="manh_id" width="-1" hidden="0"/>
-      <column type="field" name="manh_display_name" width="-1" hidden="0"/>
-      <column type="field" name="manh_code" width="-1" hidden="0"/>
-      <column type="field" name="manh_connection_node_id" width="-1" hidden="0"/>
-      <column type="field" name="manh_shape" width="-1" hidden="0"/>
-      <column type="field" name="manh_width" width="-1" hidden="0"/>
-      <column type="field" name="manh_length" width="-1" hidden="0"/>
-      <column type="field" name="manh_manhole_indicator" width="-1" hidden="0"/>
-      <column type="field" name="manh_calculation_type" width="-1" hidden="0"/>
-      <column type="field" name="manh_bottom_level" width="-1" hidden="0"/>
-      <column type="field" name="manh_surface_level" width="-1" hidden="0"/>
-      <column type="field" name="manh_drain_level" width="-1" hidden="0"/>
-      <column type="field" name="manh_sediment_level" width="-1" hidden="0"/>
-      <column type="field" name="manh_zoom_category" width="-1" hidden="0"/>
-      <column type="field" name="node_id" width="-1" hidden="0"/>
-      <column type="field" name="node_storage_area" width="-1" hidden="0"/>
-      <column type="field" name="node_initial_waterlevel" width="-1" hidden="0"/>
-      <column type="field" name="node_code" width="-1" hidden="0"/>
-      <column type="field" name="node_the_geom_linestring" width="-1" hidden="0"/>
-      <column type="actions" width="-1" hidden="1"/>
+      <column width="-1" hidden="0" name="ROWID" type="field"/>
+      <column width="-1" hidden="0" name="manh_id" type="field"/>
+      <column width="-1" hidden="0" name="manh_display_name" type="field"/>
+      <column width="-1" hidden="0" name="manh_code" type="field"/>
+      <column width="-1" hidden="0" name="manh_connection_node_id" type="field"/>
+      <column width="-1" hidden="0" name="manh_shape" type="field"/>
+      <column width="-1" hidden="0" name="manh_width" type="field"/>
+      <column width="-1" hidden="0" name="manh_length" type="field"/>
+      <column width="-1" hidden="0" name="manh_manhole_indicator" type="field"/>
+      <column width="-1" hidden="0" name="manh_calculation_type" type="field"/>
+      <column width="-1" hidden="0" name="manh_bottom_level" type="field"/>
+      <column width="-1" hidden="0" name="manh_surface_level" type="field"/>
+      <column width="-1" hidden="0" name="manh_drain_level" type="field"/>
+      <column width="-1" hidden="0" name="manh_sediment_level" type="field"/>
+      <column width="-1" hidden="0" name="manh_zoom_category" type="field"/>
+      <column width="-1" hidden="0" name="node_id" type="field"/>
+      <column width="-1" hidden="0" name="node_storage_area" type="field"/>
+      <column width="-1" hidden="0" name="node_initial_waterlevel" type="field"/>
+      <column width="-1" hidden="0" name="node_code" type="field"/>
+      <column width="-1" hidden="0" name="node_the_geom_linestring" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -616,54 +616,54 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer columnCount="1" visibilityExpression="" name="Manhole_view" groupBox="0" visibilityExpressionEnabled="0" showLabel="1">
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="manh_id" index="13" showLabel="1"/>
-        <attributeEditorField name="manh_display_name" index="4" showLabel="1"/>
-        <attributeEditorField name="manh_code" index="16" showLabel="1"/>
-        <attributeEditorField name="manh_calculation_type" index="9" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Manhole_view" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="1" name="manh_id"/>
+        <attributeEditorField showLabel="1" index="2" name="manh_display_name"/>
+        <attributeEditorField showLabel="1" index="3" name="manh_code"/>
+        <attributeEditorField showLabel="1" index="9" name="manh_calculation_type"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="manh_shape" index="5" showLabel="1"/>
-        <attributeEditorField name="manh_width" index="6" showLabel="1"/>
-        <attributeEditorField name="manh_length" index="7" showLabel="1"/>
-        <attributeEditorField name="manh_bottom_level" index="2" showLabel="1"/>
-        <attributeEditorField name="manh_surface_level" index="3" showLabel="1"/>
-        <attributeEditorField name="manh_drain_level" index="10" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="5" name="manh_shape"/>
+        <attributeEditorField showLabel="1" index="6" name="manh_width"/>
+        <attributeEditorField showLabel="1" index="7" name="manh_length"/>
+        <attributeEditorField showLabel="1" index="10" name="manh_bottom_level"/>
+        <attributeEditorField showLabel="1" index="11" name="manh_surface_level"/>
+        <attributeEditorField showLabel="1" index="12" name="manh_drain_level"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Visualisation" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="manh_manhole_indicator" index="8" showLabel="1"/>
-        <attributeEditorField name="manh_zoom_category" index="11" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Visualisation" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="8" name="manh_manhole_indicator"/>
+        <attributeEditorField showLabel="1" index="14" name="manh_zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Connection node" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="manh_connection_node_id" index="14" showLabel="1"/>
-        <attributeEditorField name="node_code" index="17" showLabel="1"/>
-        <attributeEditorField name="node_initial_waterlevel" index="12" showLabel="1"/>
-        <attributeEditorField name="node_storage_area" index="15" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Connection node" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="4" name="manh_connection_node_id"/>
+        <attributeEditorField showLabel="1" index="18" name="node_code"/>
+        <attributeEditorField showLabel="1" index="17" name="node_initial_waterlevel"/>
+        <attributeEditorField showLabel="1" index="16" name="node_storage_area"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="ROWID" editable="1"/>
-    <field name="manh_bottom_level" editable="1"/>
-    <field name="manh_calculation_type" editable="1"/>
-    <field name="manh_code" editable="1"/>
-    <field name="manh_connection_node_id" editable="0"/>
-    <field name="manh_display_name" editable="1"/>
-    <field name="manh_drain_level" editable="1"/>
-    <field name="manh_id" editable="0"/>
-    <field name="manh_length" editable="1"/>
-    <field name="manh_manhole_indicator" editable="1"/>
-    <field name="manh_sediment_level" editable="1"/>
-    <field name="manh_shape" editable="1"/>
-    <field name="manh_surface_level" editable="1"/>
-    <field name="manh_width" editable="1"/>
-    <field name="manh_zoom_category" editable="1"/>
-    <field name="node_code" editable="1"/>
-    <field name="node_id" editable="0"/>
-    <field name="node_initial_waterlevel" editable="1"/>
-    <field name="node_storage_area" editable="1"/>
-    <field name="node_the_geom_linestring" editable="1"/>
+    <field editable="1" name="ROWID"/>
+    <field editable="1" name="manh_bottom_level"/>
+    <field editable="1" name="manh_calculation_type"/>
+    <field editable="1" name="manh_code"/>
+    <field editable="0" name="manh_connection_node_id"/>
+    <field editable="1" name="manh_display_name"/>
+    <field editable="1" name="manh_drain_level"/>
+    <field editable="0" name="manh_id"/>
+    <field editable="1" name="manh_length"/>
+    <field editable="1" name="manh_manhole_indicator"/>
+    <field editable="1" name="manh_sediment_level"/>
+    <field editable="1" name="manh_shape"/>
+    <field editable="1" name="manh_surface_level"/>
+    <field editable="1" name="manh_width"/>
+    <field editable="1" name="manh_zoom_category"/>
+    <field editable="1" name="node_code"/>
+    <field editable="0" name="node_id"/>
+    <field editable="1" name="node_initial_waterlevel"/>
+    <field editable="1" name="node_storage_area"/>
+    <field editable="1" name="node_the_geom_linestring"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="ROWID"/>

--- a/layer_styles/schematisation/v2_manhole_view.qml
+++ b/layer_styles/schematisation/v2_manhole_view.qml
@@ -1,22 +1,22 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="0" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis version="3.4.5-Madeira" labelsEnabled="0" styleCategories="AllStyleCategories" simplifyLocal="1" simplifyMaxScale="1" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" maxScale="-4.65661e-10" readOnly="0" minScale="1e+08">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="RuleRenderer" forceraster="0" symbollevels="0">
+  <renderer-v2 type="RuleRenderer" forceraster="0" symbollevels="0" enableorderby="0">
     <rules key="{4fbba513-a3b1-4a92-97bc-3d44735ac986}">
-      <rule key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}" symbol="0" scalemaxdenom="2500" label="Inspectieput" filter="manh_manhole_indicator = 0"/>
-      <rule key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}" symbol="1" scalemaxdenom="15000" label="Uitlaat - boundary" filter="manh_manhole_indicator = 1"/>
-      <rule key="{bb971e07-f3e6-48c3-b84b-12496560a739}" symbol="2" scalemaxdenom="15000" label="Uitlaat - connectie met 2d" filter="manh_calculation_type = 0"/>
-      <rule key="{a1d98efc-8098-4201-a75e-93dc7c47f076}" symbol="3" label="Gemaalkelder" filter="manh_manhole_indicator = 2"/>
-      <rule key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}" symbol="4" label="Inprikpunt" filter="manh_manhole_indicator = 3"/>
-      <rule key="{c3de3024-005b-42ac-9705-3bae1dc13053}" symbol="5" label="RWZI" filter="manh_manhole_indicator = 4"/>
+      <rule scalemaxdenom="2500" label="Inspectieput" symbol="0" filter="manh_manhole_indicator = 0" key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}"/>
+      <rule scalemaxdenom="15000" label="Uitlaat - boundary" symbol="1" filter="manh_manhole_indicator = 1" key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}"/>
+      <rule scalemaxdenom="15000" label="Uitlaat - connectie met 2d" symbol="2" filter="manh_calculation_type = 0" key="{bb971e07-f3e6-48c3-b84b-12496560a739}"/>
+      <rule label="Gemaalkelder" symbol="3" filter="manh_manhole_indicator = 2" key="{a1d98efc-8098-4201-a75e-93dc7c47f076}"/>
+      <rule label="Inprikpunt" symbol="4" filter="manh_manhole_indicator = 3" key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}"/>
+      <rule label="RWZI" symbol="5" filter="manh_manhole_indicator = 4" key="{c3de3024-005b-42ac-9705-3bae1dc13053}"/>
     </rules>
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="0">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+      <symbol type="marker" name="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,255,127,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -37,15 +37,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="1">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+      <symbol type="marker" name="1" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="170,0,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -66,15 +66,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="2">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+      <symbol type="marker" name="2" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="254,0,199,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -95,15 +95,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="3">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+      <symbol type="marker" name="3" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,170,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -124,15 +124,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="4">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+      <symbol type="marker" name="4" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,255,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -153,15 +153,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="5">
-        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+      <symbol type="marker" name="5" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,170,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -182,9 +182,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -200,18 +200,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory scaleBasedVisibility="0" sizeType="MM" lineSizeType="MM" diagramOrientation="Up" barWidth="5" maxScaleDenominator="1e+08" labelPlacementMethod="XHeight" width="15" penAlpha="255" backgroundAlpha="255" penColor="#000000" penWidth="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" minimumSize="0" rotationOffset="270" minScaleDenominator="-4.65661e-10" opacity="1" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0" enabled="0" height="15">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="0" zIndex="0">
+  <DiagramLayerSettings zIndex="0" obstacle="0" showAll="1" priority="0" placement="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option type="QString" name="name" value=""/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option type="QString" name="type" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -224,8 +224,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -234,8 +234,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -244,8 +244,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -254,8 +254,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -264,8 +264,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -276,13 +276,13 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="00" type="QString" name="00: square"/>
+                <Option type="QString" name="00: square" value="00"/>
               </Option>
               <Option type="Map">
-                <Option value="01" type="QString" name="01: round"/>
+                <Option type="QString" name="01: round" value="01"/>
               </Option>
               <Option type="Map">
-                <Option value="02" type="QString" name="02: rectangle"/>
+                <Option type="QString" name="02: rectangle" value="02"/>
               </Option>
             </Option>
           </Option>
@@ -293,8 +293,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -303,8 +303,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -315,13 +315,13 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="0" type="QString" name="0: inspection"/>
+                <Option type="QString" name="0: inspection" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1: outlet"/>
+                <Option type="QString" name="1: outlet" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: pump"/>
+                <Option type="QString" name="2: pump" value="2"/>
               </Option>
             </Option>
           </Option>
@@ -334,13 +334,13 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="0" type="QString" name="0: embedded"/>
+                <Option type="QString" name="0: embedded" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1: isolated"/>
+                <Option type="QString" name="1: isolated" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: connected"/>
+                <Option type="QString" name="2: connected" value="2"/>
               </Option>
             </Option>
           </Option>
@@ -351,8 +351,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -363,25 +363,25 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="-1" type="QString" name="-1"/>
+                <Option type="QString" name="-1" value="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" type="QString" name="0"/>
+                <Option type="QString" name="0" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1"/>
+                <Option type="QString" name="1" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2"/>
+                <Option type="QString" name="2" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3"/>
+                <Option type="QString" name="3" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4"/>
+                <Option type="QString" name="4" value="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5"/>
+                <Option type="QString" name="5" value="5"/>
               </Option>
             </Option>
           </Option>
@@ -392,8 +392,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -402,8 +402,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -412,8 +412,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -422,8 +422,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -432,8 +432,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -442,8 +442,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -452,8 +452,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -462,8 +462,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -494,98 +494,98 @@
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="node_id"/>
-    <default expression="&quot;manh_bottom_level&quot;&lt;&quot;manh_surface_level&quot;" applyOnUpdate="0" field="manh_bottom_level"/>
-    <default expression="" applyOnUpdate="0" field="manh_surface_level"/>
-    <default expression="'new'" applyOnUpdate="0" field="manh_display_name"/>
-    <default expression="'00'" applyOnUpdate="0" field="manh_shape"/>
-    <default expression="0.8" applyOnUpdate="0" field="manh_width"/>
-    <default expression="" applyOnUpdate="0" field="manh_length"/>
-    <default expression="'0'" applyOnUpdate="0" field="manh_manhole_indicator"/>
-    <default expression="" applyOnUpdate="0" field="manh_calculation_type"/>
-    <default expression="" applyOnUpdate="0" field="manh_drain_level"/>
-    <default expression="1" applyOnUpdate="0" field="manh_zoom_category"/>
-    <default expression="" applyOnUpdate="0" field="node_initial_waterlevel"/>
-    <default expression="if(maximum(manh_id) is null,1, maximum(manh_id)+1)" applyOnUpdate="0" field="manh_id"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="manh_connection_node_id"/>
-    <default expression="" applyOnUpdate="0" field="node_storage_area"/>
-    <default expression="'new'" applyOnUpdate="0" field="manh_code"/>
-    <default expression="'new'" applyOnUpdate="0" field="node_code"/>
-    <default expression="" applyOnUpdate="0" field="node_the_geom_linestring"/>
-    <default expression="" applyOnUpdate="0" field="manh_sediment_level"/>
+    <default field="ROWID" applyOnUpdate="0" expression=""/>
+    <default field="node_id" applyOnUpdate="0" expression="'filled automatically'"/>
+    <default field="manh_bottom_level" applyOnUpdate="0" expression="&quot;manh_bottom_level&quot;&lt;&quot;manh_surface_level&quot;"/>
+    <default field="manh_surface_level" applyOnUpdate="0" expression=""/>
+    <default field="manh_display_name" applyOnUpdate="0" expression="'new'"/>
+    <default field="manh_shape" applyOnUpdate="0" expression="'00'"/>
+    <default field="manh_width" applyOnUpdate="0" expression="0.8"/>
+    <default field="manh_length" applyOnUpdate="0" expression=""/>
+    <default field="manh_manhole_indicator" applyOnUpdate="0" expression="'0'"/>
+    <default field="manh_calculation_type" applyOnUpdate="0" expression=""/>
+    <default field="manh_drain_level" applyOnUpdate="0" expression=""/>
+    <default field="manh_zoom_category" applyOnUpdate="0" expression="1"/>
+    <default field="node_initial_waterlevel" applyOnUpdate="0" expression=""/>
+    <default field="manh_id" applyOnUpdate="0" expression="if(maximum(manh_id) is null,1, maximum(manh_id)+1)"/>
+    <default field="manh_connection_node_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,geometry(@parent))))"/>
+    <default field="node_storage_area" applyOnUpdate="0" expression=""/>
+    <default field="manh_code" applyOnUpdate="0" expression="'new'"/>
+    <default field="node_code" applyOnUpdate="0" expression="'new'"/>
+    <default field="node_the_geom_linestring" applyOnUpdate="0" expression=""/>
+    <default field="manh_sediment_level" applyOnUpdate="0" expression=""/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_bottom_level"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_surface_level"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_shape"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_width"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_length"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_manhole_indicator"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_calculation_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_drain_level"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_initial_waterlevel"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_connection_node_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_storage_area"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="node_code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_the_geom_linestring"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_sediment_level"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_id" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_bottom_level" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_surface_level" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_display_name" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_shape" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_width" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_length" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_manhole_indicator" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_calculation_type" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_drain_level" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_zoom_category" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_initial_waterlevel" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_id" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_connection_node_id" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_storage_area" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="manh_code" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="node_code" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="node_the_geom_linestring" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="manh_sediment_level" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="node_id"/>
-    <constraint exp="" desc="" field="manh_bottom_level"/>
-    <constraint exp="" desc="" field="manh_surface_level"/>
-    <constraint exp="" desc="" field="manh_display_name"/>
-    <constraint exp="" desc="" field="manh_shape"/>
-    <constraint exp="" desc="" field="manh_width"/>
-    <constraint exp="" desc="" field="manh_length"/>
-    <constraint exp="" desc="" field="manh_manhole_indicator"/>
-    <constraint exp="" desc="" field="manh_calculation_type"/>
-    <constraint exp="" desc="" field="manh_drain_level"/>
-    <constraint exp="" desc="" field="manh_zoom_category"/>
-    <constraint exp="" desc="" field="node_initial_waterlevel"/>
-    <constraint exp="" desc="" field="manh_id"/>
-    <constraint exp="" desc="" field="manh_connection_node_id"/>
-    <constraint exp="" desc="" field="node_storage_area"/>
-    <constraint exp="" desc="" field="manh_code"/>
-    <constraint exp="" desc="" field="node_code"/>
-    <constraint exp="" desc="" field="node_the_geom_linestring"/>
-    <constraint exp="" desc="" field="manh_sediment_level"/>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="node_id" desc=""/>
+    <constraint exp="" field="manh_bottom_level" desc=""/>
+    <constraint exp="" field="manh_surface_level" desc=""/>
+    <constraint exp="" field="manh_display_name" desc=""/>
+    <constraint exp="" field="manh_shape" desc=""/>
+    <constraint exp="" field="manh_width" desc=""/>
+    <constraint exp="" field="manh_length" desc=""/>
+    <constraint exp="" field="manh_manhole_indicator" desc=""/>
+    <constraint exp="" field="manh_calculation_type" desc=""/>
+    <constraint exp="" field="manh_drain_level" desc=""/>
+    <constraint exp="" field="manh_zoom_category" desc=""/>
+    <constraint exp="" field="node_initial_waterlevel" desc=""/>
+    <constraint exp="" field="manh_id" desc=""/>
+    <constraint exp="" field="manh_connection_node_id" desc=""/>
+    <constraint exp="" field="node_storage_area" desc=""/>
+    <constraint exp="" field="manh_code" desc=""/>
+    <constraint exp="" field="node_code" desc=""/>
+    <constraint exp="" field="node_the_geom_linestring" desc=""/>
+    <constraint exp="" field="manh_sediment_level" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="&quot;manh_id&quot;">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;manh_id&quot;" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="ROWID"/>
-      <column width="-1" type="field" hidden="0" name="manh_id"/>
-      <column width="-1" type="field" hidden="0" name="manh_display_name"/>
-      <column width="-1" type="field" hidden="0" name="manh_code"/>
-      <column width="-1" type="field" hidden="0" name="manh_connection_node_id"/>
-      <column width="-1" type="field" hidden="0" name="manh_shape"/>
-      <column width="-1" type="field" hidden="0" name="manh_width"/>
-      <column width="-1" type="field" hidden="0" name="manh_length"/>
-      <column width="-1" type="field" hidden="0" name="manh_manhole_indicator"/>
-      <column width="-1" type="field" hidden="0" name="manh_calculation_type"/>
-      <column width="-1" type="field" hidden="0" name="manh_bottom_level"/>
-      <column width="-1" type="field" hidden="0" name="manh_surface_level"/>
-      <column width="-1" type="field" hidden="0" name="manh_drain_level"/>
-      <column width="-1" type="field" hidden="0" name="manh_sediment_level"/>
-      <column width="-1" type="field" hidden="0" name="manh_zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="node_id"/>
-      <column width="-1" type="field" hidden="0" name="node_storage_area"/>
-      <column width="-1" type="field" hidden="0" name="node_initial_waterlevel"/>
-      <column width="-1" type="field" hidden="0" name="node_code"/>
-      <column width="-1" type="field" hidden="0" name="node_the_geom_linestring"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column type="field" name="ROWID" width="-1" hidden="0"/>
+      <column type="field" name="manh_id" width="-1" hidden="0"/>
+      <column type="field" name="manh_display_name" width="-1" hidden="0"/>
+      <column type="field" name="manh_code" width="-1" hidden="0"/>
+      <column type="field" name="manh_connection_node_id" width="-1" hidden="0"/>
+      <column type="field" name="manh_shape" width="-1" hidden="0"/>
+      <column type="field" name="manh_width" width="-1" hidden="0"/>
+      <column type="field" name="manh_length" width="-1" hidden="0"/>
+      <column type="field" name="manh_manhole_indicator" width="-1" hidden="0"/>
+      <column type="field" name="manh_calculation_type" width="-1" hidden="0"/>
+      <column type="field" name="manh_bottom_level" width="-1" hidden="0"/>
+      <column type="field" name="manh_surface_level" width="-1" hidden="0"/>
+      <column type="field" name="manh_drain_level" width="-1" hidden="0"/>
+      <column type="field" name="manh_sediment_level" width="-1" hidden="0"/>
+      <column type="field" name="manh_zoom_category" width="-1" hidden="0"/>
+      <column type="field" name="node_id" width="-1" hidden="0"/>
+      <column type="field" name="node_storage_area" width="-1" hidden="0"/>
+      <column type="field" name="node_initial_waterlevel" width="-1" hidden="0"/>
+      <column type="field" name="node_code" width="-1" hidden="0"/>
+      <column type="field" name="node_the_geom_linestring" width="-1" hidden="0"/>
+      <column type="actions" width="-1" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -616,30 +616,30 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Manhole_view" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-        <attributeEditorField showLabel="1" name="manh_id" index="13"/>
-        <attributeEditorField showLabel="1" name="manh_display_name" index="4"/>
-        <attributeEditorField showLabel="1" name="manh_code" index="16"/>
-        <attributeEditorField showLabel="1" name="manh_calculation_type" index="9"/>
+    <attributeEditorContainer columnCount="1" visibilityExpression="" name="Manhole_view" groupBox="0" visibilityExpressionEnabled="0" showLabel="1">
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="manh_id" index="13" showLabel="1"/>
+        <attributeEditorField name="manh_display_name" index="4" showLabel="1"/>
+        <attributeEditorField name="manh_code" index="16" showLabel="1"/>
+        <attributeEditorField name="manh_calculation_type" index="9" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
-        <attributeEditorField showLabel="1" name="manh_shape" index="5"/>
-        <attributeEditorField showLabel="1" name="manh_width" index="6"/>
-        <attributeEditorField showLabel="1" name="manh_length" index="7"/>
-        <attributeEditorField showLabel="1" name="manh_bottom_level" index="2"/>
-        <attributeEditorField showLabel="1" name="manh_surface_level" index="3"/>
-        <attributeEditorField showLabel="1" name="manh_drain_level" index="10"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="manh_shape" index="5" showLabel="1"/>
+        <attributeEditorField name="manh_width" index="6" showLabel="1"/>
+        <attributeEditorField name="manh_length" index="7" showLabel="1"/>
+        <attributeEditorField name="manh_bottom_level" index="2" showLabel="1"/>
+        <attributeEditorField name="manh_surface_level" index="3" showLabel="1"/>
+        <attributeEditorField name="manh_drain_level" index="10" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualisation" columnCount="1">
-        <attributeEditorField showLabel="1" name="manh_manhole_indicator" index="8"/>
-        <attributeEditorField showLabel="1" name="manh_zoom_category" index="11"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Visualisation" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="manh_manhole_indicator" index="8" showLabel="1"/>
+        <attributeEditorField name="manh_zoom_category" index="11" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection node" columnCount="1">
-        <attributeEditorField showLabel="1" name="manh_connection_node_id" index="14"/>
-        <attributeEditorField showLabel="1" name="node_code" index="17"/>
-        <attributeEditorField showLabel="1" name="node_initial_waterlevel" index="12"/>
-        <attributeEditorField showLabel="1" name="node_storage_area" index="15"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Connection node" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="manh_connection_node_id" index="14" showLabel="1"/>
+        <attributeEditorField name="node_code" index="17" showLabel="1"/>
+        <attributeEditorField name="node_initial_waterlevel" index="12" showLabel="1"/>
+        <attributeEditorField name="node_storage_area" index="15" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_manhole_view.qml
+++ b/layer_styles/schematisation/v2_manhole_view.qml
@@ -1,22 +1,22 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.4.5-Madeira" styleCategories="AllStyleCategories" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyAlgorithm="0" labelsEnabled="0" simplifyDrawingTol="1" minScale="1e+08" maxScale="-4.65661e-10" simplifyDrawingHints="0" readOnly="0">
+<qgis maxScale="-4.65661e-10" simplifyDrawingTol="1" simplifyLocal="1" readOnly="0" simplifyDrawingHints="0" version="3.4.5-Madeira" styleCategories="AllStyleCategories" minScale="1e+08" labelsEnabled="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" enableorderby="0" symbollevels="0" type="RuleRenderer">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="RuleRenderer">
     <rules key="{4fbba513-a3b1-4a92-97bc-3d44735ac986}">
-      <rule scalemaxdenom="2500" symbol="0" filter="manh_manhole_indicator = 0" label="Inspectieput" key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}"/>
-      <rule scalemaxdenom="15000" symbol="1" filter="manh_manhole_indicator = 1" label="Uitlaat - boundary" key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}"/>
-      <rule scalemaxdenom="15000" symbol="2" filter="manh_calculation_type = 0" label="Uitlaat - connectie met 2d" key="{bb971e07-f3e6-48c3-b84b-12496560a739}"/>
-      <rule symbol="3" filter="manh_manhole_indicator = 2" label="Gemaalkelder" key="{a1d98efc-8098-4201-a75e-93dc7c47f076}"/>
-      <rule symbol="4" filter="manh_manhole_indicator = 3" label="Inprikpunt" key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}"/>
-      <rule symbol="5" filter="manh_manhole_indicator = 4" label="RWZI" key="{c3de3024-005b-42ac-9705-3bae1dc13053}"/>
+      <rule key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}" label="Inspectieput" scalemaxdenom="2500" filter="manh_manhole_indicator = 0" symbol="0"/>
+      <rule key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}" label="Uitlaat - boundary" scalemaxdenom="15000" filter="manh_manhole_indicator = 1" symbol="1"/>
+      <rule key="{bb971e07-f3e6-48c3-b84b-12496560a739}" label="Uitlaat - connectie met 2d" scalemaxdenom="15000" filter="manh_calculation_type = 0" symbol="2"/>
+      <rule key="{a1d98efc-8098-4201-a75e-93dc7c47f076}" label="Gemaalkelder" filter="manh_manhole_indicator = 2" symbol="3"/>
+      <rule key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}" label="Inprikpunt" filter="manh_manhole_indicator = 3" symbol="4"/>
+      <rule key="{c3de3024-005b-42ac-9705-3bae1dc13053}" label="RWZI" filter="manh_manhole_indicator = 4" symbol="5"/>
     </rules>
     <symbols>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="0">
-        <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+      <symbol alpha="1" clip_to_extent="1" name="0" force_rhr="0" type="marker">
+        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,255,127,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -37,15 +37,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="1">
-        <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+      <symbol alpha="1" clip_to_extent="1" name="1" force_rhr="0" type="marker">
+        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="170,0,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -66,15 +66,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="2">
-        <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+      <symbol alpha="1" clip_to_extent="1" name="2" force_rhr="0" type="marker">
+        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="254,0,199,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -95,15 +95,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="3">
-        <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+      <symbol alpha="1" clip_to_extent="1" name="3" force_rhr="0" type="marker">
+        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,170,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -124,15 +124,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="4">
-        <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+      <symbol alpha="1" clip_to_extent="1" name="4" force_rhr="0" type="marker">
+        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,255,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -153,15 +153,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="5">
-        <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+      <symbol alpha="1" clip_to_extent="1" name="5" force_rhr="0" type="marker">
+        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,170,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -182,9 +182,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -192,6 +192,7 @@
     </symbols>
   </renderer-v2>
   <customproperties>
+    <property value="manh_display_name" key="dualview/previewExpressions"/>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
@@ -199,22 +200,22 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" backgroundAlpha="255" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" maxScaleDenominator="1e+08" opacity="1" rotationOffset="270" scaleDependency="Area" minimumSize="0" width="15" minScaleDenominator="-4.65661e-10" backgroundColor="#ffffff" labelPlacementMethod="XHeight" diagramOrientation="Up" barWidth="5" enabled="0" height="15" penWidth="0" penAlpha="255" scaleBasedVisibility="0">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory minimumSize="0" height="15" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" penWidth="0" labelPlacementMethod="XHeight" opacity="1" width="15" sizeType="MM" enabled="0" lineSizeType="MM" penColor="#000000" maxScaleDenominator="1e+08" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" backgroundAlpha="255" penAlpha="255" barWidth="5" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute color="#000000" field="" label=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings priority="0" linePlacementFlags="2" dist="0" zIndex="0" showAll="1" obstacle="0" placement="0">
+  <DiagramLayerSettings dist="0" zIndex="0" placement="0" showAll="1" linePlacementFlags="2" priority="0" obstacle="0">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -222,260 +223,368 @@
     <field name="ROWID">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_display_name">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_code">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_connection_node_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_shape">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_width">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_length">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_manhole_indicator">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_calculation_type">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_bottom_level">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_surface_level">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_drain_level">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_sediment_level">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="manh_zoom_category">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
     <field name="node_id">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
-    <field name="node_storage_area">
+    <field name="manh_bottom_level">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_surface_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="00" name="00: square" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="01" name="01: round" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="02" name="02: rectangle" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_length">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_manhole_indicator">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="0" name="0: Inspection" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1: Outlet" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2: Pump" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_calculation_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="0" name="0: embedded" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1: isolated" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2: connected" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_drain_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="-1" name="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="0" name="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="3" name="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="4" name="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="5" name="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
         </config>
       </editWidget>
     </field>
     <field name="node_initial_waterlevel">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="node_storage_area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
     <field name="node_code">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
     <field name="node_the_geom_linestring">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="manh_sediment_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" field="ROWID" name=""/>
-    <alias index="1" field="manh_id" name=""/>
-    <alias index="2" field="manh_display_name" name=""/>
-    <alias index="3" field="manh_code" name=""/>
-    <alias index="4" field="manh_connection_node_id" name=""/>
-    <alias index="5" field="manh_shape" name=""/>
-    <alias index="6" field="manh_width" name=""/>
-    <alias index="7" field="manh_length" name=""/>
-    <alias index="8" field="manh_manhole_indicator" name=""/>
-    <alias index="9" field="manh_calculation_type" name=""/>
-    <alias index="10" field="manh_bottom_level" name=""/>
-    <alias index="11" field="manh_surface_level" name=""/>
-    <alias index="12" field="manh_drain_level" name=""/>
-    <alias index="13" field="manh_sediment_level" name=""/>
-    <alias index="14" field="manh_zoom_category" name=""/>
-    <alias index="15" field="node_id" name=""/>
-    <alias index="16" field="node_storage_area" name=""/>
-    <alias index="17" field="node_initial_waterlevel" name=""/>
-    <alias index="18" field="node_code" name=""/>
-    <alias index="19" field="node_the_geom_linestring" name=""/>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="" field="node_id"/>
+    <alias index="2" name="bottom_level" field="manh_bottom_level"/>
+    <alias index="3" name="surface_level" field="manh_surface_level"/>
+    <alias index="4" name="display_name" field="manh_display_name"/>
+    <alias index="5" name="shape" field="manh_shape"/>
+    <alias index="6" name="width" field="manh_width"/>
+    <alias index="7" name="length" field="manh_length"/>
+    <alias index="8" name="manhole_indicator" field="manh_manhole_indicator"/>
+    <alias index="9" name="calculation_type" field="manh_calculation_type"/>
+    <alias index="10" name="drain_level" field="manh_drain_level"/>
+    <alias index="11" name="zoom_category" field="manh_zoom_category"/>
+    <alias index="12" name="" field="node_initial_waterlevel"/>
+    <alias index="13" name="id" field="manh_id"/>
+    <alias index="14" name="connection_node_id" field="manh_connection_node_id"/>
+    <alias index="15" name="" field="node_storage_area"/>
+    <alias index="16" name="code" field="manh_code"/>
+    <alias index="17" name="" field="node_code"/>
+    <alias index="18" name="the_geom_linestring" field="node_the_geom_linestring"/>
+    <alias index="19" name="sediment_level" field="manh_sediment_level"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" field="ROWID" applyOnUpdate="0"/>
-    <default expression="" field="manh_id" applyOnUpdate="0"/>
-    <default expression="" field="manh_display_name" applyOnUpdate="0"/>
-    <default expression="" field="manh_code" applyOnUpdate="0"/>
-    <default expression="" field="manh_connection_node_id" applyOnUpdate="0"/>
-    <default expression="" field="manh_shape" applyOnUpdate="0"/>
-    <default expression="" field="manh_width" applyOnUpdate="0"/>
-    <default expression="" field="manh_length" applyOnUpdate="0"/>
-    <default expression="" field="manh_manhole_indicator" applyOnUpdate="0"/>
-    <default expression="" field="manh_calculation_type" applyOnUpdate="0"/>
-    <default expression="" field="manh_bottom_level" applyOnUpdate="0"/>
-    <default expression="" field="manh_surface_level" applyOnUpdate="0"/>
-    <default expression="" field="manh_drain_level" applyOnUpdate="0"/>
-    <default expression="" field="manh_sediment_level" applyOnUpdate="0"/>
-    <default expression="" field="manh_zoom_category" applyOnUpdate="0"/>
-    <default expression="" field="node_id" applyOnUpdate="0"/>
-    <default expression="" field="node_storage_area" applyOnUpdate="0"/>
-    <default expression="" field="node_initial_waterlevel" applyOnUpdate="0"/>
-    <default expression="" field="node_code" applyOnUpdate="0"/>
-    <default expression="" field="node_the_geom_linestring" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="" field="node_id"/>
+    <default applyOnUpdate="0" expression="" field="manh_bottom_level"/>
+    <default applyOnUpdate="0" expression="" field="manh_surface_level"/>
+    <default applyOnUpdate="0" expression="'new'" field="manh_display_name"/>
+    <default applyOnUpdate="0" expression="'00'" field="manh_shape"/>
+    <default applyOnUpdate="0" expression="0.8" field="manh_width"/>
+    <default applyOnUpdate="0" expression="" field="manh_length"/>
+    <default applyOnUpdate="0" expression="'0'" field="manh_manhole_indicator"/>
+    <default applyOnUpdate="0" expression="" field="manh_calculation_type"/>
+    <default applyOnUpdate="0" expression="" field="manh_drain_level"/>
+    <default applyOnUpdate="0" expression="1" field="manh_zoom_category"/>
+    <default applyOnUpdate="0" expression="" field="node_initial_waterlevel"/>
+    <default applyOnUpdate="0" expression="if(maximum(manh_id) is null,1, maximum(manh_id)+1)" field="manh_id"/>
+    <default applyOnUpdate="0" expression="" field="manh_connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="node_storage_area"/>
+    <default applyOnUpdate="0" expression="'new'" field="manh_code"/>
+    <default applyOnUpdate="0" expression="'new'" field="node_code"/>
+    <default applyOnUpdate="0" expression="" field="node_the_geom_linestring"/>
+    <default applyOnUpdate="0" expression="" field="manh_sediment_level"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="0" field="ROWID" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_id" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_display_name" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_code" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_connection_node_id" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_shape" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_width" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_length" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_manhole_indicator" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_calculation_type" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_bottom_level" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_surface_level" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_drain_level" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_sediment_level" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="manh_zoom_category" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="node_id" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="node_storage_area" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="node_initial_waterlevel" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="node_code" constraints="0" exp_strength="0" notnull_strength="0"/>
-    <constraint unique_strength="0" field="node_the_geom_linestring" constraints="0" exp_strength="0" notnull_strength="0"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="ROWID"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_id"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_bottom_level"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_surface_level"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_display_name"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_shape"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_width"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_length"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_manhole_indicator"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_calculation_type"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_drain_level"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_zoom_category"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_initial_waterlevel"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_id"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_connection_node_id"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_storage_area"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_code"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="node_code"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_the_geom_linestring"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_sediment_level"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" field="ROWID" exp=""/>
-    <constraint desc="" field="manh_id" exp=""/>
-    <constraint desc="" field="manh_display_name" exp=""/>
-    <constraint desc="" field="manh_code" exp=""/>
-    <constraint desc="" field="manh_connection_node_id" exp=""/>
-    <constraint desc="" field="manh_shape" exp=""/>
-    <constraint desc="" field="manh_width" exp=""/>
-    <constraint desc="" field="manh_length" exp=""/>
-    <constraint desc="" field="manh_manhole_indicator" exp=""/>
-    <constraint desc="" field="manh_calculation_type" exp=""/>
-    <constraint desc="" field="manh_bottom_level" exp=""/>
-    <constraint desc="" field="manh_surface_level" exp=""/>
-    <constraint desc="" field="manh_drain_level" exp=""/>
-    <constraint desc="" field="manh_sediment_level" exp=""/>
-    <constraint desc="" field="manh_zoom_category" exp=""/>
-    <constraint desc="" field="node_id" exp=""/>
-    <constraint desc="" field="node_storage_area" exp=""/>
-    <constraint desc="" field="node_initial_waterlevel" exp=""/>
-    <constraint desc="" field="node_code" exp=""/>
-    <constraint desc="" field="node_the_geom_linestring" exp=""/>
+    <constraint desc="" exp="" field="ROWID"/>
+    <constraint desc="" exp="" field="node_id"/>
+    <constraint desc="" exp="" field="manh_bottom_level"/>
+    <constraint desc="" exp="" field="manh_surface_level"/>
+    <constraint desc="" exp="" field="manh_display_name"/>
+    <constraint desc="" exp="" field="manh_shape"/>
+    <constraint desc="" exp="" field="manh_width"/>
+    <constraint desc="" exp="" field="manh_length"/>
+    <constraint desc="" exp="" field="manh_manhole_indicator"/>
+    <constraint desc="" exp="" field="manh_calculation_type"/>
+    <constraint desc="" exp="" field="manh_drain_level"/>
+    <constraint desc="" exp="" field="manh_zoom_category"/>
+    <constraint desc="" exp="" field="node_initial_waterlevel"/>
+    <constraint desc="" exp="" field="manh_id"/>
+    <constraint desc="" exp="" field="manh_connection_node_id"/>
+    <constraint desc="" exp="" field="node_storage_area"/>
+    <constraint desc="" exp="" field="manh_code"/>
+    <constraint desc="" exp="" field="node_code"/>
+    <constraint desc="" exp="" field="node_the_geom_linestring"/>
+    <constraint desc="" exp="" field="manh_sediment_level"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig sortExpression="&quot;manh_id&quot;" actionWidgetStyle="dropDown" sortOrder="0">
     <columns>
-      <column hidden="0" width="-1" type="field" name="ROWID"/>
-      <column hidden="0" width="-1" type="field" name="manh_id"/>
-      <column hidden="0" width="-1" type="field" name="manh_display_name"/>
-      <column hidden="0" width="-1" type="field" name="manh_code"/>
-      <column hidden="0" width="-1" type="field" name="manh_connection_node_id"/>
-      <column hidden="0" width="-1" type="field" name="manh_shape"/>
-      <column hidden="0" width="-1" type="field" name="manh_width"/>
-      <column hidden="0" width="-1" type="field" name="manh_length"/>
-      <column hidden="0" width="-1" type="field" name="manh_manhole_indicator"/>
-      <column hidden="0" width="-1" type="field" name="manh_calculation_type"/>
-      <column hidden="0" width="-1" type="field" name="manh_bottom_level"/>
-      <column hidden="0" width="-1" type="field" name="manh_surface_level"/>
-      <column hidden="0" width="-1" type="field" name="manh_drain_level"/>
-      <column hidden="0" width="-1" type="field" name="manh_sediment_level"/>
-      <column hidden="0" width="-1" type="field" name="manh_zoom_category"/>
-      <column hidden="0" width="-1" type="field" name="node_id"/>
-      <column hidden="0" width="-1" type="field" name="node_storage_area"/>
-      <column hidden="0" width="-1" type="field" name="node_initial_waterlevel"/>
-      <column hidden="0" width="-1" type="field" name="node_code"/>
-      <column hidden="0" width="-1" type="field" name="node_the_geom_linestring"/>
+      <column hidden="0" name="ROWID" width="-1" type="field"/>
+      <column hidden="0" name="manh_id" width="-1" type="field"/>
+      <column hidden="0" name="manh_display_name" width="-1" type="field"/>
+      <column hidden="0" name="manh_code" width="-1" type="field"/>
+      <column hidden="0" name="manh_connection_node_id" width="-1" type="field"/>
+      <column hidden="0" name="manh_shape" width="-1" type="field"/>
+      <column hidden="0" name="manh_width" width="-1" type="field"/>
+      <column hidden="0" name="manh_length" width="-1" type="field"/>
+      <column hidden="0" name="manh_manhole_indicator" width="-1" type="field"/>
+      <column hidden="0" name="manh_calculation_type" width="-1" type="field"/>
+      <column hidden="0" name="manh_bottom_level" width="-1" type="field"/>
+      <column hidden="0" name="manh_surface_level" width="-1" type="field"/>
+      <column hidden="0" name="manh_drain_level" width="-1" type="field"/>
+      <column hidden="0" name="manh_sediment_level" width="-1" type="field"/>
+      <column hidden="0" name="manh_zoom_category" width="-1" type="field"/>
+      <column hidden="0" name="node_id" width="-1" type="field"/>
+      <column hidden="0" name="node_storage_area" width="-1" type="field"/>
+      <column hidden="0" name="node_initial_waterlevel" width="-1" type="field"/>
+      <column hidden="0" name="node_code" width="-1" type="field"/>
+      <column hidden="0" name="node_the_geom_linestring" width="-1" type="field"/>
       <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -505,50 +614,79 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" name="Manhole_view" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="13" name="manh_id"/>
+        <attributeEditorField showLabel="1" index="4" name="manh_display_name"/>
+        <attributeEditorField showLabel="1" index="16" name="manh_code"/>
+        <attributeEditorField showLabel="1" index="9" name="manh_calculation_type"/>
+        <attributeEditorField showLabel="1" index="14" name="manh_connection_node_id"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="5" name="manh_shape"/>
+        <attributeEditorField showLabel="1" index="6" name="manh_width"/>
+        <attributeEditorField showLabel="1" index="7" name="manh_length"/>
+        <attributeEditorField showLabel="1" index="2" name="manh_bottom_level"/>
+        <attributeEditorField showLabel="1" index="3" name="manh_surface_level"/>
+        <attributeEditorField showLabel="1" index="10" name="manh_drain_level"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Visualisation" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="8" name="manh_manhole_indicator"/>
+        <attributeEditorField showLabel="1" index="11" name="manh_zoom_category"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Connection node" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="1" name="node_id"/>
+        <attributeEditorField showLabel="1" index="17" name="node_code"/>
+        <attributeEditorField showLabel="1" index="12" name="node_initial_waterlevel"/>
+        <attributeEditorField showLabel="1" index="15" name="node_storage_area"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
   <editable>
-    <field editable="1" name="ROWID"/>
-    <field editable="1" name="manh_bottom_level"/>
-    <field editable="1" name="manh_calculation_type"/>
-    <field editable="1" name="manh_code"/>
-    <field editable="1" name="manh_connection_node_id"/>
-    <field editable="1" name="manh_display_name"/>
-    <field editable="1" name="manh_drain_level"/>
-    <field editable="1" name="manh_id"/>
-    <field editable="1" name="manh_length"/>
-    <field editable="1" name="manh_manhole_indicator"/>
-    <field editable="1" name="manh_sediment_level"/>
-    <field editable="1" name="manh_shape"/>
-    <field editable="1" name="manh_surface_level"/>
-    <field editable="1" name="manh_width"/>
-    <field editable="1" name="manh_zoom_category"/>
-    <field editable="1" name="node_code"/>
-    <field editable="1" name="node_id"/>
-    <field editable="1" name="node_initial_waterlevel"/>
-    <field editable="1" name="node_storage_area"/>
-    <field editable="1" name="node_the_geom_linestring"/>
+    <field name="ROWID" editable="1"/>
+    <field name="manh_bottom_level" editable="1"/>
+    <field name="manh_calculation_type" editable="1"/>
+    <field name="manh_code" editable="1"/>
+    <field name="manh_connection_node_id" editable="1"/>
+    <field name="manh_display_name" editable="1"/>
+    <field name="manh_drain_level" editable="1"/>
+    <field name="manh_id" editable="0"/>
+    <field name="manh_length" editable="1"/>
+    <field name="manh_manhole_indicator" editable="1"/>
+    <field name="manh_sediment_level" editable="1"/>
+    <field name="manh_shape" editable="1"/>
+    <field name="manh_surface_level" editable="1"/>
+    <field name="manh_width" editable="1"/>
+    <field name="manh_zoom_category" editable="1"/>
+    <field name="node_code" editable="1"/>
+    <field name="node_id" editable="1"/>
+    <field name="node_initial_waterlevel" editable="1"/>
+    <field name="node_storage_area" editable="1"/>
+    <field name="node_the_geom_linestring" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ROWID"/>
-    <field labelOnTop="0" name="manh_bottom_level"/>
-    <field labelOnTop="0" name="manh_calculation_type"/>
-    <field labelOnTop="0" name="manh_code"/>
-    <field labelOnTop="0" name="manh_connection_node_id"/>
-    <field labelOnTop="0" name="manh_display_name"/>
-    <field labelOnTop="0" name="manh_drain_level"/>
-    <field labelOnTop="0" name="manh_id"/>
-    <field labelOnTop="0" name="manh_length"/>
-    <field labelOnTop="0" name="manh_manhole_indicator"/>
-    <field labelOnTop="0" name="manh_sediment_level"/>
-    <field labelOnTop="0" name="manh_shape"/>
-    <field labelOnTop="0" name="manh_surface_level"/>
-    <field labelOnTop="0" name="manh_width"/>
-    <field labelOnTop="0" name="manh_zoom_category"/>
-    <field labelOnTop="0" name="node_code"/>
-    <field labelOnTop="0" name="node_id"/>
-    <field labelOnTop="0" name="node_initial_waterlevel"/>
-    <field labelOnTop="0" name="node_storage_area"/>
-    <field labelOnTop="0" name="node_the_geom_linestring"/>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="manh_bottom_level" labelOnTop="0"/>
+    <field name="manh_calculation_type" labelOnTop="0"/>
+    <field name="manh_code" labelOnTop="0"/>
+    <field name="manh_connection_node_id" labelOnTop="0"/>
+    <field name="manh_display_name" labelOnTop="0"/>
+    <field name="manh_drain_level" labelOnTop="0"/>
+    <field name="manh_id" labelOnTop="0"/>
+    <field name="manh_length" labelOnTop="0"/>
+    <field name="manh_manhole_indicator" labelOnTop="0"/>
+    <field name="manh_sediment_level" labelOnTop="0"/>
+    <field name="manh_shape" labelOnTop="0"/>
+    <field name="manh_surface_level" labelOnTop="0"/>
+    <field name="manh_width" labelOnTop="0"/>
+    <field name="manh_zoom_category" labelOnTop="0"/>
+    <field name="node_code" labelOnTop="0"/>
+    <field name="node_id" labelOnTop="0"/>
+    <field name="node_initial_waterlevel" labelOnTop="0"/>
+    <field name="node_storage_area" labelOnTop="0"/>
+    <field name="node_the_geom_linestring" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>manh_display_name</previewExpression>

--- a/layer_styles/schematisation/v2_manhole_view.qml
+++ b/layer_styles/schematisation/v2_manhole_view.qml
@@ -1,22 +1,22 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis maxScale="-4.65661e-10" simplifyDrawingTol="1" simplifyLocal="1" readOnly="0" simplifyDrawingHints="0" version="3.4.5-Madeira" styleCategories="AllStyleCategories" minScale="1e+08" labelsEnabled="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="0" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="RuleRenderer">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" forceraster="0" symbollevels="0">
     <rules key="{4fbba513-a3b1-4a92-97bc-3d44735ac986}">
-      <rule key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}" label="Inspectieput" scalemaxdenom="2500" filter="manh_manhole_indicator = 0" symbol="0"/>
-      <rule key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}" label="Uitlaat - boundary" scalemaxdenom="15000" filter="manh_manhole_indicator = 1" symbol="1"/>
-      <rule key="{bb971e07-f3e6-48c3-b84b-12496560a739}" label="Uitlaat - connectie met 2d" scalemaxdenom="15000" filter="manh_calculation_type = 0" symbol="2"/>
-      <rule key="{a1d98efc-8098-4201-a75e-93dc7c47f076}" label="Gemaalkelder" filter="manh_manhole_indicator = 2" symbol="3"/>
-      <rule key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}" label="Inprikpunt" filter="manh_manhole_indicator = 3" symbol="4"/>
-      <rule key="{c3de3024-005b-42ac-9705-3bae1dc13053}" label="RWZI" filter="manh_manhole_indicator = 4" symbol="5"/>
+      <rule key="{a951db60-faa9-4c95-9eaa-a51d84ff90b1}" symbol="0" scalemaxdenom="2500" label="Inspectieput" filter="manh_manhole_indicator = 0"/>
+      <rule key="{c9e7ab73-45d5-45d6-970d-b4e28230c1e5}" symbol="1" scalemaxdenom="15000" label="Uitlaat - boundary" filter="manh_manhole_indicator = 1"/>
+      <rule key="{bb971e07-f3e6-48c3-b84b-12496560a739}" symbol="2" scalemaxdenom="15000" label="Uitlaat - connectie met 2d" filter="manh_calculation_type = 0"/>
+      <rule key="{a1d98efc-8098-4201-a75e-93dc7c47f076}" symbol="3" label="Gemaalkelder" filter="manh_manhole_indicator = 2"/>
+      <rule key="{b15fd57b-e6e4-43b6-8496-7ebf4f15ea68}" symbol="4" label="Inprikpunt" filter="manh_manhole_indicator = 3"/>
+      <rule key="{c3de3024-005b-42ac-9705-3bae1dc13053}" symbol="5" label="RWZI" filter="manh_manhole_indicator = 4"/>
     </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" name="0" force_rhr="0" type="marker">
-        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="0">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,255,127,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -37,15 +37,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" name="1" force_rhr="0" type="marker">
-        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="1">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="170,0,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -66,15 +66,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" name="2" force_rhr="0" type="marker">
-        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="2">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="254,0,199,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -95,15 +95,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" name="3" force_rhr="0" type="marker">
-        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="3">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,170,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -124,15 +124,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" name="4" force_rhr="0" type="marker">
-        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="4">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,255,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -153,15 +153,15 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" name="5" force_rhr="0" type="marker">
-        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="5">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="85,170,255,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -182,9 +182,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -200,22 +200,22 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory minimumSize="0" height="15" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" penWidth="0" labelPlacementMethod="XHeight" opacity="1" width="15" sizeType="MM" enabled="0" lineSizeType="MM" penColor="#000000" maxScaleDenominator="1e+08" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" backgroundAlpha="255" penAlpha="255" barWidth="5" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" color="#000000" field=""/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" zIndex="0" placement="0" showAll="1" linePlacementFlags="2" priority="0" obstacle="0">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -224,8 +224,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -234,8 +234,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -244,8 +244,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -254,8 +254,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -264,8 +264,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -274,15 +274,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="00" name="00: square" type="QString"/>
+                <Option value="00" type="QString" name="00: square"/>
               </Option>
               <Option type="Map">
-                <Option value="01" name="01: round" type="QString"/>
+                <Option value="01" type="QString" name="01: round"/>
               </Option>
               <Option type="Map">
-                <Option value="02" name="02: rectangle" type="QString"/>
+                <Option value="02" type="QString" name="02: rectangle"/>
               </Option>
             </Option>
           </Option>
@@ -293,8 +293,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -303,8 +303,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -313,15 +313,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="0" name="0: Inspection" type="QString"/>
+                <Option value="0" type="QString" name="0: inspection"/>
               </Option>
               <Option type="Map">
-                <Option value="1" name="1: Outlet" type="QString"/>
+                <Option value="1" type="QString" name="1: outlet"/>
               </Option>
               <Option type="Map">
-                <Option value="2" name="2: Pump" type="QString"/>
+                <Option value="2" type="QString" name="2: pump"/>
               </Option>
             </Option>
           </Option>
@@ -332,15 +332,15 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="0" name="0: embedded" type="QString"/>
+                <Option value="0" type="QString" name="0: embedded"/>
               </Option>
               <Option type="Map">
-                <Option value="1" name="1: isolated" type="QString"/>
+                <Option value="1" type="QString" name="1: isolated"/>
               </Option>
               <Option type="Map">
-                <Option value="2" name="2: connected" type="QString"/>
+                <Option value="2" type="QString" name="2: connected"/>
               </Option>
             </Option>
           </Option>
@@ -351,8 +351,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -361,27 +361,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="-1" name="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" name="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" name="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" name="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" name="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" name="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" name="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -392,8 +392,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -402,8 +402,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -412,8 +412,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -422,8 +422,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -432,8 +432,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -442,8 +442,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -452,8 +452,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -462,130 +462,130 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="ROWID"/>
-    <alias index="1" name="" field="node_id"/>
-    <alias index="2" name="bottom_level" field="manh_bottom_level"/>
-    <alias index="3" name="surface_level" field="manh_surface_level"/>
-    <alias index="4" name="display_name" field="manh_display_name"/>
-    <alias index="5" name="shape" field="manh_shape"/>
-    <alias index="6" name="width" field="manh_width"/>
-    <alias index="7" name="length" field="manh_length"/>
-    <alias index="8" name="manhole_indicator" field="manh_manhole_indicator"/>
-    <alias index="9" name="calculation_type" field="manh_calculation_type"/>
-    <alias index="10" name="drain_level" field="manh_drain_level"/>
-    <alias index="11" name="zoom_category" field="manh_zoom_category"/>
-    <alias index="12" name="" field="node_initial_waterlevel"/>
-    <alias index="13" name="id" field="manh_id"/>
-    <alias index="14" name="connection_node_id" field="manh_connection_node_id"/>
-    <alias index="15" name="" field="node_storage_area"/>
-    <alias index="16" name="code" field="manh_code"/>
-    <alias index="17" name="" field="node_code"/>
-    <alias index="18" name="the_geom_linestring" field="node_the_geom_linestring"/>
-    <alias index="19" name="sediment_level" field="manh_sediment_level"/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="" field="node_id" index="1"/>
+    <alias name="bottom_level" field="manh_bottom_level" index="2"/>
+    <alias name="surface_level" field="manh_surface_level" index="3"/>
+    <alias name="display_name" field="manh_display_name" index="4"/>
+    <alias name="shape" field="manh_shape" index="5"/>
+    <alias name="width" field="manh_width" index="6"/>
+    <alias name="length" field="manh_length" index="7"/>
+    <alias name="manhole_indicator" field="manh_manhole_indicator" index="8"/>
+    <alias name="calculation_type" field="manh_calculation_type" index="9"/>
+    <alias name="drain_level" field="manh_drain_level" index="10"/>
+    <alias name="zoom_category" field="manh_zoom_category" index="11"/>
+    <alias name="" field="node_initial_waterlevel" index="12"/>
+    <alias name="id" field="manh_id" index="13"/>
+    <alias name="connection_node_id" field="manh_connection_node_id" index="14"/>
+    <alias name="" field="node_storage_area" index="15"/>
+    <alias name="code" field="manh_code" index="16"/>
+    <alias name="" field="node_code" index="17"/>
+    <alias name="the_geom_linestring" field="node_the_geom_linestring" index="18"/>
+    <alias name="sediment_level" field="manh_sediment_level" index="19"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" expression="" field="ROWID"/>
-    <default applyOnUpdate="0" expression="" field="node_id"/>
-    <default applyOnUpdate="0" expression="" field="manh_bottom_level"/>
-    <default applyOnUpdate="0" expression="" field="manh_surface_level"/>
-    <default applyOnUpdate="0" expression="'new'" field="manh_display_name"/>
-    <default applyOnUpdate="0" expression="'00'" field="manh_shape"/>
-    <default applyOnUpdate="0" expression="0.8" field="manh_width"/>
-    <default applyOnUpdate="0" expression="" field="manh_length"/>
-    <default applyOnUpdate="0" expression="'0'" field="manh_manhole_indicator"/>
-    <default applyOnUpdate="0" expression="" field="manh_calculation_type"/>
-    <default applyOnUpdate="0" expression="" field="manh_drain_level"/>
-    <default applyOnUpdate="0" expression="1" field="manh_zoom_category"/>
-    <default applyOnUpdate="0" expression="" field="node_initial_waterlevel"/>
-    <default applyOnUpdate="0" expression="if(maximum(manh_id) is null,1, maximum(manh_id)+1)" field="manh_id"/>
-    <default applyOnUpdate="0" expression="" field="manh_connection_node_id"/>
-    <default applyOnUpdate="0" expression="" field="node_storage_area"/>
-    <default applyOnUpdate="0" expression="'new'" field="manh_code"/>
-    <default applyOnUpdate="0" expression="'new'" field="node_code"/>
-    <default applyOnUpdate="0" expression="" field="node_the_geom_linestring"/>
-    <default applyOnUpdate="0" expression="" field="manh_sediment_level"/>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="node_id"/>
+    <default expression="&quot;manh_bottom_level&quot;&lt;&quot;manh_surface_level&quot;" applyOnUpdate="0" field="manh_bottom_level"/>
+    <default expression="" applyOnUpdate="0" field="manh_surface_level"/>
+    <default expression="'new'" applyOnUpdate="0" field="manh_display_name"/>
+    <default expression="'00'" applyOnUpdate="0" field="manh_shape"/>
+    <default expression="0.8" applyOnUpdate="0" field="manh_width"/>
+    <default expression="" applyOnUpdate="0" field="manh_length"/>
+    <default expression="'0'" applyOnUpdate="0" field="manh_manhole_indicator"/>
+    <default expression="" applyOnUpdate="0" field="manh_calculation_type"/>
+    <default expression="" applyOnUpdate="0" field="manh_drain_level"/>
+    <default expression="1" applyOnUpdate="0" field="manh_zoom_category"/>
+    <default expression="" applyOnUpdate="0" field="node_initial_waterlevel"/>
+    <default expression="if(maximum(manh_id) is null,1, maximum(manh_id)+1)" applyOnUpdate="0" field="manh_id"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="manh_connection_node_id"/>
+    <default expression="" applyOnUpdate="0" field="node_storage_area"/>
+    <default expression="'new'" applyOnUpdate="0" field="manh_code"/>
+    <default expression="'new'" applyOnUpdate="0" field="node_code"/>
+    <default expression="" applyOnUpdate="0" field="node_the_geom_linestring"/>
+    <default expression="" applyOnUpdate="0" field="manh_sediment_level"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="ROWID"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_id"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_bottom_level"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_surface_level"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_display_name"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_shape"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_width"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_length"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_manhole_indicator"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_calculation_type"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_drain_level"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_zoom_category"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_initial_waterlevel"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_id"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_connection_node_id"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_storage_area"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="manh_code"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="node_code"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="node_the_geom_linestring"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="manh_sediment_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_bottom_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_surface_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_shape"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_width"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_length"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_manhole_indicator"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_calculation_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_drain_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_initial_waterlevel"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_connection_node_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_storage_area"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="manh_code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="node_code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="node_the_geom_linestring"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="manh_sediment_level"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" exp="" field="ROWID"/>
-    <constraint desc="" exp="" field="node_id"/>
-    <constraint desc="" exp="" field="manh_bottom_level"/>
-    <constraint desc="" exp="" field="manh_surface_level"/>
-    <constraint desc="" exp="" field="manh_display_name"/>
-    <constraint desc="" exp="" field="manh_shape"/>
-    <constraint desc="" exp="" field="manh_width"/>
-    <constraint desc="" exp="" field="manh_length"/>
-    <constraint desc="" exp="" field="manh_manhole_indicator"/>
-    <constraint desc="" exp="" field="manh_calculation_type"/>
-    <constraint desc="" exp="" field="manh_drain_level"/>
-    <constraint desc="" exp="" field="manh_zoom_category"/>
-    <constraint desc="" exp="" field="node_initial_waterlevel"/>
-    <constraint desc="" exp="" field="manh_id"/>
-    <constraint desc="" exp="" field="manh_connection_node_id"/>
-    <constraint desc="" exp="" field="node_storage_area"/>
-    <constraint desc="" exp="" field="manh_code"/>
-    <constraint desc="" exp="" field="node_code"/>
-    <constraint desc="" exp="" field="node_the_geom_linestring"/>
-    <constraint desc="" exp="" field="manh_sediment_level"/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="node_id"/>
+    <constraint exp="" desc="" field="manh_bottom_level"/>
+    <constraint exp="" desc="" field="manh_surface_level"/>
+    <constraint exp="" desc="" field="manh_display_name"/>
+    <constraint exp="" desc="" field="manh_shape"/>
+    <constraint exp="" desc="" field="manh_width"/>
+    <constraint exp="" desc="" field="manh_length"/>
+    <constraint exp="" desc="" field="manh_manhole_indicator"/>
+    <constraint exp="" desc="" field="manh_calculation_type"/>
+    <constraint exp="" desc="" field="manh_drain_level"/>
+    <constraint exp="" desc="" field="manh_zoom_category"/>
+    <constraint exp="" desc="" field="node_initial_waterlevel"/>
+    <constraint exp="" desc="" field="manh_id"/>
+    <constraint exp="" desc="" field="manh_connection_node_id"/>
+    <constraint exp="" desc="" field="node_storage_area"/>
+    <constraint exp="" desc="" field="manh_code"/>
+    <constraint exp="" desc="" field="node_code"/>
+    <constraint exp="" desc="" field="node_the_geom_linestring"/>
+    <constraint exp="" desc="" field="manh_sediment_level"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="&quot;manh_id&quot;" actionWidgetStyle="dropDown" sortOrder="0">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="&quot;manh_id&quot;">
     <columns>
-      <column hidden="0" name="ROWID" width="-1" type="field"/>
-      <column hidden="0" name="manh_id" width="-1" type="field"/>
-      <column hidden="0" name="manh_display_name" width="-1" type="field"/>
-      <column hidden="0" name="manh_code" width="-1" type="field"/>
-      <column hidden="0" name="manh_connection_node_id" width="-1" type="field"/>
-      <column hidden="0" name="manh_shape" width="-1" type="field"/>
-      <column hidden="0" name="manh_width" width="-1" type="field"/>
-      <column hidden="0" name="manh_length" width="-1" type="field"/>
-      <column hidden="0" name="manh_manhole_indicator" width="-1" type="field"/>
-      <column hidden="0" name="manh_calculation_type" width="-1" type="field"/>
-      <column hidden="0" name="manh_bottom_level" width="-1" type="field"/>
-      <column hidden="0" name="manh_surface_level" width="-1" type="field"/>
-      <column hidden="0" name="manh_drain_level" width="-1" type="field"/>
-      <column hidden="0" name="manh_sediment_level" width="-1" type="field"/>
-      <column hidden="0" name="manh_zoom_category" width="-1" type="field"/>
-      <column hidden="0" name="node_id" width="-1" type="field"/>
-      <column hidden="0" name="node_storage_area" width="-1" type="field"/>
-      <column hidden="0" name="node_initial_waterlevel" width="-1" type="field"/>
-      <column hidden="0" name="node_code" width="-1" type="field"/>
-      <column hidden="0" name="node_the_geom_linestring" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="manh_id"/>
+      <column width="-1" type="field" hidden="0" name="manh_display_name"/>
+      <column width="-1" type="field" hidden="0" name="manh_code"/>
+      <column width="-1" type="field" hidden="0" name="manh_connection_node_id"/>
+      <column width="-1" type="field" hidden="0" name="manh_shape"/>
+      <column width="-1" type="field" hidden="0" name="manh_width"/>
+      <column width="-1" type="field" hidden="0" name="manh_length"/>
+      <column width="-1" type="field" hidden="0" name="manh_manhole_indicator"/>
+      <column width="-1" type="field" hidden="0" name="manh_calculation_type"/>
+      <column width="-1" type="field" hidden="0" name="manh_bottom_level"/>
+      <column width="-1" type="field" hidden="0" name="manh_surface_level"/>
+      <column width="-1" type="field" hidden="0" name="manh_drain_level"/>
+      <column width="-1" type="field" hidden="0" name="manh_sediment_level"/>
+      <column width="-1" type="field" hidden="0" name="manh_zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="node_id"/>
+      <column width="-1" type="field" hidden="0" name="node_storage_area"/>
+      <column width="-1" type="field" hidden="0" name="node_initial_waterlevel"/>
+      <column width="-1" type="field" hidden="0" name="node_code"/>
+      <column width="-1" type="field" hidden="0" name="node_the_geom_linestring"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -616,31 +616,30 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="Manhole_view" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
-      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="13" name="manh_id"/>
-        <attributeEditorField showLabel="1" index="4" name="manh_display_name"/>
-        <attributeEditorField showLabel="1" index="16" name="manh_code"/>
-        <attributeEditorField showLabel="1" index="9" name="manh_calculation_type"/>
-        <attributeEditorField showLabel="1" index="14" name="manh_connection_node_id"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Manhole_view" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="manh_id" index="13"/>
+        <attributeEditorField showLabel="1" name="manh_display_name" index="4"/>
+        <attributeEditorField showLabel="1" name="manh_code" index="16"/>
+        <attributeEditorField showLabel="1" name="manh_calculation_type" index="9"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="5" name="manh_shape"/>
-        <attributeEditorField showLabel="1" index="6" name="manh_width"/>
-        <attributeEditorField showLabel="1" index="7" name="manh_length"/>
-        <attributeEditorField showLabel="1" index="2" name="manh_bottom_level"/>
-        <attributeEditorField showLabel="1" index="3" name="manh_surface_level"/>
-        <attributeEditorField showLabel="1" index="10" name="manh_drain_level"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="manh_shape" index="5"/>
+        <attributeEditorField showLabel="1" name="manh_width" index="6"/>
+        <attributeEditorField showLabel="1" name="manh_length" index="7"/>
+        <attributeEditorField showLabel="1" name="manh_bottom_level" index="2"/>
+        <attributeEditorField showLabel="1" name="manh_surface_level" index="3"/>
+        <attributeEditorField showLabel="1" name="manh_drain_level" index="10"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Visualisation" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="8" name="manh_manhole_indicator"/>
-        <attributeEditorField showLabel="1" index="11" name="manh_zoom_category"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualisation" columnCount="1">
+        <attributeEditorField showLabel="1" name="manh_manhole_indicator" index="8"/>
+        <attributeEditorField showLabel="1" name="manh_zoom_category" index="11"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Connection node" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="1" name="node_id"/>
-        <attributeEditorField showLabel="1" index="17" name="node_code"/>
-        <attributeEditorField showLabel="1" index="12" name="node_initial_waterlevel"/>
-        <attributeEditorField showLabel="1" index="15" name="node_storage_area"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection node" columnCount="1">
+        <attributeEditorField showLabel="1" name="manh_connection_node_id" index="14"/>
+        <attributeEditorField showLabel="1" name="node_code" index="17"/>
+        <attributeEditorField showLabel="1" name="node_initial_waterlevel" index="12"/>
+        <attributeEditorField showLabel="1" name="node_storage_area" index="15"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -649,7 +648,7 @@ def my_form_open(dialog, layer, feature):
     <field name="manh_bottom_level" editable="1"/>
     <field name="manh_calculation_type" editable="1"/>
     <field name="manh_code" editable="1"/>
-    <field name="manh_connection_node_id" editable="1"/>
+    <field name="manh_connection_node_id" editable="0"/>
     <field name="manh_display_name" editable="1"/>
     <field name="manh_drain_level" editable="1"/>
     <field name="manh_id" editable="0"/>
@@ -661,32 +660,32 @@ def my_form_open(dialog, layer, feature):
     <field name="manh_width" editable="1"/>
     <field name="manh_zoom_category" editable="1"/>
     <field name="node_code" editable="1"/>
-    <field name="node_id" editable="1"/>
+    <field name="node_id" editable="0"/>
     <field name="node_initial_waterlevel" editable="1"/>
     <field name="node_storage_area" editable="1"/>
     <field name="node_the_geom_linestring" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="manh_bottom_level" labelOnTop="0"/>
-    <field name="manh_calculation_type" labelOnTop="0"/>
-    <field name="manh_code" labelOnTop="0"/>
-    <field name="manh_connection_node_id" labelOnTop="0"/>
-    <field name="manh_display_name" labelOnTop="0"/>
-    <field name="manh_drain_level" labelOnTop="0"/>
-    <field name="manh_id" labelOnTop="0"/>
-    <field name="manh_length" labelOnTop="0"/>
-    <field name="manh_manhole_indicator" labelOnTop="0"/>
-    <field name="manh_sediment_level" labelOnTop="0"/>
-    <field name="manh_shape" labelOnTop="0"/>
-    <field name="manh_surface_level" labelOnTop="0"/>
-    <field name="manh_width" labelOnTop="0"/>
-    <field name="manh_zoom_category" labelOnTop="0"/>
-    <field name="node_code" labelOnTop="0"/>
-    <field name="node_id" labelOnTop="0"/>
-    <field name="node_initial_waterlevel" labelOnTop="0"/>
-    <field name="node_storage_area" labelOnTop="0"/>
-    <field name="node_the_geom_linestring" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="manh_bottom_level"/>
+    <field labelOnTop="0" name="manh_calculation_type"/>
+    <field labelOnTop="0" name="manh_code"/>
+    <field labelOnTop="0" name="manh_connection_node_id"/>
+    <field labelOnTop="0" name="manh_display_name"/>
+    <field labelOnTop="0" name="manh_drain_level"/>
+    <field labelOnTop="0" name="manh_id"/>
+    <field labelOnTop="0" name="manh_length"/>
+    <field labelOnTop="0" name="manh_manhole_indicator"/>
+    <field labelOnTop="0" name="manh_sediment_level"/>
+    <field labelOnTop="0" name="manh_shape"/>
+    <field labelOnTop="0" name="manh_surface_level"/>
+    <field labelOnTop="0" name="manh_width"/>
+    <field labelOnTop="0" name="manh_zoom_category"/>
+    <field labelOnTop="0" name="node_code"/>
+    <field labelOnTop="0" name="node_id"/>
+    <field labelOnTop="0" name="node_initial_waterlevel"/>
+    <field labelOnTop="0" name="node_storage_area"/>
+    <field labelOnTop="0" name="node_the_geom_linestring"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>manh_display_name</previewExpression>

--- a/layer_styles/schematisation/v2_numerical_settings.qml
+++ b/layer_styles/schematisation/v2_numerical_settings.qml
@@ -1,0 +1,505 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis maxScale="0" version="3.4.5-Madeira" readOnly="0" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="dualview/previewExpressions">
+      <value>id</value>
+    </property>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cfl_strictness_factor_1d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cfl_strictness_factor_2d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="convergence_cg">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="convergence_eps">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="flow_direction_threshold">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="frict_shallow_water_correction">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="general_numerical_threshold">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="integration_method">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="limiter_grad_1d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="limiter_grad_2d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="limiter_slope_crossectional_area_2d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="limiter_slope_friction_2d">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_nonlin_iterations">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_degree">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="700" name="700: for 1D flow"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="5" name="5: for surface 2D flow only"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="7" name="7: for 1D and 2D flow"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="70" name="70: for surface 1D, 2D surface and groundwater flow or higher"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="minimum_friction_velocity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="minimum_surface_area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="precon_cg">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="preissmann_slot">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_implicit_ratio">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="thin_water_layer_definition">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_of_cg">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="use_of_nested_newton">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="0" name="0: for 2D or open profiles (like channels)"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1" name="1: for 1D systems with closed profiles (like sewerage)"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="id" index="0" name=""/>
+    <alias field="cfl_strictness_factor_1d" index="1" name=""/>
+    <alias field="cfl_strictness_factor_2d" index="2" name=""/>
+    <alias field="convergence_cg" index="3" name=""/>
+    <alias field="convergence_eps" index="4" name=""/>
+    <alias field="flow_direction_threshold" index="5" name=""/>
+    <alias field="frict_shallow_water_correction" index="6" name=""/>
+    <alias field="general_numerical_threshold" index="7" name=""/>
+    <alias field="integration_method" index="8" name=""/>
+    <alias field="limiter_grad_1d" index="9" name=""/>
+    <alias field="limiter_grad_2d" index="10" name=""/>
+    <alias field="limiter_slope_crossectional_area_2d" index="11" name=""/>
+    <alias field="limiter_slope_friction_2d" index="12" name=""/>
+    <alias field="max_nonlin_iterations" index="13" name=""/>
+    <alias field="max_degree" index="14" name=""/>
+    <alias field="minimum_friction_velocity" index="15" name=""/>
+    <alias field="minimum_surface_area" index="16" name=""/>
+    <alias field="precon_cg" index="17" name=""/>
+    <alias field="preissmann_slot" index="18" name=""/>
+    <alias field="pump_implicit_ratio" index="19" name=""/>
+    <alias field="thin_water_layer_definition" index="20" name=""/>
+    <alias field="use_of_cg" index="21" name=""/>
+    <alias field="use_of_nested_newton" index="22" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="id" expression=" if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
+    <default field="cfl_strictness_factor_1d" expression="" applyOnUpdate="0"/>
+    <default field="cfl_strictness_factor_2d" expression="" applyOnUpdate="0"/>
+    <default field="convergence_cg" expression="" applyOnUpdate="0"/>
+    <default field="convergence_eps" expression="0.00001" applyOnUpdate="0"/>
+    <default field="flow_direction_threshold" expression="" applyOnUpdate="0"/>
+    <default field="frict_shallow_water_correction" expression="" applyOnUpdate="0"/>
+    <default field="general_numerical_threshold" expression="" applyOnUpdate="0"/>
+    <default field="integration_method" expression="0" applyOnUpdate="0"/>
+    <default field="limiter_grad_1d" expression="" applyOnUpdate="0"/>
+    <default field="limiter_grad_2d" expression="" applyOnUpdate="0"/>
+    <default field="limiter_slope_crossectional_area_2d" expression="" applyOnUpdate="0"/>
+    <default field="limiter_slope_friction_2d" expression="" applyOnUpdate="0"/>
+    <default field="max_nonlin_iterations" expression="20" applyOnUpdate="0"/>
+    <default field="max_degree" expression="" applyOnUpdate="0"/>
+    <default field="minimum_friction_velocity" expression="" applyOnUpdate="0"/>
+    <default field="minimum_surface_area" expression="" applyOnUpdate="0"/>
+    <default field="precon_cg" expression="" applyOnUpdate="0"/>
+    <default field="preissmann_slot" expression="" applyOnUpdate="0"/>
+    <default field="pump_implicit_ratio" expression="" applyOnUpdate="0"/>
+    <default field="thin_water_layer_definition" expression="" applyOnUpdate="0"/>
+    <default field="use_of_cg" expression="20" applyOnUpdate="0"/>
+    <default field="use_of_nested_newton" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="id" constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint field="cfl_strictness_factor_1d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="cfl_strictness_factor_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="convergence_cg" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="convergence_eps" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="flow_direction_threshold" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="frict_shallow_water_correction" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="general_numerical_threshold" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="integration_method" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="limiter_grad_1d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="limiter_grad_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="limiter_slope_crossectional_area_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="limiter_slope_friction_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="max_nonlin_iterations" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="max_degree" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="minimum_friction_velocity" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="minimum_surface_area" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="precon_cg" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="preissmann_slot" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="pump_implicit_ratio" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="thin_water_layer_definition" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint field="use_of_cg" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint field="use_of_nested_newton" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="id" desc="" exp=""/>
+    <constraint field="cfl_strictness_factor_1d" desc="" exp=""/>
+    <constraint field="cfl_strictness_factor_2d" desc="" exp=""/>
+    <constraint field="convergence_cg" desc="" exp=""/>
+    <constraint field="convergence_eps" desc="" exp=""/>
+    <constraint field="flow_direction_threshold" desc="" exp=""/>
+    <constraint field="frict_shallow_water_correction" desc="" exp=""/>
+    <constraint field="general_numerical_threshold" desc="" exp=""/>
+    <constraint field="integration_method" desc="" exp=""/>
+    <constraint field="limiter_grad_1d" desc="" exp=""/>
+    <constraint field="limiter_grad_2d" desc="" exp=""/>
+    <constraint field="limiter_slope_crossectional_area_2d" desc="" exp=""/>
+    <constraint field="limiter_slope_friction_2d" desc="" exp=""/>
+    <constraint field="max_nonlin_iterations" desc="" exp=""/>
+    <constraint field="max_degree" desc="" exp=""/>
+    <constraint field="minimum_friction_velocity" desc="" exp=""/>
+    <constraint field="minimum_surface_area" desc="" exp=""/>
+    <constraint field="precon_cg" desc="" exp=""/>
+    <constraint field="preissmann_slot" desc="" exp=""/>
+    <constraint field="pump_implicit_ratio" desc="" exp=""/>
+    <constraint field="thin_water_layer_definition" desc="" exp=""/>
+    <constraint field="use_of_cg" desc="" exp=""/>
+    <constraint field="use_of_nested_newton" desc="" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+    <columns>
+      <column type="field" hidden="0" name="id" width="-1"/>
+      <column type="field" hidden="0" name="cfl_strictness_factor_1d" width="-1"/>
+      <column type="field" hidden="0" name="cfl_strictness_factor_2d" width="-1"/>
+      <column type="field" hidden="0" name="convergence_cg" width="-1"/>
+      <column type="field" hidden="0" name="convergence_eps" width="-1"/>
+      <column type="field" hidden="0" name="flow_direction_threshold" width="-1"/>
+      <column type="field" hidden="0" name="frict_shallow_water_correction" width="-1"/>
+      <column type="field" hidden="0" name="general_numerical_threshold" width="-1"/>
+      <column type="field" hidden="0" name="integration_method" width="-1"/>
+      <column type="field" hidden="0" name="limiter_grad_1d" width="-1"/>
+      <column type="field" hidden="0" name="limiter_grad_2d" width="-1"/>
+      <column type="field" hidden="0" name="limiter_slope_crossectional_area_2d" width="-1"/>
+      <column type="field" hidden="0" name="limiter_slope_friction_2d" width="-1"/>
+      <column type="field" hidden="0" name="max_nonlin_iterations" width="-1"/>
+      <column type="field" hidden="0" name="max_degree" width="-1"/>
+      <column type="field" hidden="0" name="minimum_friction_velocity" width="-1"/>
+      <column type="field" hidden="0" name="minimum_surface_area" width="-1"/>
+      <column type="field" hidden="0" name="precon_cg" width="-1"/>
+      <column type="field" hidden="0" name="preissmann_slot" width="-1"/>
+      <column type="field" hidden="0" name="pump_implicit_ratio" width="-1"/>
+      <column type="field" hidden="0" name="thin_water_layer_definition" width="-1"/>
+      <column type="field" hidden="0" name="use_of_cg" width="-1"/>
+      <column type="field" hidden="0" name="use_of_nested_newton" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General">
+      <attributeEditorField showLabel="1" index="0" name="id"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Limiters">
+      <attributeEditorField showLabel="1" index="9" name="limiter_grad_1d"/>
+      <attributeEditorField showLabel="1" index="10" name="limiter_grad_2d"/>
+      <attributeEditorField showLabel="1" index="11" name="limiter_slope_crossectional_area_2d"/>
+      <attributeEditorField showLabel="1" index="12" name="limiter_slope_friction_2d"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Matrix">
+      <attributeEditorField showLabel="1" index="3" name="convergence_cg"/>
+      <attributeEditorField showLabel="1" index="4" name="convergence_eps"/>
+      <attributeEditorField showLabel="1" index="21" name="use_of_cg"/>
+      <attributeEditorField showLabel="1" index="22" name="use_of_nested_newton"/>
+      <attributeEditorField showLabel="1" index="14" name="max_degree"/>
+      <attributeEditorField showLabel="1" index="13" name="max_nonlin_iterations"/>
+      <attributeEditorField showLabel="1" index="17" name="precon_cg"/>
+      <attributeEditorField showLabel="1" index="8" name="integration_method"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Thresholds">
+      <attributeEditorField showLabel="1" index="5" name="flow_direction_threshold"/>
+      <attributeEditorField showLabel="1" index="6" name="frict_shallow_water_correction"/>
+      <attributeEditorField showLabel="1" index="7" name="general_numerical_threshold"/>
+      <attributeEditorField showLabel="1" index="20" name="thin_water_layer_definition"/>
+      <attributeEditorField showLabel="1" index="15" name="minimum_friction_velocity"/>
+      <attributeEditorField showLabel="1" index="16" name="minimum_surface_area"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Miscelaneous">
+      <attributeEditorField showLabel="1" index="1" name="cfl_strictness_factor_1d"/>
+      <attributeEditorField showLabel="1" index="2" name="cfl_strictness_factor_2d"/>
+      <attributeEditorField showLabel="1" index="19" name="pump_implicit_ratio"/>
+      <attributeEditorField showLabel="1" index="18" name="preissmann_slot"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="cfl_strictness_factor_1d"/>
+    <field editable="1" name="cfl_strictness_factor_2d"/>
+    <field editable="1" name="convergence_cg"/>
+    <field editable="1" name="convergence_eps"/>
+    <field editable="1" name="flow_direction_threshold"/>
+    <field editable="1" name="frict_shallow_water_correction"/>
+    <field editable="1" name="general_numerical_threshold"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="integration_method"/>
+    <field editable="1" name="limiter_grad_1d"/>
+    <field editable="1" name="limiter_grad_2d"/>
+    <field editable="1" name="limiter_slope_crossectional_area_2d"/>
+    <field editable="1" name="limiter_slope_friction_2d"/>
+    <field editable="1" name="max_degree"/>
+    <field editable="1" name="max_nonlin_iterations"/>
+    <field editable="1" name="minimum_friction_velocity"/>
+    <field editable="1" name="minimum_surface_area"/>
+    <field editable="1" name="precon_cg"/>
+    <field editable="1" name="preissmann_slot"/>
+    <field editable="1" name="pump_implicit_ratio"/>
+    <field editable="1" name="thin_water_layer_definition"/>
+    <field editable="1" name="use_of_cg"/>
+    <field editable="1" name="use_of_nested_newton"/>
+  </editable>
+  <labelOnTop>
+    <field name="cfl_strictness_factor_1d" labelOnTop="0"/>
+    <field name="cfl_strictness_factor_2d" labelOnTop="0"/>
+    <field name="convergence_cg" labelOnTop="0"/>
+    <field name="convergence_eps" labelOnTop="0"/>
+    <field name="flow_direction_threshold" labelOnTop="0"/>
+    <field name="frict_shallow_water_correction" labelOnTop="0"/>
+    <field name="general_numerical_threshold" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="integration_method" labelOnTop="0"/>
+    <field name="limiter_grad_1d" labelOnTop="0"/>
+    <field name="limiter_grad_2d" labelOnTop="0"/>
+    <field name="limiter_slope_crossectional_area_2d" labelOnTop="0"/>
+    <field name="limiter_slope_friction_2d" labelOnTop="0"/>
+    <field name="max_degree" labelOnTop="0"/>
+    <field name="max_nonlin_iterations" labelOnTop="0"/>
+    <field name="minimum_friction_velocity" labelOnTop="0"/>
+    <field name="minimum_surface_area" labelOnTop="0"/>
+    <field name="precon_cg" labelOnTop="0"/>
+    <field name="preissmann_slot" labelOnTop="0"/>
+    <field name="pump_implicit_ratio" labelOnTop="0"/>
+    <field name="thin_water_layer_definition" labelOnTop="0"/>
+    <field name="use_of_cg" labelOnTop="0"/>
+    <field name="use_of_nested_newton" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_numerical_settings.qml
+++ b/layer_styles/schematisation/v2_numerical_settings.qml
@@ -254,10 +254,10 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option value="0" name="0: for 2D or open profiles (like channels)" type="QString"/>
+                <Option value="0" name="0: When the schematisation does not include 1D-elements with closed-profiles" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option value="1" name="1: for 1D systems with closed profiles (like sewerage)" type="QString"/>
+                <Option value="1" name="1: When the schematisation  includes 1D-elements with closed-profiles" type="QString"/>
               </Option>
             </Option>
           </Option>

--- a/layer_styles/schematisation/v2_numerical_settings.qml
+++ b/layer_styles/schematisation/v2_numerical_settings.qml
@@ -1,14 +1,12 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis maxScale="0" version="3.4.5-Madeira" readOnly="0" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property key="dualview/previewExpressions">
-      <value>id</value>
-    </property>
+    <property value="id" key="dualview/previewExpressions"/>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
@@ -22,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -32,8 +30,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -42,8 +40,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -52,8 +50,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -62,8 +60,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -72,8 +70,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -81,14 +79,20 @@
     <field name="frict_shallow_water_correction">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
     <field name="general_numerical_threshold">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
@@ -96,8 +100,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -105,21 +109,30 @@
     <field name="limiter_grad_1d">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
     <field name="limiter_grad_2d">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
     <field name="limiter_slope_crossectional_area_2d">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
         </config>
       </editWidget>
     </field>
@@ -127,8 +140,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -137,8 +150,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -147,18 +160,18 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="700" name="700: for 1D flow"/>
+                <Option value="5" name="5: for surface 2D flow only" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="5" name="5: for surface 2D flow only"/>
+                <Option value="7" name="7: for 1D and 2D flow" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="7" name="7: for 1D and 2D flow"/>
+                <Option value="70" name="70: for surface 1D, 2D surface and groundwater flow or higher" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="70" name="70: for surface 1D, 2D surface and groundwater flow or higher"/>
+                <Option value="700" name="700: for 1D flow" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -169,8 +182,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -179,8 +192,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -189,8 +202,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -199,8 +212,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -209,8 +222,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -219,8 +232,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -229,8 +242,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -239,12 +252,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="0" name="0: for 2D or open profiles (like channels)"/>
+                <Option value="0" name="0: for 2D or open profiles (like channels)" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1" name="1: for 1D systems with closed profiles (like sewerage)"/>
+                <Option value="1" name="1: for 1D systems with closed profiles (like sewerage)" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -253,137 +266,137 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="id" index="0" name=""/>
-    <alias field="cfl_strictness_factor_1d" index="1" name=""/>
-    <alias field="cfl_strictness_factor_2d" index="2" name=""/>
-    <alias field="convergence_cg" index="3" name=""/>
-    <alias field="convergence_eps" index="4" name=""/>
-    <alias field="flow_direction_threshold" index="5" name=""/>
-    <alias field="frict_shallow_water_correction" index="6" name=""/>
-    <alias field="general_numerical_threshold" index="7" name=""/>
-    <alias field="integration_method" index="8" name=""/>
-    <alias field="limiter_grad_1d" index="9" name=""/>
-    <alias field="limiter_grad_2d" index="10" name=""/>
-    <alias field="limiter_slope_crossectional_area_2d" index="11" name=""/>
-    <alias field="limiter_slope_friction_2d" index="12" name=""/>
-    <alias field="max_nonlin_iterations" index="13" name=""/>
-    <alias field="max_degree" index="14" name=""/>
-    <alias field="minimum_friction_velocity" index="15" name=""/>
-    <alias field="minimum_surface_area" index="16" name=""/>
-    <alias field="precon_cg" index="17" name=""/>
-    <alias field="preissmann_slot" index="18" name=""/>
-    <alias field="pump_implicit_ratio" index="19" name=""/>
-    <alias field="thin_water_layer_definition" index="20" name=""/>
-    <alias field="use_of_cg" index="21" name=""/>
-    <alias field="use_of_nested_newton" index="22" name=""/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="cfl_strictness_factor_1d"/>
+    <alias index="2" name="" field="cfl_strictness_factor_2d"/>
+    <alias index="3" name="" field="convergence_cg"/>
+    <alias index="4" name="" field="convergence_eps"/>
+    <alias index="5" name="" field="flow_direction_threshold"/>
+    <alias index="6" name="" field="frict_shallow_water_correction"/>
+    <alias index="7" name="" field="general_numerical_threshold"/>
+    <alias index="8" name="" field="integration_method"/>
+    <alias index="9" name="" field="limiter_grad_1d"/>
+    <alias index="10" name="" field="limiter_grad_2d"/>
+    <alias index="11" name="" field="limiter_slope_crossectional_area_2d"/>
+    <alias index="12" name="" field="limiter_slope_friction_2d"/>
+    <alias index="13" name="" field="max_nonlin_iterations"/>
+    <alias index="14" name="" field="max_degree"/>
+    <alias index="15" name="" field="minimum_friction_velocity"/>
+    <alias index="16" name="" field="minimum_surface_area"/>
+    <alias index="17" name="" field="precon_cg"/>
+    <alias index="18" name="" field="preissmann_slot"/>
+    <alias index="19" name="" field="pump_implicit_ratio"/>
+    <alias index="20" name="" field="thin_water_layer_definition"/>
+    <alias index="21" name="" field="use_of_cg"/>
+    <alias index="22" name="" field="use_of_nested_newton"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="id" expression=" if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0"/>
-    <default field="cfl_strictness_factor_1d" expression="" applyOnUpdate="0"/>
-    <default field="cfl_strictness_factor_2d" expression="" applyOnUpdate="0"/>
-    <default field="convergence_cg" expression="" applyOnUpdate="0"/>
-    <default field="convergence_eps" expression="0.00001" applyOnUpdate="0"/>
-    <default field="flow_direction_threshold" expression="" applyOnUpdate="0"/>
-    <default field="frict_shallow_water_correction" expression="" applyOnUpdate="0"/>
-    <default field="general_numerical_threshold" expression="" applyOnUpdate="0"/>
-    <default field="integration_method" expression="0" applyOnUpdate="0"/>
-    <default field="limiter_grad_1d" expression="" applyOnUpdate="0"/>
-    <default field="limiter_grad_2d" expression="" applyOnUpdate="0"/>
-    <default field="limiter_slope_crossectional_area_2d" expression="" applyOnUpdate="0"/>
-    <default field="limiter_slope_friction_2d" expression="" applyOnUpdate="0"/>
-    <default field="max_nonlin_iterations" expression="20" applyOnUpdate="0"/>
-    <default field="max_degree" expression="" applyOnUpdate="0"/>
-    <default field="minimum_friction_velocity" expression="" applyOnUpdate="0"/>
-    <default field="minimum_surface_area" expression="" applyOnUpdate="0"/>
-    <default field="precon_cg" expression="" applyOnUpdate="0"/>
-    <default field="preissmann_slot" expression="" applyOnUpdate="0"/>
-    <default field="pump_implicit_ratio" expression="" applyOnUpdate="0"/>
-    <default field="thin_water_layer_definition" expression="" applyOnUpdate="0"/>
-    <default field="use_of_cg" expression="20" applyOnUpdate="0"/>
-    <default field="use_of_nested_newton" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" expression=" if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="1" field="cfl_strictness_factor_1d"/>
+    <default applyOnUpdate="0" expression="1" field="cfl_strictness_factor_2d"/>
+    <default applyOnUpdate="0" expression="0.000000001" field="convergence_cg"/>
+    <default applyOnUpdate="0" expression="0.00001" field="convergence_eps"/>
+    <default applyOnUpdate="0" expression="0.000001" field="flow_direction_threshold"/>
+    <default applyOnUpdate="0" expression="0" field="frict_shallow_water_correction"/>
+    <default applyOnUpdate="0" expression="0.00000001" field="general_numerical_threshold"/>
+    <default applyOnUpdate="0" expression="0" field="integration_method"/>
+    <default applyOnUpdate="0" expression="1" field="limiter_grad_1d"/>
+    <default applyOnUpdate="0" expression="0" field="limiter_grad_2d"/>
+    <default applyOnUpdate="0" expression="0" field="limiter_slope_crossectional_area_2d"/>
+    <default applyOnUpdate="0" expression="0" field="limiter_slope_friction_2d"/>
+    <default applyOnUpdate="0" expression="20" field="max_nonlin_iterations"/>
+    <default applyOnUpdate="0" expression="" field="max_degree"/>
+    <default applyOnUpdate="0" expression="0.05" field="minimum_friction_velocity"/>
+    <default applyOnUpdate="0" expression="0.00000001" field="minimum_surface_area"/>
+    <default applyOnUpdate="0" expression="1" field="precon_cg"/>
+    <default applyOnUpdate="0" expression="0" field="preissmann_slot"/>
+    <default applyOnUpdate="0" expression="1" field="pump_implicit_ratio"/>
+    <default applyOnUpdate="0" expression="0.05" field="thin_water_layer_definition"/>
+    <default applyOnUpdate="0" expression="20" field="use_of_cg"/>
+    <default applyOnUpdate="0" expression="" field="use_of_nested_newton"/>
   </defaults>
   <constraints>
-    <constraint field="id" constraints="3" unique_strength="1" exp_strength="0" notnull_strength="1"/>
-    <constraint field="cfl_strictness_factor_1d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="cfl_strictness_factor_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="convergence_cg" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="convergence_eps" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="flow_direction_threshold" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="frict_shallow_water_correction" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="general_numerical_threshold" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="integration_method" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="limiter_grad_1d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="limiter_grad_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="limiter_slope_crossectional_area_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="limiter_slope_friction_2d" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="max_nonlin_iterations" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="max_degree" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="minimum_friction_velocity" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="minimum_surface_area" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="precon_cg" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="preissmann_slot" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="pump_implicit_ratio" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="thin_water_layer_definition" constraints="0" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint field="use_of_cg" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
-    <constraint field="use_of_nested_newton" constraints="1" unique_strength="0" exp_strength="0" notnull_strength="2"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="0" field="cfl_strictness_factor_1d" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="cfl_strictness_factor_2d" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="convergence_cg" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="convergence_eps" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="flow_direction_threshold" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="frict_shallow_water_correction" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="general_numerical_threshold" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="integration_method" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="limiter_grad_1d" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="limiter_grad_2d" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="limiter_slope_crossectional_area_2d" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="limiter_slope_friction_2d" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="max_nonlin_iterations" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="max_degree" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="minimum_friction_velocity" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="minimum_surface_area" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="precon_cg" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="preissmann_slot" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="pump_implicit_ratio" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="thin_water_layer_definition" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="use_of_cg" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="use_of_nested_newton" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="id" desc="" exp=""/>
-    <constraint field="cfl_strictness_factor_1d" desc="" exp=""/>
-    <constraint field="cfl_strictness_factor_2d" desc="" exp=""/>
-    <constraint field="convergence_cg" desc="" exp=""/>
-    <constraint field="convergence_eps" desc="" exp=""/>
-    <constraint field="flow_direction_threshold" desc="" exp=""/>
-    <constraint field="frict_shallow_water_correction" desc="" exp=""/>
-    <constraint field="general_numerical_threshold" desc="" exp=""/>
-    <constraint field="integration_method" desc="" exp=""/>
-    <constraint field="limiter_grad_1d" desc="" exp=""/>
-    <constraint field="limiter_grad_2d" desc="" exp=""/>
-    <constraint field="limiter_slope_crossectional_area_2d" desc="" exp=""/>
-    <constraint field="limiter_slope_friction_2d" desc="" exp=""/>
-    <constraint field="max_nonlin_iterations" desc="" exp=""/>
-    <constraint field="max_degree" desc="" exp=""/>
-    <constraint field="minimum_friction_velocity" desc="" exp=""/>
-    <constraint field="minimum_surface_area" desc="" exp=""/>
-    <constraint field="precon_cg" desc="" exp=""/>
-    <constraint field="preissmann_slot" desc="" exp=""/>
-    <constraint field="pump_implicit_ratio" desc="" exp=""/>
-    <constraint field="thin_water_layer_definition" desc="" exp=""/>
-    <constraint field="use_of_cg" desc="" exp=""/>
-    <constraint field="use_of_nested_newton" desc="" exp=""/>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="cfl_strictness_factor_1d"/>
+    <constraint exp="" desc="" field="cfl_strictness_factor_2d"/>
+    <constraint exp="" desc="" field="convergence_cg"/>
+    <constraint exp="" desc="" field="convergence_eps"/>
+    <constraint exp="" desc="" field="flow_direction_threshold"/>
+    <constraint exp="" desc="" field="frict_shallow_water_correction"/>
+    <constraint exp="" desc="" field="general_numerical_threshold"/>
+    <constraint exp="" desc="" field="integration_method"/>
+    <constraint exp="" desc="" field="limiter_grad_1d"/>
+    <constraint exp="" desc="" field="limiter_grad_2d"/>
+    <constraint exp="" desc="" field="limiter_slope_crossectional_area_2d"/>
+    <constraint exp="" desc="" field="limiter_slope_friction_2d"/>
+    <constraint exp="" desc="" field="max_nonlin_iterations"/>
+    <constraint exp="" desc="" field="max_degree"/>
+    <constraint exp="" desc="" field="minimum_friction_velocity"/>
+    <constraint exp="" desc="" field="minimum_surface_area"/>
+    <constraint exp="" desc="" field="precon_cg"/>
+    <constraint exp="" desc="" field="preissmann_slot"/>
+    <constraint exp="" desc="" field="pump_implicit_ratio"/>
+    <constraint exp="" desc="" field="thin_water_layer_definition"/>
+    <constraint exp="" desc="" field="use_of_cg"/>
+    <constraint exp="" desc="" field="use_of_nested_newton"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column type="field" hidden="0" name="id" width="-1"/>
-      <column type="field" hidden="0" name="cfl_strictness_factor_1d" width="-1"/>
-      <column type="field" hidden="0" name="cfl_strictness_factor_2d" width="-1"/>
-      <column type="field" hidden="0" name="convergence_cg" width="-1"/>
-      <column type="field" hidden="0" name="convergence_eps" width="-1"/>
-      <column type="field" hidden="0" name="flow_direction_threshold" width="-1"/>
-      <column type="field" hidden="0" name="frict_shallow_water_correction" width="-1"/>
-      <column type="field" hidden="0" name="general_numerical_threshold" width="-1"/>
-      <column type="field" hidden="0" name="integration_method" width="-1"/>
-      <column type="field" hidden="0" name="limiter_grad_1d" width="-1"/>
-      <column type="field" hidden="0" name="limiter_grad_2d" width="-1"/>
-      <column type="field" hidden="0" name="limiter_slope_crossectional_area_2d" width="-1"/>
-      <column type="field" hidden="0" name="limiter_slope_friction_2d" width="-1"/>
-      <column type="field" hidden="0" name="max_nonlin_iterations" width="-1"/>
-      <column type="field" hidden="0" name="max_degree" width="-1"/>
-      <column type="field" hidden="0" name="minimum_friction_velocity" width="-1"/>
-      <column type="field" hidden="0" name="minimum_surface_area" width="-1"/>
-      <column type="field" hidden="0" name="precon_cg" width="-1"/>
-      <column type="field" hidden="0" name="preissmann_slot" width="-1"/>
-      <column type="field" hidden="0" name="pump_implicit_ratio" width="-1"/>
-      <column type="field" hidden="0" name="thin_water_layer_definition" width="-1"/>
-      <column type="field" hidden="0" name="use_of_cg" width="-1"/>
-      <column type="field" hidden="0" name="use_of_nested_newton" width="-1"/>
-      <column type="actions" hidden="1" width="-1"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="cfl_strictness_factor_1d" type="field"/>
+      <column width="-1" hidden="0" name="cfl_strictness_factor_2d" type="field"/>
+      <column width="-1" hidden="0" name="convergence_cg" type="field"/>
+      <column width="-1" hidden="0" name="convergence_eps" type="field"/>
+      <column width="-1" hidden="0" name="flow_direction_threshold" type="field"/>
+      <column width="-1" hidden="0" name="frict_shallow_water_correction" type="field"/>
+      <column width="-1" hidden="0" name="general_numerical_threshold" type="field"/>
+      <column width="-1" hidden="0" name="integration_method" type="field"/>
+      <column width="-1" hidden="0" name="limiter_grad_1d" type="field"/>
+      <column width="-1" hidden="0" name="limiter_grad_2d" type="field"/>
+      <column width="-1" hidden="0" name="limiter_slope_crossectional_area_2d" type="field"/>
+      <column width="-1" hidden="0" name="limiter_slope_friction_2d" type="field"/>
+      <column width="-1" hidden="0" name="max_nonlin_iterations" type="field"/>
+      <column width="-1" hidden="0" name="max_degree" type="field"/>
+      <column width="-1" hidden="0" name="minimum_friction_velocity" type="field"/>
+      <column width="-1" hidden="0" name="minimum_surface_area" type="field"/>
+      <column width="-1" hidden="0" name="precon_cg" type="field"/>
+      <column width="-1" hidden="0" name="preissmann_slot" type="field"/>
+      <column width="-1" hidden="0" name="pump_implicit_ratio" type="field"/>
+      <column width="-1" hidden="0" name="thin_water_layer_definition" type="field"/>
+      <column width="-1" hidden="0" name="use_of_cg" type="field"/>
+      <column width="-1" hidden="0" name="use_of_nested_newton" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -414,16 +427,16 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="0" name="id"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Limiters">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Limiters" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="9" name="limiter_grad_1d"/>
       <attributeEditorField showLabel="1" index="10" name="limiter_grad_2d"/>
       <attributeEditorField showLabel="1" index="11" name="limiter_slope_crossectional_area_2d"/>
       <attributeEditorField showLabel="1" index="12" name="limiter_slope_friction_2d"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Matrix">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Matrix" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="3" name="convergence_cg"/>
       <attributeEditorField showLabel="1" index="4" name="convergence_eps"/>
       <attributeEditorField showLabel="1" index="21" name="use_of_cg"/>
@@ -433,17 +446,17 @@ def my_form_open(dialog, layer, feature):
       <attributeEditorField showLabel="1" index="17" name="precon_cg"/>
       <attributeEditorField showLabel="1" index="8" name="integration_method"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Thresholds">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Thresholds" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="5" name="flow_direction_threshold"/>
-      <attributeEditorField showLabel="1" index="6" name="frict_shallow_water_correction"/>
       <attributeEditorField showLabel="1" index="7" name="general_numerical_threshold"/>
       <attributeEditorField showLabel="1" index="20" name="thin_water_layer_definition"/>
       <attributeEditorField showLabel="1" index="15" name="minimum_friction_velocity"/>
       <attributeEditorField showLabel="1" index="16" name="minimum_surface_area"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="Miscelaneous">
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Miscellaneous" groupBox="0" visibilityExpressionEnabled="0">
       <attributeEditorField showLabel="1" index="1" name="cfl_strictness_factor_1d"/>
       <attributeEditorField showLabel="1" index="2" name="cfl_strictness_factor_2d"/>
+      <attributeEditorField showLabel="1" index="6" name="frict_shallow_water_correction"/>
       <attributeEditorField showLabel="1" index="19" name="pump_implicit_ratio"/>
       <attributeEditorField showLabel="1" index="18" name="preissmann_slot"/>
     </attributeEditorContainer>
@@ -474,29 +487,29 @@ def my_form_open(dialog, layer, feature):
     <field editable="1" name="use_of_nested_newton"/>
   </editable>
   <labelOnTop>
-    <field name="cfl_strictness_factor_1d" labelOnTop="0"/>
-    <field name="cfl_strictness_factor_2d" labelOnTop="0"/>
-    <field name="convergence_cg" labelOnTop="0"/>
-    <field name="convergence_eps" labelOnTop="0"/>
-    <field name="flow_direction_threshold" labelOnTop="0"/>
-    <field name="frict_shallow_water_correction" labelOnTop="0"/>
-    <field name="general_numerical_threshold" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="integration_method" labelOnTop="0"/>
-    <field name="limiter_grad_1d" labelOnTop="0"/>
-    <field name="limiter_grad_2d" labelOnTop="0"/>
-    <field name="limiter_slope_crossectional_area_2d" labelOnTop="0"/>
-    <field name="limiter_slope_friction_2d" labelOnTop="0"/>
-    <field name="max_degree" labelOnTop="0"/>
-    <field name="max_nonlin_iterations" labelOnTop="0"/>
-    <field name="minimum_friction_velocity" labelOnTop="0"/>
-    <field name="minimum_surface_area" labelOnTop="0"/>
-    <field name="precon_cg" labelOnTop="0"/>
-    <field name="preissmann_slot" labelOnTop="0"/>
-    <field name="pump_implicit_ratio" labelOnTop="0"/>
-    <field name="thin_water_layer_definition" labelOnTop="0"/>
-    <field name="use_of_cg" labelOnTop="0"/>
-    <field name="use_of_nested_newton" labelOnTop="0"/>
+    <field labelOnTop="0" name="cfl_strictness_factor_1d"/>
+    <field labelOnTop="0" name="cfl_strictness_factor_2d"/>
+    <field labelOnTop="0" name="convergence_cg"/>
+    <field labelOnTop="0" name="convergence_eps"/>
+    <field labelOnTop="0" name="flow_direction_threshold"/>
+    <field labelOnTop="0" name="frict_shallow_water_correction"/>
+    <field labelOnTop="0" name="general_numerical_threshold"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="integration_method"/>
+    <field labelOnTop="0" name="limiter_grad_1d"/>
+    <field labelOnTop="0" name="limiter_grad_2d"/>
+    <field labelOnTop="0" name="limiter_slope_crossectional_area_2d"/>
+    <field labelOnTop="0" name="limiter_slope_friction_2d"/>
+    <field labelOnTop="0" name="max_degree"/>
+    <field labelOnTop="0" name="max_nonlin_iterations"/>
+    <field labelOnTop="0" name="minimum_friction_velocity"/>
+    <field labelOnTop="0" name="minimum_surface_area"/>
+    <field labelOnTop="0" name="precon_cg"/>
+    <field labelOnTop="0" name="preissmann_slot"/>
+    <field labelOnTop="0" name="pump_implicit_ratio"/>
+    <field labelOnTop="0" name="thin_water_layer_definition"/>
+    <field labelOnTop="0" name="use_of_cg"/>
+    <field labelOnTop="0" name="use_of_nested_newton"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>id</previewExpression>

--- a/layer_styles/schematisation/v2_obstacle.qml
+++ b/layer_styles/schematisation/v2_obstacle.qml
@@ -1,23 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="crest_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" labelsEnabled="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" maxScale="0" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
+        <layer enabled="1" pass="0" locked="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -26,215 +20,90 @@
           <prop k="line_width" v="0.46"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
+    <property key="dualview/previewExpressions" value="&quot;id&quot;"/>
     <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="11"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>id</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="Ubuntu"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
-      <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory labelPlacementMethod="XHeight" scaleBasedVisibility="0" opacity="1" penColor="#000000" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" backgroundColor="#ffffff" width="15" sizeType="MM" scaleDependency="Area" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" height="15" minScaleDenominator="0" penWidth="0" lineSizeType="MM" rotationOffset="270" enabled="0" barWidth="5" maxScaleDenominator="1e+08" backgroundAlpha="255">
+      <fontProperties style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="0" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="2" linePlacementFlags="2" showAll="1" dist="0" priority="0" obstacle="0" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option type="Map" name="properties">
+          <Option type="Map" name="show">
+            <Option type="bool" value="true" name="active"/>
+            <Option type="QString" value="code" name="field"/>
+            <Option type="int" value="2" name="type"/>
+          </Option>
+        </Option>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="crest_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
     <alias field="code" index="0" name=""/>
     <alias field="id" index="1" name=""/>
@@ -242,8 +111,26 @@
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <defaults>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="crest_level"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="code" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="crest_level" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="code" exp=""/>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="crest_level" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
       <column width="-1" hidden="0" type="field" name="code"/>
       <column width="-1" hidden="0" type="field" name="id"/>
@@ -251,7 +138,11 @@
       <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform></editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -273,17 +164,26 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="1" name="id" showLabel="1"/>
+      <attributeEditorField index="0" name="code" showLabel="1"/>
+      <attributeEditorField index="2" name="crest_level" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="code"/>
+    <field editable="1" name="crest_level"/>
+    <field editable="1" name="id"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="crest_level"/>
+    <field labelOnTop="0" name="id"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="code" expression=""/>
-    <default field="id" expression=""/>
-    <default field="crest_level" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_orifice.qml
+++ b/layer_styles/schematisation/v2_orifice.qml
@@ -1,116 +1,19 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
-    <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="101,101,101,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.66"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
-          <prop k="interval" v="3"/>
-          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="interval_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="placement" v="centralpoint"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="rotate" v="0"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
-              <prop k="angle" v="0"/>
-              <prop k="color" v="101,101,101,255"/>
-              <prop k="horizontal_anchor_point" v="1"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="name" v="circle"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="0,0,0,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="scale_method" v="area"/>
-              <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="size_unit" v="MM"/>
-              <prop k="vertical_anchor_point" v="1"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
-                  <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
-        </layer>
-      </symbol>
-    </symbols>
-    <rotation/>
-    <sizescale/>
-  </renderer-v2>
   <customproperties>
+    <property key="dualview/previewExpressions">
+      <value>display_name</value>
+      <value>"display_name"</value>
+    </property>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
-    </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
-    <properties>
-      <Option type="Map">
-        <Option name="name" value="" type="QString"/>
-        <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
-      </Option>
-    </properties>
-  </DiagramLayerSettings>
   <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
@@ -167,6 +70,16 @@
         </config>
       </editWidget>
     </field>
+    <field name="connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
     <field name="discharge_coefficient_negative">
       <editWidget type="TextEdit">
         <config>
@@ -177,12 +90,12 @@
         </config>
       </editWidget>
     </field>
-    <field name="dist_calc_points">
-      <editWidget type="TextEdit">
+    <field name="sewerage">
+      <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="CheckedState" value="1" type="QString"/>
+            <Option name="UncheckedState" value="0" type="QString"/>
           </Option>
         </config>
       </editWidget>
@@ -207,7 +120,7 @@
         </config>
       </editWidget>
     </field>
-    <field name="cross_section_definition_id">
+    <field name="crest_level">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -217,7 +130,7 @@
         </config>
       </editWidget>
     </field>
-    <field name="invert_level_end_point">
+    <field name="max_capacity">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -227,32 +140,16 @@
         </config>
       </editWidget>
     </field>
-    <field name="invert_level_start_point">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="calculation_type">
+    <field name="crest_type">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="100: embedded" value="100" type="QString"/>
+                <Option name="3: broad crested" value="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="101: isolated" value="101" type="QString"/>
-              </Option>
-              <Option type="Map">
-                <Option name="102: connected" value="102" type="QString"/>
-              </Option>
-              <Option type="Map">
-                <Option name="105: double connected" value="105" type="QString"/>
+                <Option name="4: short crested" value="4" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -268,7 +165,7 @@
                 <Option name="1: Chezy" value="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" value="2" type="QString"/>
+                <Option name="2: manning" value="2" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -276,6 +173,16 @@
       </editWidget>
     </field>
     <field name="friction_value">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cross_section_definition_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -295,86 +202,76 @@
         </config>
       </editWidget>
     </field>
-    <field name="connection_node_end_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
   </fieldConfiguration>
   <aliases>
     <alias name="" index="0" field="zoom_category"/>
     <alias name="" index="1" field="code"/>
     <alias name="" index="2" field="display_name"/>
-    <alias name="" index="3" field="discharge_coefficient_negative"/>
-    <alias name="" index="4" field="dist_calc_points"/>
-    <alias name="" index="5" field="connection_node_start_id"/>
-    <alias name="" index="6" field="discharge_coefficient_positive"/>
-    <alias name="" index="7" field="cross_section_definition_id"/>
-    <alias name="" index="8" field="invert_level_end_point"/>
-    <alias name="" index="9" field="invert_level_start_point"/>
-    <alias name="" index="10" field="calculation_type"/>
+    <alias name="" index="3" field="connection_node_end_id"/>
+    <alias name="" index="4" field="discharge_coefficient_negative"/>
+    <alias name="" index="5" field="sewerage"/>
+    <alias name="" index="6" field="connection_node_start_id"/>
+    <alias name="" index="7" field="discharge_coefficient_positive"/>
+    <alias name="" index="8" field="crest_level"/>
+    <alias name="" index="9" field="max_capacity"/>
+    <alias name="" index="10" field="crest_type"/>
     <alias name="" index="11" field="friction_type"/>
     <alias name="" index="12" field="friction_value"/>
-    <alias name="" index="13" field="id"/>
-    <alias name="" index="14" field="connection_node_end_id"/>
+    <alias name="" index="13" field="cross_section_definition_id"/>
+    <alias name="" index="14" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="zoom_category" expression="4"/>
+    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
     <default applyOnUpdate="0" field="code" expression="'new'"/>
     <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
     <default applyOnUpdate="0" field="discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="dist_calc_points" expression="10000"/>
+    <default applyOnUpdate="0" field="sewerage" expression=""/>
     <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
     <default applyOnUpdate="0" field="discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_end_point" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_start_point" expression=""/>
-    <default applyOnUpdate="0" field="calculation_type" expression="101"/>
+    <default applyOnUpdate="0" field="crest_level" expression=""/>
+    <default applyOnUpdate="0" field="max_capacity" expression=""/>
+    <default applyOnUpdate="0" field="crest_type" expression="4"/>
     <default applyOnUpdate="0" field="friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="friction_value" expression="0.0145"/>
+    <default applyOnUpdate="0" field="friction_value" expression="0.02"/>
+    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
     <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
   </defaults>
   <constraints>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dist_calc_points" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sewerage" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_end_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_start_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_level" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="max_capacity" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_type" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_type" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_value" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
     <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="zoom_category" desc=""/>
     <constraint exp="" field="code" desc=""/>
     <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="connection_node_end_id" desc=""/>
     <constraint exp="" field="discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="dist_calc_points" desc=""/>
+    <constraint exp="" field="sewerage" desc=""/>
     <constraint exp="" field="connection_node_start_id" desc=""/>
     <constraint exp="" field="discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="cross_section_definition_id" desc=""/>
-    <constraint exp="" field="invert_level_end_point" desc=""/>
-    <constraint exp="" field="invert_level_start_point" desc=""/>
-    <constraint exp="" field="calculation_type" desc=""/>
+    <constraint exp="" field="crest_level" desc=""/>
+    <constraint exp="" field="max_capacity" desc=""/>
+    <constraint exp="" field="crest_type" desc=""/>
     <constraint exp="" field="friction_type" desc=""/>
     <constraint exp="" field="friction_value" desc=""/>
+    <constraint exp="" field="cross_section_definition_id" desc=""/>
     <constraint exp="" field="id" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
@@ -385,18 +282,18 @@
       <column name="zoom_category" hidden="0" width="-1" type="field"/>
       <column name="code" hidden="0" width="-1" type="field"/>
       <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
       <column name="discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="dist_calc_points" hidden="0" width="-1" type="field"/>
+      <column name="sewerage" hidden="0" width="-1" type="field"/>
       <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
       <column name="discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_end_point" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_start_point" hidden="0" width="-1" type="field"/>
-      <column name="calculation_type" hidden="0" width="-1" type="field"/>
+      <column name="crest_level" hidden="0" width="-1" type="field"/>
+      <column name="max_capacity" hidden="0" width="-1" type="field"/>
+      <column name="crest_type" hidden="0" width="-1" type="field"/>
       <column name="friction_type" hidden="0" width="-1" type="field"/>
       <column name="friction_value" hidden="0" width="-1" type="field"/>
+      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
       <column name="id" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
       <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -404,10 +301,10 @@
     <rowstyles/>
     <fieldstyles/>
   </conditionalstyles>
-  <editform tolerant="1">.</editform>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath>.</editforminitfilepath>
+  <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -419,7 +316,7 @@ Enter the name of the function in the "Python Init function"
 field.
 An example follows:
 """
-from PyQt4.QtGui import QWidget
+from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
@@ -428,68 +325,68 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Culvert" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+    <attributeEditorContainer name="Orifice" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
       <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="13" showLabel="1"/>
+        <attributeEditorField name="id" index="14" showLabel="1"/>
         <attributeEditorField name="display_name" index="2" showLabel="1"/>
         <attributeEditorField name="code" index="1" showLabel="1"/>
-        <attributeEditorField name="calculation_type" index="10" showLabel="1"/>
-        <attributeEditorField name="dist_calc_points" index="4" showLabel="1"/>
       </attributeEditorContainer>
       <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="invert_level_start_point" index="9" showLabel="1"/>
-        <attributeEditorField name="invert_level_end_point" index="8" showLabel="1"/>
+        <attributeEditorField name="crest_level" index="8" showLabel="1"/>
+        <attributeEditorField name="crest_type" index="10" showLabel="1"/>
+        <attributeEditorField name="discharge_coefficient_positive" index="7" showLabel="1"/>
+        <attributeEditorField name="discharge_coefficient_negative" index="4" showLabel="1"/>
         <attributeEditorField name="friction_value" index="12" showLabel="1"/>
         <attributeEditorField name="friction_type" index="11" showLabel="1"/>
-        <attributeEditorField name="cross_section_definition_id" index="7" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_positive" index="6" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_negative" index="3" showLabel="1"/>
+        <attributeEditorField name="cross_section_definition_id" index="13" showLabel="1"/>
+        <attributeEditorField name="max_capacity" index="9" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="Visualizations" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
         <attributeEditorField name="zoom_category" index="0" showLabel="1"/>
+        <attributeEditorField name="sewerage" index="5" showLabel="1"/>
       </attributeEditorContainer>
       <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="5" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="14" showLabel="1"/>
+        <attributeEditorField name="connection_node_start_id" index="6" showLabel="1"/>
+        <attributeEditorField name="connection_node_end_id" index="3" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="calculation_type" editable="1"/>
     <field name="code" editable="1"/>
     <field name="connection_node_end_id" editable="1"/>
     <field name="connection_node_start_id" editable="1"/>
+    <field name="crest_level" editable="1"/>
+    <field name="crest_type" editable="1"/>
     <field name="cross_section_definition_id" editable="1"/>
     <field name="discharge_coefficient_negative" editable="1"/>
     <field name="discharge_coefficient_positive" editable="1"/>
     <field name="display_name" editable="1"/>
-    <field name="dist_calc_points" editable="1"/>
     <field name="friction_type" editable="1"/>
     <field name="friction_value" editable="1"/>
     <field name="id" editable="1"/>
-    <field name="invert_level_end_point" editable="1"/>
-    <field name="invert_level_start_point" editable="1"/>
+    <field name="max_capacity" editable="1"/>
+    <field name="sewerage" editable="1"/>
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="calculation_type" labelOnTop="0"/>
     <field name="code" labelOnTop="0"/>
     <field name="connection_node_end_id" labelOnTop="0"/>
     <field name="connection_node_start_id" labelOnTop="0"/>
+    <field name="crest_level" labelOnTop="0"/>
+    <field name="crest_type" labelOnTop="0"/>
     <field name="cross_section_definition_id" labelOnTop="0"/>
     <field name="discharge_coefficient_negative" labelOnTop="0"/>
     <field name="discharge_coefficient_positive" labelOnTop="0"/>
     <field name="display_name" labelOnTop="0"/>
-    <field name="dist_calc_points" labelOnTop="0"/>
     <field name="friction_type" labelOnTop="0"/>
     <field name="friction_value" labelOnTop="0"/>
     <field name="id" labelOnTop="0"/>
-    <field name="invert_level_end_point" labelOnTop="0"/>
-    <field name="invert_level_start_point" labelOnTop="0"/>
+    <field name="max_capacity" labelOnTop="0"/>
+    <field name="sewerage" labelOnTop="0"/>
     <field name="zoom_category" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>
   <mapTip></mapTip>
-  <layerGeometryType>1</layerGeometryType>
+  <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_orifice.qml
+++ b/layer_styles/schematisation/v2_orifice.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
+<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -23,27 +23,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -54,8 +54,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -64,8 +64,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -74,8 +74,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -84,8 +84,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -94,8 +94,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="CheckedState" value="1" type="QString"/>
-            <Option name="UncheckedState" value="0" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -104,8 +104,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -114,8 +114,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -124,8 +124,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -134,8 +134,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -144,12 +144,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="3: broad crested" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: broad crested"/>
               </Option>
               <Option type="Map">
-                <Option name="4: short crested" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: short crested"/>
               </Option>
             </Option>
           </Option>
@@ -160,12 +160,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: manning" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -176,8 +176,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -186,8 +186,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -196,105 +196,105 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="zoom_category"/>
-    <alias name="" index="1" field="code"/>
-    <alias name="" index="2" field="display_name"/>
-    <alias name="" index="3" field="connection_node_end_id"/>
-    <alias name="" index="4" field="discharge_coefficient_negative"/>
-    <alias name="" index="5" field="sewerage"/>
-    <alias name="" index="6" field="connection_node_start_id"/>
-    <alias name="" index="7" field="discharge_coefficient_positive"/>
-    <alias name="" index="8" field="crest_level"/>
-    <alias name="" index="9" field="max_capacity"/>
-    <alias name="" index="10" field="crest_type"/>
-    <alias name="" index="11" field="friction_type"/>
-    <alias name="" index="12" field="friction_value"/>
-    <alias name="" index="13" field="cross_section_definition_id"/>
-    <alias name="" index="14" field="id"/>
+    <alias name="" field="zoom_category" index="0"/>
+    <alias name="" field="code" index="1"/>
+    <alias name="" field="display_name" index="2"/>
+    <alias name="" field="connection_node_end_id" index="3"/>
+    <alias name="" field="discharge_coefficient_negative" index="4"/>
+    <alias name="" field="sewerage" index="5"/>
+    <alias name="" field="connection_node_start_id" index="6"/>
+    <alias name="" field="discharge_coefficient_positive" index="7"/>
+    <alias name="" field="crest_level" index="8"/>
+    <alias name="" field="max_capacity" index="9"/>
+    <alias name="" field="crest_type" index="10"/>
+    <alias name="" field="friction_type" index="11"/>
+    <alias name="" field="friction_value" index="12"/>
+    <alias name="" field="cross_section_definition_id" index="13"/>
+    <alias name="" field="id" index="14"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
-    <default applyOnUpdate="0" field="discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="sewerage" expression=""/>
-    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
-    <default applyOnUpdate="0" field="discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="crest_level" expression=""/>
-    <default applyOnUpdate="0" field="max_capacity" expression=""/>
-    <default applyOnUpdate="0" field="crest_type" expression="4"/>
-    <default applyOnUpdate="0" field="friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="friction_value" expression="0.02"/>
-    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default expression="3" applyOnUpdate="0" field="zoom_category"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_end_id"/>
+    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_negative"/>
+    <default expression="" applyOnUpdate="0" field="sewerage"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_start_id"/>
+    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_positive"/>
+    <default expression="" applyOnUpdate="0" field="crest_level"/>
+    <default expression="" applyOnUpdate="0" field="max_capacity"/>
+    <default expression="4" applyOnUpdate="0" field="crest_type"/>
+    <default expression="2" applyOnUpdate="0" field="friction_type"/>
+    <default expression="0.02" applyOnUpdate="0" field="friction_value"/>
+    <default expression="" applyOnUpdate="0" field="cross_section_definition_id"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sewerage" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_level" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="max_capacity" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_value" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_negative"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="sewerage"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_positive"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="crest_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="max_capacity"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="crest_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cross_section_definition_id"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
-    <constraint exp="" field="discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="sewerage" desc=""/>
-    <constraint exp="" field="connection_node_start_id" desc=""/>
-    <constraint exp="" field="discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="crest_level" desc=""/>
-    <constraint exp="" field="max_capacity" desc=""/>
-    <constraint exp="" field="crest_type" desc=""/>
-    <constraint exp="" field="friction_type" desc=""/>
-    <constraint exp="" field="friction_value" desc=""/>
-    <constraint exp="" field="cross_section_definition_id" desc=""/>
-    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="connection_node_end_id"/>
+    <constraint exp="" desc="" field="discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="sewerage"/>
+    <constraint exp="" desc="" field="connection_node_start_id"/>
+    <constraint exp="" desc="" field="discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="crest_level"/>
+    <constraint exp="" desc="" field="max_capacity"/>
+    <constraint exp="" desc="" field="crest_type"/>
+    <constraint exp="" desc="" field="friction_type"/>
+    <constraint exp="" desc="" field="friction_value"/>
+    <constraint exp="" desc="" field="cross_section_definition_id"/>
+    <constraint exp="" desc="" field="id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="sewerage" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="crest_level" hidden="0" width="-1" type="field"/>
-      <column name="max_capacity" hidden="0" width="-1" type="field"/>
-      <column name="crest_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_value" hidden="0" width="-1" type="field"/>
-      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="code"/>
+      <column width="-1" type="field" hidden="0" name="display_name"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="discharge_coefficient_negative"/>
+      <column width="-1" type="field" hidden="0" name="sewerage"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="discharge_coefficient_positive"/>
+      <column width="-1" type="field" hidden="0" name="crest_level"/>
+      <column width="-1" type="field" hidden="0" name="max_capacity"/>
+      <column width="-1" type="field" hidden="0" name="crest_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_value"/>
+      <column width="-1" type="field" hidden="0" name="cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -325,29 +325,29 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Orifice" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="14" showLabel="1"/>
-        <attributeEditorField name="display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="code" index="1" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Orifice" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="id" index="14"/>
+        <attributeEditorField showLabel="1" name="display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="code" index="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="crest_level" index="8" showLabel="1"/>
-        <attributeEditorField name="crest_type" index="10" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_positive" index="7" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_negative" index="4" showLabel="1"/>
-        <attributeEditorField name="friction_value" index="12" showLabel="1"/>
-        <attributeEditorField name="friction_type" index="11" showLabel="1"/>
-        <attributeEditorField name="cross_section_definition_id" index="13" showLabel="1"/>
-        <attributeEditorField name="max_capacity" index="9" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="crest_level" index="8"/>
+        <attributeEditorField showLabel="1" name="crest_type" index="10"/>
+        <attributeEditorField showLabel="1" name="discharge_coefficient_positive" index="7"/>
+        <attributeEditorField showLabel="1" name="discharge_coefficient_negative" index="4"/>
+        <attributeEditorField showLabel="1" name="friction_value" index="12"/>
+        <attributeEditorField showLabel="1" name="friction_type" index="11"/>
+        <attributeEditorField showLabel="1" name="cross_section_definition_id" index="13"/>
+        <attributeEditorField showLabel="1" name="max_capacity" index="9"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualizations" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="0" showLabel="1"/>
-        <attributeEditorField name="sewerage" index="5" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualizations" columnCount="1">
+        <attributeEditorField showLabel="1" name="zoom_category" index="0"/>
+        <attributeEditorField showLabel="1" name="sewerage" index="5"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="6" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="3" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="connection_node_start_id" index="6"/>
+        <attributeEditorField showLabel="1" name="connection_node_end_id" index="3"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -369,21 +369,21 @@ def my_form_open(dialog, layer, feature):
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_end_id" labelOnTop="0"/>
-    <field name="connection_node_start_id" labelOnTop="0"/>
-    <field name="crest_level" labelOnTop="0"/>
-    <field name="crest_type" labelOnTop="0"/>
-    <field name="cross_section_definition_id" labelOnTop="0"/>
-    <field name="discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="discharge_coefficient_positive" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="friction_type" labelOnTop="0"/>
-    <field name="friction_value" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="max_capacity" labelOnTop="0"/>
-    <field name="sewerage" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_end_id"/>
+    <field labelOnTop="0" name="connection_node_start_id"/>
+    <field labelOnTop="0" name="crest_level"/>
+    <field labelOnTop="0" name="crest_type"/>
+    <field labelOnTop="0" name="cross_section_definition_id"/>
+    <field labelOnTop="0" name="discharge_coefficient_negative"/>
+    <field labelOnTop="0" name="discharge_coefficient_positive"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="friction_type"/>
+    <field labelOnTop="0" name="friction_value"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="max_capacity"/>
+    <field labelOnTop="0" name="sewerage"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_orifice_view.qml
+++ b/layer_styles/schematisation/v2_orifice_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="0" simplifyLocal="1" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" simplifyAlgorithm="0" readOnly="0" minScale="1e+08" version="3.4.5-Madeira" maxScale="-4.65661e-10">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 forceraster="0" enableorderby="0" symbollevels="0" type="singleSymbol">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+      <symbol name="0" alpha="1" type="line" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
-            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <symbol name="@0@1" alpha="1" type="marker" clip_to_extent="1" force_rhr="0">
+            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
               <prop k="angle" v="0"/>
               <prop k="color" v="51,160,44,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" type="QString" name="name"/>
+                  <Option name="name" type="QString" value=""/>
                   <Option name="properties"/>
-                  <Option value="collection" type="QString" name="type"/>
+                  <Option name="type" type="QString" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -89,26 +89,26 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property value="ROWID" key="dualview/previewExpressions"/>
-    <property value="0" key="embeddedWidgets/count"/>
+    <property key="dualview/previewExpressions" value="ROWID"/>
+    <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
-      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory backgroundAlpha="255" height="15" minScaleDenominator="-4.65661e-10" opacity="1" penColor="#000000" lineSizeType="MM" penAlpha="255" labelPlacementMethod="XHeight" diagramOrientation="Up" rotationOffset="270" maxScaleDenominator="1e+08" scaleDependency="Area" width="15" barWidth="5" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" sizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" penWidth="0" minimumSize="0" enabled="0">
+      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
+  <DiagramLayerSettings linePlacementFlags="2" showAll="1" zIndex="0" placement="2" obstacle="0" dist="0" priority="0">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option name="type" type="QString" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -128,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -138,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -148,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -158,8 +158,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -168,8 +168,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -178,8 +178,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="1" type="QString" name="CheckedState"/>
-            <Option value="0" type="QString" name="UncheckedState"/>
+            <Option name="CheckedState" type="QString" value="1"/>
+            <Option name="UncheckedState" type="QString" value="0"/>
           </Option>
         </config>
       </editWidget>
@@ -188,8 +188,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -198,8 +198,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -208,12 +208,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Chèzy"/>
+                <Option name="1: Chèzy" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Manning"/>
+                <Option name="2: Manning" type="QString" value="2"/>
               </Option>
             </Option>
           </Option>
@@ -224,8 +224,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -234,8 +234,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -244,27 +244,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="-1" type="QString" name="-1"/>
+                <Option name="-1" type="QString" value="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" type="QString" name="0"/>
+                <Option name="0" type="QString" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1"/>
+                <Option name="1" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2"/>
+                <Option name="2" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3"/>
+                <Option name="3" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4"/>
+                <Option name="4" type="QString" value="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5"/>
+                <Option name="5" type="QString" value="5"/>
               </Option>
             </Option>
           </Option>
@@ -275,12 +275,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="3" type="QString" name="3: broad crested"/>
+                <Option name="3: broad crested" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4: short crested"/>
+                <Option name="4: short crested" type="QString" value="4"/>
               </Option>
             </Option>
           </Option>
@@ -291,8 +291,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -301,8 +301,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -311,8 +311,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -321,21 +321,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: rectangle"/>
+                <Option name="1: rectangle" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: round"/>
+                <Option name="2: round" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: egg"/>
+                <Option name="3: egg" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: tabulated rectangle"/>
+                <Option name="5: tabulated rectangle" type="QString" value="5"/>
               </Option>
               <Option type="Map">
-                <Option value="6" type="QString" name="6: tabulated trapezium"/>
+                <Option name="6: tabulated trapezium" type="QString" value="6"/>
               </Option>
             </Option>
           </Option>
@@ -346,8 +346,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -356,8 +356,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -366,135 +366,135 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="ROWID" index="0"/>
-    <alias name="id" field="orf_id" index="1"/>
-    <alias name="display_name" field="orf_display_name" index="2"/>
-    <alias name="code" field="orf_code" index="3"/>
-    <alias name="max_capacity" field="orf_max_capacity" index="4"/>
-    <alias name="crest_level" field="orf_crest_level" index="5"/>
-    <alias name="sewerage" field="orf_sewerage" index="6"/>
-    <alias name="cross_section_definition_id" field="orf_cross_section_definition_id" index="7"/>
-    <alias name="friction_value" field="orf_friction_value" index="8"/>
-    <alias name="friction_type" field="orf_friction_type" index="9"/>
-    <alias name="discharge_coefficient_positive" field="orf_discharge_coefficient_positive" index="10"/>
-    <alias name="discharge_coefficient_negative" field="orf_discharge_coefficient_negative" index="11"/>
-    <alias name="zoom_category" field="orf_zoom_category" index="12"/>
-    <alias name="crest_type" field="orf_crest_type" index="13"/>
-    <alias name="connection_node_start_id" field="orf_connection_node_start_id" index="14"/>
-    <alias name="connection_node_end_id" field="orf_connection_node_end_id" index="15"/>
-    <alias name="id" field="def_id" index="16"/>
-    <alias name="shape" field="def_shape" index="17"/>
-    <alias name="width" field="def_width" index="18"/>
-    <alias name="height" field="def_height" index="19"/>
-    <alias name="code" field="def_code" index="20"/>
+    <alias field="ROWID" name="" index="0"/>
+    <alias field="orf_id" name="id" index="1"/>
+    <alias field="orf_display_name" name="display_name" index="2"/>
+    <alias field="orf_code" name="code" index="3"/>
+    <alias field="orf_max_capacity" name="max_capacity" index="4"/>
+    <alias field="orf_crest_level" name="crest_level" index="5"/>
+    <alias field="orf_sewerage" name="sewerage" index="6"/>
+    <alias field="orf_cross_section_definition_id" name="cross_section_definition_id" index="7"/>
+    <alias field="orf_friction_value" name="friction_value" index="8"/>
+    <alias field="orf_friction_type" name="friction_type" index="9"/>
+    <alias field="orf_discharge_coefficient_positive" name="discharge_coefficient_positive" index="10"/>
+    <alias field="orf_discharge_coefficient_negative" name="discharge_coefficient_negative" index="11"/>
+    <alias field="orf_zoom_category" name="zoom_category" index="12"/>
+    <alias field="orf_crest_type" name="crest_type" index="13"/>
+    <alias field="orf_connection_node_start_id" name="connection_node_start_id" index="14"/>
+    <alias field="orf_connection_node_end_id" name="connection_node_end_id" index="15"/>
+    <alias field="def_id" name="id" index="16"/>
+    <alias field="def_shape" name="shape" index="17"/>
+    <alias field="def_width" name="width" index="18"/>
+    <alias field="def_height" name="height" index="19"/>
+    <alias field="def_code" name="code" index="20"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="if(maximum(orf_id) is null,1, maximum(orf_id)+1)" applyOnUpdate="0" field="orf_id"/>
-    <default expression="'new'" applyOnUpdate="0" field="orf_display_name"/>
-    <default expression="'new'" applyOnUpdate="0" field="orf_code"/>
-    <default expression="" applyOnUpdate="0" field="orf_max_capacity"/>
-    <default expression="" applyOnUpdate="0" field="orf_crest_level"/>
-    <default expression="" applyOnUpdate="0" field="orf_sewerage"/>
-    <default expression="" applyOnUpdate="0" field="orf_cross_section_definition_id"/>
-    <default expression="0.02" applyOnUpdate="0" field="orf_friction_value"/>
-    <default expression="2" applyOnUpdate="0" field="orf_friction_type"/>
-    <default expression="0.8" applyOnUpdate="0" field="orf_discharge_coefficient_positive"/>
-    <default expression="0.8" applyOnUpdate="0" field="orf_discharge_coefficient_negative"/>
-    <default expression="3" applyOnUpdate="0" field="orf_zoom_category"/>
-    <default expression="4" applyOnUpdate="0" field="orf_crest_type"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="orf_connection_node_start_id"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="orf_connection_node_end_id"/>
-    <default expression="" applyOnUpdate="0" field="def_id"/>
-    <default expression="" applyOnUpdate="0" field="def_shape"/>
-    <default expression="" applyOnUpdate="0" field="def_width"/>
-    <default expression="" applyOnUpdate="0" field="def_height"/>
-    <default expression="" applyOnUpdate="0" field="def_code"/>
+    <default expression="" field="ROWID" applyOnUpdate="0"/>
+    <default expression="if(maximum(orf_id) is null,1, maximum(orf_id)+1)" field="orf_id" applyOnUpdate="0"/>
+    <default expression="'new'" field="orf_display_name" applyOnUpdate="0"/>
+    <default expression="'new'" field="orf_code" applyOnUpdate="0"/>
+    <default expression="" field="orf_max_capacity" applyOnUpdate="0"/>
+    <default expression="" field="orf_crest_level" applyOnUpdate="0"/>
+    <default expression="" field="orf_sewerage" applyOnUpdate="0"/>
+    <default expression="" field="orf_cross_section_definition_id" applyOnUpdate="0"/>
+    <default expression="0.02" field="orf_friction_value" applyOnUpdate="0"/>
+    <default expression="2" field="orf_friction_type" applyOnUpdate="0"/>
+    <default expression="0.8" field="orf_discharge_coefficient_positive" applyOnUpdate="0"/>
+    <default expression="0.8" field="orf_discharge_coefficient_negative" applyOnUpdate="0"/>
+    <default expression="3" field="orf_zoom_category" applyOnUpdate="0"/>
+    <default expression="4" field="orf_crest_type" applyOnUpdate="0"/>
+    <default expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))" field="orf_connection_node_start_id" applyOnUpdate="0"/>
+    <default expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))" field="orf_connection_node_end_id" applyOnUpdate="0"/>
+    <default expression="" field="def_id" applyOnUpdate="0"/>
+    <default expression="" field="def_shape" applyOnUpdate="0"/>
+    <default expression="" field="def_width" applyOnUpdate="0"/>
+    <default expression="" field="def_height" applyOnUpdate="0"/>
+    <default expression="" field="def_code" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_id"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="orf_display_name"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="orf_code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="orf_max_capacity"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_crest_level"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="orf_sewerage"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_cross_section_definition_id"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="orf_friction_value"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_friction_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_discharge_coefficient_positive"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_discharge_coefficient_negative"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_crest_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_connection_node_start_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_connection_node_end_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
+    <constraint field="ROWID" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="orf_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_display_name" exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_code" exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_max_capacity" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="orf_crest_level" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_sewerage" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="orf_cross_section_definition_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_friction_value" exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_friction_type" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_discharge_coefficient_positive" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_discharge_coefficient_negative" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_zoom_category" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_crest_type" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_connection_node_start_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="orf_connection_node_end_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="def_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="def_shape" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="def_width" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="def_height" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="def_code" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="orf_id"/>
-    <constraint exp="&quot;orf_display_name&quot; is not null" desc="" field="orf_display_name"/>
-    <constraint exp="&quot;orf_code&quot; is not null&#xd;&#xa;" desc="" field="orf_code"/>
-    <constraint exp="" desc="" field="orf_max_capacity"/>
-    <constraint exp="" desc="" field="orf_crest_level"/>
-    <constraint exp="" desc="" field="orf_sewerage"/>
-    <constraint exp="" desc="" field="orf_cross_section_definition_id"/>
-    <constraint exp="&quot;orf_friction_value&quot; is not null" desc="" field="orf_friction_value"/>
-    <constraint exp="" desc="" field="orf_friction_type"/>
-    <constraint exp="" desc="" field="orf_discharge_coefficient_positive"/>
-    <constraint exp="" desc="" field="orf_discharge_coefficient_negative"/>
-    <constraint exp="" desc="" field="orf_zoom_category"/>
-    <constraint exp="" desc="" field="orf_crest_type"/>
-    <constraint exp="" desc="" field="orf_connection_node_start_id"/>
-    <constraint exp="" desc="" field="orf_connection_node_end_id"/>
-    <constraint exp="" desc="" field="def_id"/>
-    <constraint exp="" desc="" field="def_shape"/>
-    <constraint exp="" desc="" field="def_width"/>
-    <constraint exp="" desc="" field="def_height"/>
-    <constraint exp="" desc="" field="def_code"/>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="orf_id" desc=""/>
+    <constraint exp="&quot;orf_display_name&quot; is not null" field="orf_display_name" desc=""/>
+    <constraint exp="&quot;orf_code&quot; is not null&#xd;&#xa;" field="orf_code" desc=""/>
+    <constraint exp="" field="orf_max_capacity" desc=""/>
+    <constraint exp="" field="orf_crest_level" desc=""/>
+    <constraint exp="" field="orf_sewerage" desc=""/>
+    <constraint exp="" field="orf_cross_section_definition_id" desc=""/>
+    <constraint exp="&quot;orf_friction_value&quot; is not null" field="orf_friction_value" desc=""/>
+    <constraint exp="" field="orf_friction_type" desc=""/>
+    <constraint exp="" field="orf_discharge_coefficient_positive" desc=""/>
+    <constraint exp="" field="orf_discharge_coefficient_negative" desc=""/>
+    <constraint exp="" field="orf_zoom_category" desc=""/>
+    <constraint exp="" field="orf_crest_type" desc=""/>
+    <constraint exp="" field="orf_connection_node_start_id" desc=""/>
+    <constraint exp="" field="orf_connection_node_end_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
-      <column width="-1" type="field" hidden="0" name="ROWID"/>
-      <column width="-1" type="field" hidden="0" name="orf_id"/>
-      <column width="-1" type="field" hidden="0" name="orf_display_name"/>
-      <column width="-1" type="field" hidden="0" name="orf_code"/>
-      <column width="-1" type="field" hidden="0" name="orf_max_capacity"/>
-      <column width="-1" type="field" hidden="0" name="orf_crest_level"/>
-      <column width="-1" type="field" hidden="0" name="orf_sewerage"/>
-      <column width="-1" type="field" hidden="0" name="orf_cross_section_definition_id"/>
-      <column width="-1" type="field" hidden="0" name="orf_friction_value"/>
-      <column width="-1" type="field" hidden="0" name="orf_friction_type"/>
-      <column width="-1" type="field" hidden="0" name="orf_discharge_coefficient_positive"/>
-      <column width="-1" type="field" hidden="0" name="orf_discharge_coefficient_negative"/>
-      <column width="-1" type="field" hidden="0" name="orf_zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="orf_crest_type"/>
-      <column width="-1" type="field" hidden="0" name="orf_connection_node_start_id"/>
-      <column width="-1" type="field" hidden="0" name="orf_connection_node_end_id"/>
-      <column width="-1" type="field" hidden="0" name="def_id"/>
-      <column width="-1" type="field" hidden="0" name="def_shape"/>
-      <column width="-1" type="field" hidden="0" name="def_width"/>
-      <column width="-1" type="field" hidden="0" name="def_height"/>
-      <column width="-1" type="field" hidden="0" name="def_code"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column name="ROWID" hidden="0" type="field" width="-1"/>
+      <column name="orf_id" hidden="0" type="field" width="-1"/>
+      <column name="orf_display_name" hidden="0" type="field" width="-1"/>
+      <column name="orf_code" hidden="0" type="field" width="-1"/>
+      <column name="orf_max_capacity" hidden="0" type="field" width="-1"/>
+      <column name="orf_crest_level" hidden="0" type="field" width="-1"/>
+      <column name="orf_sewerage" hidden="0" type="field" width="-1"/>
+      <column name="orf_cross_section_definition_id" hidden="0" type="field" width="-1"/>
+      <column name="orf_friction_value" hidden="0" type="field" width="-1"/>
+      <column name="orf_friction_type" hidden="0" type="field" width="-1"/>
+      <column name="orf_discharge_coefficient_positive" hidden="0" type="field" width="-1"/>
+      <column name="orf_discharge_coefficient_negative" hidden="0" type="field" width="-1"/>
+      <column name="orf_zoom_category" hidden="0" type="field" width="-1"/>
+      <column name="orf_crest_type" hidden="0" type="field" width="-1"/>
+      <column name="orf_connection_node_start_id" hidden="0" type="field" width="-1"/>
+      <column name="orf_connection_node_end_id" hidden="0" type="field" width="-1"/>
+      <column name="def_id" hidden="0" type="field" width="-1"/>
+      <column name="def_shape" hidden="0" type="field" width="-1"/>
+      <column name="def_width" hidden="0" type="field" width="-1"/>
+      <column name="def_height" hidden="0" type="field" width="-1"/>
+      <column name="def_code" hidden="0" type="field" width="-1"/>
+      <column hidden="1" type="actions" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -525,35 +525,35 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Orifice view" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-        <attributeEditorField showLabel="1" name="orf_id" index="1"/>
-        <attributeEditorField showLabel="1" name="orf_display_name" index="2"/>
-        <attributeEditorField showLabel="1" name="orf_code" index="3"/>
+    <attributeEditorContainer name="Orifice view" showLabel="1" columnCount="1" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer name="General" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="orf_id" showLabel="1" index="1"/>
+        <attributeEditorField name="orf_display_name" showLabel="1" index="2"/>
+        <attributeEditorField name="orf_code" showLabel="1" index="3"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
-        <attributeEditorField showLabel="1" name="orf_crest_level" index="5"/>
-        <attributeEditorField showLabel="1" name="orf_crest_type" index="13"/>
-        <attributeEditorField showLabel="1" name="orf_friction_value" index="8"/>
-        <attributeEditorField showLabel="1" name="orf_friction_type" index="9"/>
-        <attributeEditorField showLabel="1" name="orf_discharge_coefficient_positive" index="10"/>
-        <attributeEditorField showLabel="1" name="orf_discharge_coefficient_negative" index="11"/>
-        <attributeEditorField showLabel="1" name="orf_max_capacity" index="4"/>
+      <attributeEditorContainer name="Characteristics" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="orf_crest_level" showLabel="1" index="5"/>
+        <attributeEditorField name="orf_crest_type" showLabel="1" index="13"/>
+        <attributeEditorField name="orf_friction_value" showLabel="1" index="8"/>
+        <attributeEditorField name="orf_friction_type" showLabel="1" index="9"/>
+        <attributeEditorField name="orf_discharge_coefficient_positive" showLabel="1" index="10"/>
+        <attributeEditorField name="orf_discharge_coefficient_negative" showLabel="1" index="11"/>
+        <attributeEditorField name="orf_max_capacity" showLabel="1" index="4"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
-        <attributeEditorField showLabel="1" name="orf_sewerage" index="6"/>
-        <attributeEditorField showLabel="1" name="orf_zoom_category" index="12"/>
+      <attributeEditorContainer name="Visualization" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="orf_sewerage" showLabel="1" index="6"/>
+        <attributeEditorField name="orf_zoom_category" showLabel="1" index="12"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section" columnCount="1">
-        <attributeEditorField showLabel="1" name="orf_cross_section_definition_id" index="7"/>
-        <attributeEditorField showLabel="1" name="def_shape" index="17"/>
-        <attributeEditorField showLabel="1" name="def_width" index="18"/>
-        <attributeEditorField showLabel="1" name="def_height" index="19"/>
-        <attributeEditorField showLabel="1" name="def_code" index="20"/>
+      <attributeEditorContainer name="Cross section" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="orf_cross_section_definition_id" showLabel="1" index="7"/>
+        <attributeEditorField name="def_shape" showLabel="1" index="17"/>
+        <attributeEditorField name="def_width" showLabel="1" index="18"/>
+        <attributeEditorField name="def_height" showLabel="1" index="19"/>
+        <attributeEditorField name="def_code" showLabel="1" index="20"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
-        <attributeEditorField showLabel="1" name="orf_connection_node_start_id" index="14"/>
-        <attributeEditorField showLabel="1" name="orf_connection_node_end_id" index="15"/>
+      <attributeEditorContainer name="Connection nodes" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="orf_connection_node_start_id" showLabel="1" index="14"/>
+        <attributeEditorField name="orf_connection_node_end_id" showLabel="1" index="15"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -581,27 +581,27 @@ def my_form_open(dialog, layer, feature):
     <field name="orf_zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ROWID"/>
-    <field labelOnTop="0" name="def_code"/>
-    <field labelOnTop="0" name="def_height"/>
-    <field labelOnTop="0" name="def_id"/>
-    <field labelOnTop="0" name="def_shape"/>
-    <field labelOnTop="0" name="def_width"/>
-    <field labelOnTop="0" name="orf_code"/>
-    <field labelOnTop="0" name="orf_connection_node_end_id"/>
-    <field labelOnTop="0" name="orf_connection_node_start_id"/>
-    <field labelOnTop="0" name="orf_crest_level"/>
-    <field labelOnTop="0" name="orf_crest_type"/>
-    <field labelOnTop="0" name="orf_cross_section_definition_id"/>
-    <field labelOnTop="0" name="orf_discharge_coefficient_negative"/>
-    <field labelOnTop="0" name="orf_discharge_coefficient_positive"/>
-    <field labelOnTop="0" name="orf_display_name"/>
-    <field labelOnTop="0" name="orf_friction_type"/>
-    <field labelOnTop="0" name="orf_friction_value"/>
-    <field labelOnTop="0" name="orf_id"/>
-    <field labelOnTop="0" name="orf_max_capacity"/>
-    <field labelOnTop="0" name="orf_sewerage"/>
-    <field labelOnTop="0" name="orf_zoom_category"/>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="def_code" labelOnTop="0"/>
+    <field name="def_height" labelOnTop="0"/>
+    <field name="def_id" labelOnTop="0"/>
+    <field name="def_shape" labelOnTop="0"/>
+    <field name="def_width" labelOnTop="0"/>
+    <field name="orf_code" labelOnTop="0"/>
+    <field name="orf_connection_node_end_id" labelOnTop="0"/>
+    <field name="orf_connection_node_start_id" labelOnTop="0"/>
+    <field name="orf_crest_level" labelOnTop="0"/>
+    <field name="orf_crest_type" labelOnTop="0"/>
+    <field name="orf_cross_section_definition_id" labelOnTop="0"/>
+    <field name="orf_discharge_coefficient_negative" labelOnTop="0"/>
+    <field name="orf_discharge_coefficient_positive" labelOnTop="0"/>
+    <field name="orf_display_name" labelOnTop="0"/>
+    <field name="orf_friction_type" labelOnTop="0"/>
+    <field name="orf_friction_value" labelOnTop="0"/>
+    <field name="orf_id" labelOnTop="0"/>
+    <field name="orf_max_capacity" labelOnTop="0"/>
+    <field name="orf_sewerage" labelOnTop="0"/>
+    <field name="orf_zoom_category" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_orifice_view.qml
+++ b/layer_styles/schematisation/v2_orifice_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
+        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
+            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
               <prop k="angle" v="0"/>
               <prop k="color" v="51,160,44,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -97,18 +97,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -128,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -138,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -148,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -158,8 +158,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -168,8 +168,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -178,8 +178,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="CheckedState" value="1" type="QString"/>
-            <Option name="UncheckedState" value="0" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -188,8 +188,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -198,8 +198,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -208,12 +208,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -224,8 +224,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -234,8 +234,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -244,27 +244,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -275,12 +275,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="3: broad crested" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: broad crested"/>
               </Option>
               <Option type="Map">
-                <Option name="4: short crested" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: short crested"/>
               </Option>
             </Option>
           </Option>
@@ -291,8 +291,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -301,8 +301,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -311,8 +311,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -321,21 +321,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: rectangle" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="2: round" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: round"/>
               </Option>
               <Option type="Map">
-                <Option name="3: egg" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: egg"/>
               </Option>
               <Option type="Map">
-                <Option name="5: tabulated rectangle" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: tabulated rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="6: tabulated trapezium" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: tabulated trapezium"/>
               </Option>
             </Option>
           </Option>
@@ -346,8 +346,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -356,8 +356,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -366,135 +366,135 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="ROWID"/>
-    <alias name="id" index="1" field="orf_id"/>
-    <alias name="display_name" index="2" field="orf_display_name"/>
-    <alias name="code" index="3" field="orf_code"/>
-    <alias name="max_capacity" index="4" field="orf_max_capacity"/>
-    <alias name="crest_level" index="5" field="orf_crest_level"/>
-    <alias name="sewerage" index="6" field="orf_sewerage"/>
-    <alias name="cross_section_definition_id" index="7" field="orf_cross_section_definition_id"/>
-    <alias name="friction_value" index="8" field="orf_friction_value"/>
-    <alias name="friction_type" index="9" field="orf_friction_type"/>
-    <alias name="discharge_coefficient_positive" index="10" field="orf_discharge_coefficient_positive"/>
-    <alias name="discharge_coefficient_negative" index="11" field="orf_discharge_coefficient_negative"/>
-    <alias name="zoom_category" index="12" field="orf_zoom_category"/>
-    <alias name="crest_type" index="13" field="orf_crest_type"/>
-    <alias name="connection_node_start_id" index="14" field="orf_connection_node_start_id"/>
-    <alias name="connection_node_end_id" index="15" field="orf_connection_node_end_id"/>
-    <alias name="id" index="16" field="def_id"/>
-    <alias name="shape" index="17" field="def_shape"/>
-    <alias name="width" index="18" field="def_width"/>
-    <alias name="height" index="19" field="def_height"/>
-    <alias name="code" index="20" field="def_code"/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="id" field="orf_id" index="1"/>
+    <alias name="display_name" field="orf_display_name" index="2"/>
+    <alias name="code" field="orf_code" index="3"/>
+    <alias name="max_capacity" field="orf_max_capacity" index="4"/>
+    <alias name="crest_level" field="orf_crest_level" index="5"/>
+    <alias name="sewerage" field="orf_sewerage" index="6"/>
+    <alias name="cross_section_definition_id" field="orf_cross_section_definition_id" index="7"/>
+    <alias name="friction_value" field="orf_friction_value" index="8"/>
+    <alias name="friction_type" field="orf_friction_type" index="9"/>
+    <alias name="discharge_coefficient_positive" field="orf_discharge_coefficient_positive" index="10"/>
+    <alias name="discharge_coefficient_negative" field="orf_discharge_coefficient_negative" index="11"/>
+    <alias name="zoom_category" field="orf_zoom_category" index="12"/>
+    <alias name="crest_type" field="orf_crest_type" index="13"/>
+    <alias name="connection_node_start_id" field="orf_connection_node_start_id" index="14"/>
+    <alias name="connection_node_end_id" field="orf_connection_node_end_id" index="15"/>
+    <alias name="id" field="def_id" index="16"/>
+    <alias name="shape" field="def_shape" index="17"/>
+    <alias name="width" field="def_width" index="18"/>
+    <alias name="height" field="def_height" index="19"/>
+    <alias name="code" field="def_code" index="20"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="ROWID" expression=""/>
-    <default applyOnUpdate="0" field="orf_id" expression="if(maximum(orf_id) is null,1, maximum(orf_id)+1)"/>
-    <default applyOnUpdate="0" field="orf_display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="orf_code" expression="'new'"/>
-    <default applyOnUpdate="0" field="orf_max_capacity" expression=""/>
-    <default applyOnUpdate="0" field="orf_crest_level" expression=""/>
-    <default applyOnUpdate="0" field="orf_sewerage" expression=""/>
-    <default applyOnUpdate="0" field="orf_cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="orf_friction_value" expression="0.02"/>
-    <default applyOnUpdate="0" field="orf_friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="orf_discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="orf_discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="orf_zoom_category" expression="3"/>
-    <default applyOnUpdate="0" field="orf_crest_type" expression="4"/>
-    <default applyOnUpdate="0" field="orf_connection_node_start_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="orf_connection_node_end_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="def_id" expression=""/>
-    <default applyOnUpdate="0" field="def_shape" expression=""/>
-    <default applyOnUpdate="0" field="def_width" expression=""/>
-    <default applyOnUpdate="0" field="def_height" expression=""/>
-    <default applyOnUpdate="0" field="def_code" expression=""/>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="if(maximum(orf_id) is null,1, maximum(orf_id)+1)" applyOnUpdate="0" field="orf_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="orf_display_name"/>
+    <default expression="'new'" applyOnUpdate="0" field="orf_code"/>
+    <default expression="" applyOnUpdate="0" field="orf_max_capacity"/>
+    <default expression="" applyOnUpdate="0" field="orf_crest_level"/>
+    <default expression="" applyOnUpdate="0" field="orf_sewerage"/>
+    <default expression="" applyOnUpdate="0" field="orf_cross_section_definition_id"/>
+    <default expression="0.02" applyOnUpdate="0" field="orf_friction_value"/>
+    <default expression="2" applyOnUpdate="0" field="orf_friction_type"/>
+    <default expression="0.8" applyOnUpdate="0" field="orf_discharge_coefficient_positive"/>
+    <default expression="0.8" applyOnUpdate="0" field="orf_discharge_coefficient_negative"/>
+    <default expression="3" applyOnUpdate="0" field="orf_zoom_category"/>
+    <default expression="4" applyOnUpdate="0" field="orf_crest_type"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="orf_connection_node_start_id"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="orf_connection_node_end_id"/>
+    <default expression="" applyOnUpdate="0" field="def_id"/>
+    <default expression="" applyOnUpdate="0" field="def_shape"/>
+    <default expression="" applyOnUpdate="0" field="def_width"/>
+    <default expression="" applyOnUpdate="0" field="def_height"/>
+    <default expression="" applyOnUpdate="0" field="def_code"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="orf_display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="orf_code" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="orf_max_capacity" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_crest_level" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="orf_sewerage" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="orf_friction_value" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_friction_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_crest_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_id"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="orf_display_name"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="orf_code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="orf_max_capacity"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_crest_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="orf_sewerage"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_cross_section_definition_id"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="orf_friction_value"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_discharge_coefficient_positive"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_discharge_coefficient_negative"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_crest_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="orf_connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="ROWID" desc=""/>
-    <constraint exp="" field="orf_id" desc=""/>
-    <constraint exp="&quot;orf_display_name&quot; is not null" field="orf_display_name" desc=""/>
-    <constraint exp="&quot;orf_code&quot; is not null&#xd;&#xa;" field="orf_code" desc=""/>
-    <constraint exp="" field="orf_max_capacity" desc=""/>
-    <constraint exp="" field="orf_crest_level" desc=""/>
-    <constraint exp="" field="orf_sewerage" desc=""/>
-    <constraint exp="" field="orf_cross_section_definition_id" desc=""/>
-    <constraint exp="&quot;orf_friction_value&quot; is not null" field="orf_friction_value" desc=""/>
-    <constraint exp="" field="orf_friction_type" desc=""/>
-    <constraint exp="" field="orf_discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="orf_discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="orf_zoom_category" desc=""/>
-    <constraint exp="" field="orf_crest_type" desc=""/>
-    <constraint exp="" field="orf_connection_node_start_id" desc=""/>
-    <constraint exp="" field="orf_connection_node_end_id" desc=""/>
-    <constraint exp="" field="def_id" desc=""/>
-    <constraint exp="" field="def_shape" desc=""/>
-    <constraint exp="" field="def_width" desc=""/>
-    <constraint exp="" field="def_height" desc=""/>
-    <constraint exp="" field="def_code" desc=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="orf_id"/>
+    <constraint exp="&quot;orf_display_name&quot; is not null" desc="" field="orf_display_name"/>
+    <constraint exp="&quot;orf_code&quot; is not null&#xd;&#xa;" desc="" field="orf_code"/>
+    <constraint exp="" desc="" field="orf_max_capacity"/>
+    <constraint exp="" desc="" field="orf_crest_level"/>
+    <constraint exp="" desc="" field="orf_sewerage"/>
+    <constraint exp="" desc="" field="orf_cross_section_definition_id"/>
+    <constraint exp="&quot;orf_friction_value&quot; is not null" desc="" field="orf_friction_value"/>
+    <constraint exp="" desc="" field="orf_friction_type"/>
+    <constraint exp="" desc="" field="orf_discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="orf_discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="orf_zoom_category"/>
+    <constraint exp="" desc="" field="orf_crest_type"/>
+    <constraint exp="" desc="" field="orf_connection_node_start_id"/>
+    <constraint exp="" desc="" field="orf_connection_node_end_id"/>
+    <constraint exp="" desc="" field="def_id"/>
+    <constraint exp="" desc="" field="def_shape"/>
+    <constraint exp="" desc="" field="def_width"/>
+    <constraint exp="" desc="" field="def_height"/>
+    <constraint exp="" desc="" field="def_code"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="ROWID" hidden="0" width="-1" type="field"/>
-      <column name="orf_id" hidden="0" width="-1" type="field"/>
-      <column name="orf_display_name" hidden="0" width="-1" type="field"/>
-      <column name="orf_code" hidden="0" width="-1" type="field"/>
-      <column name="orf_max_capacity" hidden="0" width="-1" type="field"/>
-      <column name="orf_crest_level" hidden="0" width="-1" type="field"/>
-      <column name="orf_sewerage" hidden="0" width="-1" type="field"/>
-      <column name="orf_cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="orf_friction_value" hidden="0" width="-1" type="field"/>
-      <column name="orf_friction_type" hidden="0" width="-1" type="field"/>
-      <column name="orf_discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="orf_discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="orf_zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="orf_crest_type" hidden="0" width="-1" type="field"/>
-      <column name="orf_connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="orf_connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="def_id" hidden="0" width="-1" type="field"/>
-      <column name="def_shape" hidden="0" width="-1" type="field"/>
-      <column name="def_width" hidden="0" width="-1" type="field"/>
-      <column name="def_height" hidden="0" width="-1" type="field"/>
-      <column name="def_code" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="orf_id"/>
+      <column width="-1" type="field" hidden="0" name="orf_display_name"/>
+      <column width="-1" type="field" hidden="0" name="orf_code"/>
+      <column width="-1" type="field" hidden="0" name="orf_max_capacity"/>
+      <column width="-1" type="field" hidden="0" name="orf_crest_level"/>
+      <column width="-1" type="field" hidden="0" name="orf_sewerage"/>
+      <column width="-1" type="field" hidden="0" name="orf_cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="orf_friction_value"/>
+      <column width="-1" type="field" hidden="0" name="orf_friction_type"/>
+      <column width="-1" type="field" hidden="0" name="orf_discharge_coefficient_positive"/>
+      <column width="-1" type="field" hidden="0" name="orf_discharge_coefficient_negative"/>
+      <column width="-1" type="field" hidden="0" name="orf_zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="orf_crest_type"/>
+      <column width="-1" type="field" hidden="0" name="orf_connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="orf_connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="def_id"/>
+      <column width="-1" type="field" hidden="0" name="def_shape"/>
+      <column width="-1" type="field" hidden="0" name="def_width"/>
+      <column width="-1" type="field" hidden="0" name="def_height"/>
+      <column width="-1" type="field" hidden="0" name="def_code"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -525,35 +525,35 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Orifice view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="orf_id" index="1" showLabel="1"/>
-        <attributeEditorField name="orf_display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="orf_code" index="3" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Orifice view" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="orf_id" index="1"/>
+        <attributeEditorField showLabel="1" name="orf_display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="orf_code" index="3"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="orf_crest_level" index="5" showLabel="1"/>
-        <attributeEditorField name="orf_crest_type" index="13" showLabel="1"/>
-        <attributeEditorField name="orf_friction_value" index="8" showLabel="1"/>
-        <attributeEditorField name="orf_friction_type" index="9" showLabel="1"/>
-        <attributeEditorField name="orf_discharge_coefficient_positive" index="10" showLabel="1"/>
-        <attributeEditorField name="orf_discharge_coefficient_negative" index="11" showLabel="1"/>
-        <attributeEditorField name="orf_max_capacity" index="4" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="orf_crest_level" index="5"/>
+        <attributeEditorField showLabel="1" name="orf_crest_type" index="13"/>
+        <attributeEditorField showLabel="1" name="orf_friction_value" index="8"/>
+        <attributeEditorField showLabel="1" name="orf_friction_type" index="9"/>
+        <attributeEditorField showLabel="1" name="orf_discharge_coefficient_positive" index="10"/>
+        <attributeEditorField showLabel="1" name="orf_discharge_coefficient_negative" index="11"/>
+        <attributeEditorField showLabel="1" name="orf_max_capacity" index="4"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="orf_sewerage" index="6" showLabel="1"/>
-        <attributeEditorField name="orf_zoom_category" index="12" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="orf_sewerage" index="6"/>
+        <attributeEditorField showLabel="1" name="orf_zoom_category" index="12"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Cross section" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="orf_cross_section_definition_id" index="7" showLabel="1"/>
-        <attributeEditorField name="def_shape" index="17" showLabel="1"/>
-        <attributeEditorField name="def_width" index="18" showLabel="1"/>
-        <attributeEditorField name="def_height" index="19" showLabel="1"/>
-        <attributeEditorField name="def_code" index="20" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section" columnCount="1">
+        <attributeEditorField showLabel="1" name="orf_cross_section_definition_id" index="7"/>
+        <attributeEditorField showLabel="1" name="def_shape" index="17"/>
+        <attributeEditorField showLabel="1" name="def_width" index="18"/>
+        <attributeEditorField showLabel="1" name="def_height" index="19"/>
+        <attributeEditorField showLabel="1" name="def_code" index="20"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="orf_connection_node_start_id" index="14" showLabel="1"/>
-        <attributeEditorField name="orf_connection_node_end_id" index="15" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="orf_connection_node_start_id" index="14"/>
+        <attributeEditorField showLabel="1" name="orf_connection_node_end_id" index="15"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -581,27 +581,27 @@ def my_form_open(dialog, layer, feature):
     <field name="orf_zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="def_code" labelOnTop="0"/>
-    <field name="def_height" labelOnTop="0"/>
-    <field name="def_id" labelOnTop="0"/>
-    <field name="def_shape" labelOnTop="0"/>
-    <field name="def_width" labelOnTop="0"/>
-    <field name="orf_code" labelOnTop="0"/>
-    <field name="orf_connection_node_end_id" labelOnTop="0"/>
-    <field name="orf_connection_node_start_id" labelOnTop="0"/>
-    <field name="orf_crest_level" labelOnTop="0"/>
-    <field name="orf_crest_type" labelOnTop="0"/>
-    <field name="orf_cross_section_definition_id" labelOnTop="0"/>
-    <field name="orf_discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="orf_discharge_coefficient_positive" labelOnTop="0"/>
-    <field name="orf_display_name" labelOnTop="0"/>
-    <field name="orf_friction_type" labelOnTop="0"/>
-    <field name="orf_friction_value" labelOnTop="0"/>
-    <field name="orf_id" labelOnTop="0"/>
-    <field name="orf_max_capacity" labelOnTop="0"/>
-    <field name="orf_sewerage" labelOnTop="0"/>
-    <field name="orf_zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="def_code"/>
+    <field labelOnTop="0" name="def_height"/>
+    <field labelOnTop="0" name="def_id"/>
+    <field labelOnTop="0" name="def_shape"/>
+    <field labelOnTop="0" name="def_width"/>
+    <field labelOnTop="0" name="orf_code"/>
+    <field labelOnTop="0" name="orf_connection_node_end_id"/>
+    <field labelOnTop="0" name="orf_connection_node_start_id"/>
+    <field labelOnTop="0" name="orf_crest_level"/>
+    <field labelOnTop="0" name="orf_crest_type"/>
+    <field labelOnTop="0" name="orf_cross_section_definition_id"/>
+    <field labelOnTop="0" name="orf_discharge_coefficient_negative"/>
+    <field labelOnTop="0" name="orf_discharge_coefficient_positive"/>
+    <field labelOnTop="0" name="orf_display_name"/>
+    <field labelOnTop="0" name="orf_friction_type"/>
+    <field labelOnTop="0" name="orf_friction_value"/>
+    <field labelOnTop="0" name="orf_id"/>
+    <field labelOnTop="0" name="orf_max_capacity"/>
+    <field labelOnTop="0" name="orf_sewerage"/>
+    <field labelOnTop="0" name="orf_zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_orifice_view.qml
+++ b/layer_styles/schematisation/v2_orifice_view.qml
@@ -1,74 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.4-Essen" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="ROWID">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_crest_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_crest_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_cross_section_definition_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_sewerage">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_discharge_coefficient_positive">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_discharge_coefficient_negative">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_external">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_friction_value">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_friction_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_connection_node_start_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_connection_node_end_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_shape">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_width">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_height">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -77,250 +20,488 @@
           <prop k="line_width" v="0.66"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="MarkerLine" locked="0">
+        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
           <prop k="interval" v="3"/>
-          <prop k="interval_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="placement" v="centralpoint"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="rotate" v="0"/>
-          <symbol alpha="1" clip_to_extent="1" type="marker" name="@0@1">
-            <layer pass="0" class="SimpleMarker" locked="0">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
+            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
               <prop k="angle" v="0"/>
               <prop k="color" v="51,160,44,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
               <prop k="name" v="triangle"/>
               <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="outline_color" v="0,0,0,255"/>
               <prop k="outline_style" v="solid"/>
               <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="outline_width_unit" v="MM"/>
               <prop k="scale_method" v="area"/>
               <prop k="size" v="3"/>
-              <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="size_unit" v="MM"/>
               <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property value="ROWID" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>weir_display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="0">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_max_capacity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_crest_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_sewerage">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option name="CheckedState" value="1" type="QString"/>
+            <Option name="UncheckedState" value="0" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_cross_section_definition_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_friction_value">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_friction_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: Chezy" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: Manning" value="2" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_discharge_coefficient_positive">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_discharge_coefficient_negative">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_crest_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="3: broad crested" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: short crested" value="4" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="orf_connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: rectangle" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: round" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: egg" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: tabulated rectangle" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: tabulated trapezium" value="6" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_height">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="ROWID"/>
+    <alias name="id" index="1" field="orf_id"/>
+    <alias name="display_name" index="2" field="orf_display_name"/>
+    <alias name="code" index="3" field="orf_code"/>
+    <alias name="max_capacity" index="4" field="orf_max_capacity"/>
+    <alias name="crest_level" index="5" field="orf_crest_level"/>
+    <alias name="sewerage" index="6" field="orf_sewerage"/>
+    <alias name="cross_section_definition_id" index="7" field="orf_cross_section_definition_id"/>
+    <alias name="friction_value" index="8" field="orf_friction_value"/>
+    <alias name="friction_type" index="9" field="orf_friction_type"/>
+    <alias name="discharge_coefficient_positive" index="10" field="orf_discharge_coefficient_positive"/>
+    <alias name="discharge_coefficient_negative" index="11" field="orf_discharge_coefficient_negative"/>
+    <alias name="zoom_category" index="12" field="orf_zoom_category"/>
+    <alias name="crest_type" index="13" field="orf_crest_type"/>
+    <alias name="connection_node_start_id" index="14" field="orf_connection_node_start_id"/>
+    <alias name="connection_node_end_id" index="15" field="orf_connection_node_end_id"/>
+    <alias name="id" index="16" field="def_id"/>
+    <alias name="shape" index="17" field="def_shape"/>
+    <alias name="width" index="18" field="def_width"/>
+    <alias name="height" index="19" field="def_height"/>
+    <alias name="code" index="20" field="def_code"/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform>.</editform>
+  <defaults>
+    <default applyOnUpdate="0" field="ROWID" expression=""/>
+    <default applyOnUpdate="0" field="orf_id" expression="if(maximum(orf_id) is null,1, maximum(orf_id)+1)"/>
+    <default applyOnUpdate="0" field="orf_display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="orf_code" expression="'new'"/>
+    <default applyOnUpdate="0" field="orf_max_capacity" expression=""/>
+    <default applyOnUpdate="0" field="orf_crest_level" expression=""/>
+    <default applyOnUpdate="0" field="orf_sewerage" expression=""/>
+    <default applyOnUpdate="0" field="orf_cross_section_definition_id" expression=""/>
+    <default applyOnUpdate="0" field="orf_friction_value" expression="0.02"/>
+    <default applyOnUpdate="0" field="orf_friction_type" expression="2"/>
+    <default applyOnUpdate="0" field="orf_discharge_coefficient_positive" expression="0.8"/>
+    <default applyOnUpdate="0" field="orf_discharge_coefficient_negative" expression="0.8"/>
+    <default applyOnUpdate="0" field="orf_zoom_category" expression="3"/>
+    <default applyOnUpdate="0" field="orf_crest_type" expression="4"/>
+    <default applyOnUpdate="0" field="orf_connection_node_start_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="orf_connection_node_end_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="def_id" expression=""/>
+    <default applyOnUpdate="0" field="def_shape" expression=""/>
+    <default applyOnUpdate="0" field="def_width" expression=""/>
+    <default applyOnUpdate="0" field="def_height" expression=""/>
+    <default applyOnUpdate="0" field="def_code" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="orf_display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="orf_code" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="orf_max_capacity" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_crest_level" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="orf_sewerage" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_cross_section_definition_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="orf_friction_value" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_friction_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_discharge_coefficient_positive" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_discharge_coefficient_negative" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_crest_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_connection_node_start_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="orf_connection_node_end_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="orf_id" desc=""/>
+    <constraint exp="&quot;orf_display_name&quot; is not null" field="orf_display_name" desc=""/>
+    <constraint exp="&quot;orf_code&quot; is not null&#xd;&#xa;" field="orf_code" desc=""/>
+    <constraint exp="" field="orf_max_capacity" desc=""/>
+    <constraint exp="" field="orf_crest_level" desc=""/>
+    <constraint exp="" field="orf_sewerage" desc=""/>
+    <constraint exp="" field="orf_cross_section_definition_id" desc=""/>
+    <constraint exp="&quot;orf_friction_value&quot; is not null" field="orf_friction_value" desc=""/>
+    <constraint exp="" field="orf_friction_type" desc=""/>
+    <constraint exp="" field="orf_discharge_coefficient_positive" desc=""/>
+    <constraint exp="" field="orf_discharge_coefficient_negative" desc=""/>
+    <constraint exp="" field="orf_zoom_category" desc=""/>
+    <constraint exp="" field="orf_crest_type" desc=""/>
+    <constraint exp="" field="orf_connection_node_start_id" desc=""/>
+    <constraint exp="" field="orf_connection_node_end_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+    <columns>
+      <column name="ROWID" hidden="0" width="-1" type="field"/>
+      <column name="orf_id" hidden="0" width="-1" type="field"/>
+      <column name="orf_display_name" hidden="0" width="-1" type="field"/>
+      <column name="orf_code" hidden="0" width="-1" type="field"/>
+      <column name="orf_max_capacity" hidden="0" width="-1" type="field"/>
+      <column name="orf_crest_level" hidden="0" width="-1" type="field"/>
+      <column name="orf_sewerage" hidden="0" width="-1" type="field"/>
+      <column name="orf_cross_section_definition_id" hidden="0" width="-1" type="field"/>
+      <column name="orf_friction_value" hidden="0" width="-1" type="field"/>
+      <column name="orf_friction_type" hidden="0" width="-1" type="field"/>
+      <column name="orf_discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
+      <column name="orf_discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
+      <column name="orf_zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="orf_crest_type" hidden="0" width="-1" type="field"/>
+      <column name="orf_connection_node_start_id" hidden="0" width="-1" type="field"/>
+      <column name="orf_connection_node_end_id" hidden="0" width="-1" type="field"/>
+      <column name="def_id" hidden="0" width="-1" type="field"/>
+      <column name="def_shape" hidden="0" width="-1" type="field"/>
+      <column name="def_width" hidden="0" width="-1" type="field"/>
+      <column name="def_height" hidden="0" width="-1" type="field"/>
+      <column name="def_code" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -342,11 +523,88 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Orifice view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="orf_id" index="1" showLabel="1"/>
+        <attributeEditorField name="orf_display_name" index="2" showLabel="1"/>
+        <attributeEditorField name="orf_code" index="3" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="orf_crest_level" index="5" showLabel="1"/>
+        <attributeEditorField name="orf_crest_type" index="13" showLabel="1"/>
+        <attributeEditorField name="orf_friction_value" index="8" showLabel="1"/>
+        <attributeEditorField name="orf_friction_type" index="9" showLabel="1"/>
+        <attributeEditorField name="orf_discharge_coefficient_positive" index="10" showLabel="1"/>
+        <attributeEditorField name="orf_discharge_coefficient_negative" index="11" showLabel="1"/>
+        <attributeEditorField name="orf_max_capacity" index="4" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="orf_sewerage" index="6" showLabel="1"/>
+        <attributeEditorField name="orf_zoom_category" index="12" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Cross section" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="orf_cross_section_definition_id" index="7" showLabel="1"/>
+        <attributeEditorField name="def_shape" index="17" showLabel="1"/>
+        <attributeEditorField name="def_width" index="18" showLabel="1"/>
+        <attributeEditorField name="def_height" index="19" showLabel="1"/>
+        <attributeEditorField name="def_code" index="20" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="orf_connection_node_start_id" index="14" showLabel="1"/>
+        <attributeEditorField name="orf_connection_node_end_id" index="15" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="ROWID" editable="1"/>
+    <field name="def_code" editable="0"/>
+    <field name="def_height" editable="0"/>
+    <field name="def_id" editable="1"/>
+    <field name="def_shape" editable="0"/>
+    <field name="def_width" editable="0"/>
+    <field name="orf_code" editable="1"/>
+    <field name="orf_connection_node_end_id" editable="0"/>
+    <field name="orf_connection_node_start_id" editable="0"/>
+    <field name="orf_crest_level" editable="1"/>
+    <field name="orf_crest_type" editable="1"/>
+    <field name="orf_cross_section_definition_id" editable="1"/>
+    <field name="orf_discharge_coefficient_negative" editable="1"/>
+    <field name="orf_discharge_coefficient_positive" editable="1"/>
+    <field name="orf_display_name" editable="1"/>
+    <field name="orf_friction_type" editable="1"/>
+    <field name="orf_friction_value" editable="1"/>
+    <field name="orf_id" editable="1"/>
+    <field name="orf_max_capacity" editable="1"/>
+    <field name="orf_sewerage" editable="1"/>
+    <field name="orf_zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="def_code" labelOnTop="0"/>
+    <field name="def_height" labelOnTop="0"/>
+    <field name="def_id" labelOnTop="0"/>
+    <field name="def_shape" labelOnTop="0"/>
+    <field name="def_width" labelOnTop="0"/>
+    <field name="orf_code" labelOnTop="0"/>
+    <field name="orf_connection_node_end_id" labelOnTop="0"/>
+    <field name="orf_connection_node_start_id" labelOnTop="0"/>
+    <field name="orf_crest_level" labelOnTop="0"/>
+    <field name="orf_crest_type" labelOnTop="0"/>
+    <field name="orf_cross_section_definition_id" labelOnTop="0"/>
+    <field name="orf_discharge_coefficient_negative" labelOnTop="0"/>
+    <field name="orf_discharge_coefficient_positive" labelOnTop="0"/>
+    <field name="orf_display_name" labelOnTop="0"/>
+    <field name="orf_friction_type" labelOnTop="0"/>
+    <field name="orf_friction_value" labelOnTop="0"/>
+    <field name="orf_id" labelOnTop="0"/>
+    <field name="orf_max_capacity" labelOnTop="0"/>
+    <field name="orf_sewerage" labelOnTop="0"/>
+    <field name="orf_zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>ROWID</previewExpression>
+  <mapTip>weir_display_name</mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_pipe.qml
+++ b/layer_styles/schematisation/v2_pipe.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis readOnly="0" maxScale="0" version="3.4.5-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -13,7 +13,7 @@
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -293,111 +293,111 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="zoom_category" index="0"/>
-    <alias name="" field="pipe_quality" index="1"/>
-    <alias name="" field="code" index="2"/>
-    <alias name="" field="display_name" index="3"/>
-    <alias name="" field="connection_node_end_id" index="4"/>
-    <alias name="" field="dist_calc_points" index="5"/>
-    <alias name="" field="profile_num" index="6"/>
-    <alias name="" field="connection_node_start_id" index="7"/>
-    <alias name="" field="material" index="8"/>
-    <alias name="" field="sewerage_type" index="9"/>
-    <alias name="" field="original_length" index="10"/>
-    <alias name="" field="invert_level_end_point" index="11"/>
-    <alias name="" field="invert_level_start_point" index="12"/>
-    <alias name="" field="calculation_type" index="13"/>
-    <alias name="" field="friction_type" index="14"/>
-    <alias name="" field="friction_value" index="15"/>
-    <alias name="" field="cross_section_definition_id" index="16"/>
-    <alias name="" field="id" index="17"/>
+    <alias field="zoom_category" index="0" name=""/>
+    <alias field="pipe_quality" index="1" name=""/>
+    <alias field="code" index="2" name=""/>
+    <alias field="display_name" index="3" name=""/>
+    <alias field="connection_node_end_id" index="4" name=""/>
+    <alias field="dist_calc_points" index="5" name=""/>
+    <alias field="profile_num" index="6" name=""/>
+    <alias field="connection_node_start_id" index="7" name=""/>
+    <alias field="material" index="8" name=""/>
+    <alias field="sewerage_type" index="9" name=""/>
+    <alias field="original_length" index="10" name=""/>
+    <alias field="invert_level_end_point" index="11" name=""/>
+    <alias field="invert_level_start_point" index="12" name=""/>
+    <alias field="calculation_type" index="13" name=""/>
+    <alias field="friction_type" index="14" name=""/>
+    <alias field="friction_value" index="15" name=""/>
+    <alias field="cross_section_definition_id" index="16" name=""/>
+    <alias field="id" index="17" name=""/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="3" applyOnUpdate="0" field="zoom_category"/>
-    <default expression="" applyOnUpdate="0" field="pipe_quality"/>
-    <default expression="'new'" applyOnUpdate="0" field="code"/>
-    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_end_id"/>
-    <default expression="10000" applyOnUpdate="0" field="dist_calc_points"/>
-    <default expression="" applyOnUpdate="0" field="profile_num"/>
-    <default expression="" applyOnUpdate="0" field="connection_node_start_id"/>
-    <default expression="" applyOnUpdate="0" field="material"/>
-    <default expression="0" applyOnUpdate="0" field="sewerage_type"/>
-    <default expression="" applyOnUpdate="0" field="original_length"/>
-    <default expression="" applyOnUpdate="0" field="invert_level_end_point"/>
-    <default expression="" applyOnUpdate="0" field="invert_level_start_point"/>
-    <default expression="1" applyOnUpdate="0" field="calculation_type"/>
-    <default expression="2" applyOnUpdate="0" field="friction_type"/>
-    <default expression="" applyOnUpdate="0" field="friction_value"/>
-    <default expression="" applyOnUpdate="0" field="cross_section_definition_id"/>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default field="zoom_category" applyOnUpdate="0" expression="3"/>
+    <default field="pipe_quality" applyOnUpdate="0" expression=""/>
+    <default field="code" applyOnUpdate="0" expression="'new'"/>
+    <default field="display_name" applyOnUpdate="0" expression="'new'"/>
+    <default field="connection_node_end_id" applyOnUpdate="0" expression=""/>
+    <default field="dist_calc_points" applyOnUpdate="0" expression="10000"/>
+    <default field="profile_num" applyOnUpdate="0" expression=""/>
+    <default field="connection_node_start_id" applyOnUpdate="0" expression=""/>
+    <default field="material" applyOnUpdate="0" expression=""/>
+    <default field="sewerage_type" applyOnUpdate="0" expression=""/>
+    <default field="original_length" applyOnUpdate="0" expression=""/>
+    <default field="invert_level_end_point" applyOnUpdate="0" expression=""/>
+    <default field="invert_level_start_point" applyOnUpdate="0" expression=""/>
+    <default field="calculation_type" applyOnUpdate="0" expression="1"/>
+    <default field="friction_type" applyOnUpdate="0" expression="2"/>
+    <default field="friction_value" applyOnUpdate="0" expression=""/>
+    <default field="cross_section_definition_id" applyOnUpdate="0" expression=""/>
+    <default field="id" applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_quality"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_end_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="dist_calc_points"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="profile_num"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_start_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="material"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="sewerage_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="original_length"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_end_point"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_start_point"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="calculation_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cross_section_definition_id"/>
-    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
+    <constraint notnull_strength="2" constraints="1" field="zoom_category" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_quality" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="code" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="display_name" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="connection_node_end_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="dist_calc_points" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="profile_num" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="connection_node_start_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="material" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="sewerage_type" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="original_length" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="invert_level_end_point" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="invert_level_start_point" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="calculation_type" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="friction_type" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="friction_value" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="cross_section_definition_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="1" constraints="3" field="id" unique_strength="1" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="zoom_category"/>
-    <constraint exp="" desc="" field="pipe_quality"/>
-    <constraint exp="" desc="" field="code"/>
-    <constraint exp="" desc="" field="display_name"/>
-    <constraint exp="" desc="" field="connection_node_end_id"/>
-    <constraint exp="" desc="" field="dist_calc_points"/>
-    <constraint exp="" desc="" field="profile_num"/>
-    <constraint exp="" desc="" field="connection_node_start_id"/>
-    <constraint exp="" desc="" field="material"/>
-    <constraint exp="" desc="" field="sewerage_type"/>
-    <constraint exp="" desc="" field="original_length"/>
-    <constraint exp="" desc="" field="invert_level_end_point"/>
-    <constraint exp="" desc="" field="invert_level_start_point"/>
-    <constraint exp="" desc="" field="calculation_type"/>
-    <constraint exp="" desc="" field="friction_type"/>
-    <constraint exp="" desc="" field="friction_value"/>
-    <constraint exp="" desc="" field="cross_section_definition_id"/>
-    <constraint exp="" desc="" field="id"/>
+    <constraint field="zoom_category" desc="" exp=""/>
+    <constraint field="pipe_quality" desc="" exp=""/>
+    <constraint field="code" desc="" exp=""/>
+    <constraint field="display_name" desc="" exp=""/>
+    <constraint field="connection_node_end_id" desc="" exp=""/>
+    <constraint field="dist_calc_points" desc="" exp=""/>
+    <constraint field="profile_num" desc="" exp=""/>
+    <constraint field="connection_node_start_id" desc="" exp=""/>
+    <constraint field="material" desc="" exp=""/>
+    <constraint field="sewerage_type" desc="" exp=""/>
+    <constraint field="original_length" desc="" exp=""/>
+    <constraint field="invert_level_end_point" desc="" exp=""/>
+    <constraint field="invert_level_start_point" desc="" exp=""/>
+    <constraint field="calculation_type" desc="" exp=""/>
+    <constraint field="friction_type" desc="" exp=""/>
+    <constraint field="friction_value" desc="" exp=""/>
+    <constraint field="cross_section_definition_id" desc="" exp=""/>
+    <constraint field="id" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="pipe_quality"/>
-      <column width="-1" type="field" hidden="0" name="code"/>
-      <column width="-1" type="field" hidden="0" name="display_name"/>
-      <column width="-1" type="field" hidden="0" name="connection_node_end_id"/>
-      <column width="-1" type="field" hidden="0" name="dist_calc_points"/>
-      <column width="-1" type="field" hidden="0" name="profile_num"/>
-      <column width="-1" type="field" hidden="0" name="connection_node_start_id"/>
-      <column width="-1" type="field" hidden="0" name="material"/>
-      <column width="-1" type="field" hidden="0" name="sewerage_type"/>
-      <column width="-1" type="field" hidden="0" name="original_length"/>
-      <column width="-1" type="field" hidden="0" name="invert_level_end_point"/>
-      <column width="-1" type="field" hidden="0" name="invert_level_start_point"/>
-      <column width="-1" type="field" hidden="0" name="calculation_type"/>
-      <column width="-1" type="field" hidden="0" name="friction_type"/>
-      <column width="-1" type="field" hidden="0" name="friction_value"/>
-      <column width="-1" type="field" hidden="0" name="cross_section_definition_id"/>
-      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" name="zoom_category" hidden="0"/>
+      <column width="-1" type="field" name="pipe_quality" hidden="0"/>
+      <column width="-1" type="field" name="code" hidden="0"/>
+      <column width="-1" type="field" name="display_name" hidden="0"/>
+      <column width="-1" type="field" name="connection_node_end_id" hidden="0"/>
+      <column width="-1" type="field" name="dist_calc_points" hidden="0"/>
+      <column width="-1" type="field" name="profile_num" hidden="0"/>
+      <column width="-1" type="field" name="connection_node_start_id" hidden="0"/>
+      <column width="-1" type="field" name="material" hidden="0"/>
+      <column width="-1" type="field" name="sewerage_type" hidden="0"/>
+      <column width="-1" type="field" name="original_length" hidden="0"/>
+      <column width="-1" type="field" name="invert_level_end_point" hidden="0"/>
+      <column width="-1" type="field" name="invert_level_start_point" hidden="0"/>
+      <column width="-1" type="field" name="calculation_type" hidden="0"/>
+      <column width="-1" type="field" name="friction_type" hidden="0"/>
+      <column width="-1" type="field" name="friction_value" hidden="0"/>
+      <column width="-1" type="field" name="cross_section_definition_id" hidden="0"/>
+      <column width="-1" type="field" name="id" hidden="0"/>
       <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
@@ -429,51 +429,51 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Pipe" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-        <attributeEditorField showLabel="1" name="id" index="17"/>
-        <attributeEditorField showLabel="1" name="display_name" index="3"/>
-        <attributeEditorField showLabel="1" name="code" index="2"/>
-        <attributeEditorField showLabel="1" name="calculation_type" index="13"/>
-        <attributeEditorField showLabel="1" name="dist_calc_points" index="5"/>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" columnCount="1" name="Pipe">
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="General">
+        <attributeEditorField showLabel="1" index="17" name="id"/>
+        <attributeEditorField showLabel="1" index="3" name="display_name"/>
+        <attributeEditorField showLabel="1" index="2" name="code"/>
+        <attributeEditorField showLabel="1" index="13" name="calculation_type"/>
+        <attributeEditorField showLabel="1" index="5" name="dist_calc_points"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
-        <attributeEditorField showLabel="1" name="invert_level_start_point" index="12"/>
-        <attributeEditorField showLabel="1" name="invert_level_end_point" index="11"/>
-        <attributeEditorField showLabel="1" name="friction_value" index="15"/>
-        <attributeEditorField showLabel="1" name="friction_type" index="14"/>
-        <attributeEditorField showLabel="1" name="cross_section_definition_id" index="16"/>
-        <attributeEditorField showLabel="1" name="material" index="8"/>
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Characteristics">
+        <attributeEditorField showLabel="1" index="12" name="invert_level_start_point"/>
+        <attributeEditorField showLabel="1" index="11" name="invert_level_end_point"/>
+        <attributeEditorField showLabel="1" index="15" name="friction_value"/>
+        <attributeEditorField showLabel="1" index="14" name="friction_type"/>
+        <attributeEditorField showLabel="1" index="16" name="cross_section_definition_id"/>
+        <attributeEditorField showLabel="1" index="8" name="material"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="visualization" columnCount="1">
-        <attributeEditorField showLabel="1" name="sewerage_type" index="9"/>
-        <attributeEditorField showLabel="1" name="zoom_category" index="0"/>
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="visualization">
+        <attributeEditorField showLabel="1" index="9" name="sewerage_type"/>
+        <attributeEditorField showLabel="1" index="0" name="zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
-        <attributeEditorField showLabel="1" name="connection_node_start_id" index="7"/>
-        <attributeEditorField showLabel="1" name="connection_node_end_id" index="4"/>
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Connection nodes">
+        <attributeEditorField showLabel="1" index="7" name="connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="4" name="connection_node_end_id"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="calculation_type" editable="1"/>
-    <field name="code" editable="1"/>
-    <field name="connection_node_end_id" editable="1"/>
-    <field name="connection_node_start_id" editable="1"/>
-    <field name="cross_section_definition_id" editable="1"/>
-    <field name="display_name" editable="1"/>
-    <field name="dist_calc_points" editable="1"/>
-    <field name="friction_type" editable="1"/>
-    <field name="friction_value" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="invert_level_end_point" editable="1"/>
-    <field name="invert_level_start_point" editable="1"/>
-    <field name="material" editable="1"/>
-    <field name="original_length" editable="1"/>
-    <field name="pipe_quality" editable="1"/>
-    <field name="profile_num" editable="1"/>
-    <field name="sewerage_type" editable="1"/>
-    <field name="zoom_category" editable="1"/>
+    <field editable="1" name="calculation_type"/>
+    <field editable="1" name="code"/>
+    <field editable="1" name="connection_node_end_id"/>
+    <field editable="1" name="connection_node_start_id"/>
+    <field editable="1" name="cross_section_definition_id"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="dist_calc_points"/>
+    <field editable="1" name="friction_type"/>
+    <field editable="1" name="friction_value"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="invert_level_end_point"/>
+    <field editable="1" name="invert_level_start_point"/>
+    <field editable="1" name="material"/>
+    <field editable="1" name="original_length"/>
+    <field editable="1" name="pipe_quality"/>
+    <field editable="1" name="profile_num"/>
+    <field editable="1" name="sewerage_type"/>
+    <field editable="1" name="zoom_category"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="calculation_type"/>

--- a/layer_styles/schematisation/v2_pipe.qml
+++ b/layer_styles/schematisation/v2_pipe.qml
@@ -1,116 +1,16 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
-    <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="101,101,101,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.66"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
-          <prop k="interval" v="3"/>
-          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="interval_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="placement" v="centralpoint"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="rotate" v="0"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
-              <prop k="angle" v="0"/>
-              <prop k="color" v="101,101,101,255"/>
-              <prop k="horizontal_anchor_point" v="1"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="name" v="circle"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="0,0,0,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="scale_method" v="area"/>
-              <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="size_unit" v="MM"/>
-              <prop k="vertical_anchor_point" v="1"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
-                  <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
-        </layer>
-      </symbol>
-    </symbols>
-    <rotation/>
-    <sizescale/>
-  </renderer-v2>
   <customproperties>
+    <property value="display_name" key="dualview/previewExpressions"/>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
-    </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
-    <properties>
-      <Option type="Map">
-        <Option name="name" value="" type="QString"/>
-        <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
-      </Option>
-    </properties>
-  </DiagramLayerSettings>
   <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
@@ -147,6 +47,16 @@
         </config>
       </editWidget>
     </field>
+    <field name="pipe_quality">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
     <field name="code">
       <editWidget type="TextEdit">
         <config>
@@ -167,7 +77,7 @@
         </config>
       </editWidget>
     </field>
-    <field name="discharge_coefficient_negative">
+    <field name="connection_node_end_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -187,6 +97,16 @@
         </config>
       </editWidget>
     </field>
+    <field name="profile_num">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
     <field name="connection_node_start_id">
       <editWidget type="TextEdit">
         <config>
@@ -197,17 +117,78 @@
         </config>
       </editWidget>
     </field>
-    <field name="discharge_coefficient_positive">
-      <editWidget type="TextEdit">
+    <field name="material">
+      <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="0: concrete" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1: pvc" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: gres" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: cast iron" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: brickwork" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: HPE" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: HDPE" value="6" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="7: plate iron" value="7" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="8: steel" value="8" type="QString"/>
+              </Option>
+            </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="cross_section_definition_id">
+    <field name="sewerage_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="0: mixed" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1: rain water" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: dry weather flow" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: transport" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: spillway" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: sinker" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: storage" value="6" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="7: storage tank" value="7" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="original_length">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -243,16 +224,19 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="100: embedded" value="100" type="QString"/>
+                <Option name="0: embedded" value="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="101: isolated" value="101" type="QString"/>
+                <Option name="1: isolated" value="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="102: connected" value="102" type="QString"/>
+                <Option name="2: connected" value="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="105: double connected" value="105" type="QString"/>
+                <Option name="3: broad crest" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: short crest" value="4" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -285,7 +269,7 @@
         </config>
       </editWidget>
     </field>
-    <field name="id">
+    <field name="cross_section_definition_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -295,7 +279,7 @@
         </config>
       </editWidget>
     </field>
-    <field name="connection_node_end_id">
+    <field name="id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -308,73 +292,85 @@
   </fieldConfiguration>
   <aliases>
     <alias name="" index="0" field="zoom_category"/>
-    <alias name="" index="1" field="code"/>
-    <alias name="" index="2" field="display_name"/>
-    <alias name="" index="3" field="discharge_coefficient_negative"/>
-    <alias name="" index="4" field="dist_calc_points"/>
-    <alias name="" index="5" field="connection_node_start_id"/>
-    <alias name="" index="6" field="discharge_coefficient_positive"/>
-    <alias name="" index="7" field="cross_section_definition_id"/>
-    <alias name="" index="8" field="invert_level_end_point"/>
-    <alias name="" index="9" field="invert_level_start_point"/>
-    <alias name="" index="10" field="calculation_type"/>
-    <alias name="" index="11" field="friction_type"/>
-    <alias name="" index="12" field="friction_value"/>
-    <alias name="" index="13" field="id"/>
-    <alias name="" index="14" field="connection_node_end_id"/>
+    <alias name="" index="1" field="pipe_quality"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="display_name"/>
+    <alias name="" index="4" field="connection_node_end_id"/>
+    <alias name="" index="5" field="dist_calc_points"/>
+    <alias name="" index="6" field="profile_num"/>
+    <alias name="" index="7" field="connection_node_start_id"/>
+    <alias name="" index="8" field="material"/>
+    <alias name="" index="9" field="sewerage_type"/>
+    <alias name="" index="10" field="original_length"/>
+    <alias name="" index="11" field="invert_level_end_point"/>
+    <alias name="" index="12" field="invert_level_start_point"/>
+    <alias name="" index="13" field="calculation_type"/>
+    <alias name="" index="14" field="friction_type"/>
+    <alias name="" index="15" field="friction_value"/>
+    <alias name="" index="16" field="cross_section_definition_id"/>
+    <alias name="" index="17" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="zoom_category" expression="4"/>
+    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
+    <default applyOnUpdate="0" field="pipe_quality" expression=""/>
     <default applyOnUpdate="0" field="code" expression="'new'"/>
     <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="discharge_coefficient_negative" expression="0.8"/>
+    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
     <default applyOnUpdate="0" field="dist_calc_points" expression="10000"/>
+    <default applyOnUpdate="0" field="profile_num" expression=""/>
     <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
-    <default applyOnUpdate="0" field="discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
+    <default applyOnUpdate="0" field="material" expression=""/>
+    <default applyOnUpdate="0" field="sewerage_type" expression="0"/>
+    <default applyOnUpdate="0" field="original_length" expression=""/>
     <default applyOnUpdate="0" field="invert_level_end_point" expression=""/>
     <default applyOnUpdate="0" field="invert_level_start_point" expression=""/>
-    <default applyOnUpdate="0" field="calculation_type" expression="101"/>
+    <default applyOnUpdate="0" field="calculation_type" expression="1"/>
     <default applyOnUpdate="0" field="friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="friction_value" expression="0.0145"/>
+    <default applyOnUpdate="0" field="friction_value" expression=""/>
+    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
     <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
   </defaults>
   <constraints>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_quality" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_negative" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
     <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dist_calc_points" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="profile_num" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="material" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="sewerage_type" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="original_length" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_end_point" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_start_point" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_type" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_value" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
     <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" field="pipe_quality" desc=""/>
     <constraint exp="" field="code" desc=""/>
     <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="discharge_coefficient_negative" desc=""/>
+    <constraint exp="" field="connection_node_end_id" desc=""/>
     <constraint exp="" field="dist_calc_points" desc=""/>
+    <constraint exp="" field="profile_num" desc=""/>
     <constraint exp="" field="connection_node_start_id" desc=""/>
-    <constraint exp="" field="discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="cross_section_definition_id" desc=""/>
+    <constraint exp="" field="material" desc=""/>
+    <constraint exp="" field="sewerage_type" desc=""/>
+    <constraint exp="" field="original_length" desc=""/>
     <constraint exp="" field="invert_level_end_point" desc=""/>
     <constraint exp="" field="invert_level_start_point" desc=""/>
     <constraint exp="" field="calculation_type" desc=""/>
     <constraint exp="" field="friction_type" desc=""/>
     <constraint exp="" field="friction_value" desc=""/>
+    <constraint exp="" field="cross_section_definition_id" desc=""/>
     <constraint exp="" field="id" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
@@ -383,20 +379,23 @@
   <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
       <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="pipe_quality" hidden="0" width="-1" type="field"/>
       <column name="code" hidden="0" width="-1" type="field"/>
       <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
       <column name="dist_calc_points" hidden="0" width="-1" type="field"/>
+      <column name="profile_num" hidden="0" width="-1" type="field"/>
       <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
+      <column name="material" hidden="0" width="-1" type="field"/>
+      <column name="sewerage_type" hidden="0" width="-1" type="field"/>
+      <column name="original_length" hidden="0" width="-1" type="field"/>
       <column name="invert_level_end_point" hidden="0" width="-1" type="field"/>
       <column name="invert_level_start_point" hidden="0" width="-1" type="field"/>
       <column name="calculation_type" hidden="0" width="-1" type="field"/>
       <column name="friction_type" hidden="0" width="-1" type="field"/>
       <column name="friction_value" hidden="0" width="-1" type="field"/>
+      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
       <column name="id" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
       <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -404,10 +403,10 @@
     <rowstyles/>
     <fieldstyles/>
   </conditionalstyles>
-  <editform tolerant="1">.</editform>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath>.</editforminitfilepath>
+  <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -419,7 +418,7 @@ Enter the name of the function in the "Python Init function"
 field.
 An example follows:
 """
-from PyQt4.QtGui import QWidget
+from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
@@ -428,29 +427,29 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Culvert" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+    <attributeEditorContainer name="Pipe" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
       <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="13" showLabel="1"/>
-        <attributeEditorField name="display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="code" index="1" showLabel="1"/>
-        <attributeEditorField name="calculation_type" index="10" showLabel="1"/>
-        <attributeEditorField name="dist_calc_points" index="4" showLabel="1"/>
+        <attributeEditorField name="id" index="17" showLabel="1"/>
+        <attributeEditorField name="display_name" index="3" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
+        <attributeEditorField name="calculation_type" index="13" showLabel="1"/>
+        <attributeEditorField name="dist_calc_points" index="5" showLabel="1"/>
       </attributeEditorContainer>
       <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="invert_level_start_point" index="9" showLabel="1"/>
-        <attributeEditorField name="invert_level_end_point" index="8" showLabel="1"/>
-        <attributeEditorField name="friction_value" index="12" showLabel="1"/>
-        <attributeEditorField name="friction_type" index="11" showLabel="1"/>
-        <attributeEditorField name="cross_section_definition_id" index="7" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_positive" index="6" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_negative" index="3" showLabel="1"/>
+        <attributeEditorField name="invert_level_start_point" index="12" showLabel="1"/>
+        <attributeEditorField name="invert_level_end_point" index="11" showLabel="1"/>
+        <attributeEditorField name="friction_value" index="15" showLabel="1"/>
+        <attributeEditorField name="friction_type" index="14" showLabel="1"/>
+        <attributeEditorField name="cross_section_definition_id" index="16" showLabel="1"/>
+        <attributeEditorField name="material" index="8" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="sewerage_type" index="9" showLabel="1"/>
         <attributeEditorField name="zoom_category" index="0" showLabel="1"/>
       </attributeEditorContainer>
       <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="5" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="14" showLabel="1"/>
+        <attributeEditorField name="connection_node_start_id" index="7" showLabel="1"/>
+        <attributeEditorField name="connection_node_end_id" index="4" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -460,8 +459,6 @@ def my_form_open(dialog, layer, feature):
     <field name="connection_node_end_id" editable="1"/>
     <field name="connection_node_start_id" editable="1"/>
     <field name="cross_section_definition_id" editable="1"/>
-    <field name="discharge_coefficient_negative" editable="1"/>
-    <field name="discharge_coefficient_positive" editable="1"/>
     <field name="display_name" editable="1"/>
     <field name="dist_calc_points" editable="1"/>
     <field name="friction_type" editable="1"/>
@@ -469,6 +466,11 @@ def my_form_open(dialog, layer, feature):
     <field name="id" editable="1"/>
     <field name="invert_level_end_point" editable="1"/>
     <field name="invert_level_start_point" editable="1"/>
+    <field name="material" editable="1"/>
+    <field name="original_length" editable="1"/>
+    <field name="pipe_quality" editable="1"/>
+    <field name="profile_num" editable="1"/>
+    <field name="sewerage_type" editable="1"/>
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
@@ -477,8 +479,6 @@ def my_form_open(dialog, layer, feature):
     <field name="connection_node_end_id" labelOnTop="0"/>
     <field name="connection_node_start_id" labelOnTop="0"/>
     <field name="cross_section_definition_id" labelOnTop="0"/>
-    <field name="discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="discharge_coefficient_positive" labelOnTop="0"/>
     <field name="display_name" labelOnTop="0"/>
     <field name="dist_calc_points" labelOnTop="0"/>
     <field name="friction_type" labelOnTop="0"/>
@@ -486,10 +486,15 @@ def my_form_open(dialog, layer, feature):
     <field name="id" labelOnTop="0"/>
     <field name="invert_level_end_point" labelOnTop="0"/>
     <field name="invert_level_start_point" labelOnTop="0"/>
+    <field name="material" labelOnTop="0"/>
+    <field name="original_length" labelOnTop="0"/>
+    <field name="pipe_quality" labelOnTop="0"/>
+    <field name="profile_num" labelOnTop="0"/>
+    <field name="sewerage_type" labelOnTop="0"/>
     <field name="zoom_category" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>
   <mapTip></mapTip>
-  <layerGeometryType>1</layerGeometryType>
+  <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_pipe.qml
+++ b/layer_styles/schematisation/v2_pipe.qml
@@ -1,12 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
+<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property value="display_name" key="dualview/previewExpressions"/>
+    <property key="dualview/previewExpressions">
+      <value>display_name</value>
+    </property>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
@@ -20,27 +22,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -51,8 +53,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -61,8 +63,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -71,8 +73,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -81,8 +83,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -91,8 +93,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -101,8 +103,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -111,8 +113,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -121,33 +123,33 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="0: concrete" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0: concrete"/>
               </Option>
               <Option type="Map">
-                <Option name="1: pvc" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: pvc"/>
               </Option>
               <Option type="Map">
-                <Option name="2: gres" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: gres"/>
               </Option>
               <Option type="Map">
-                <Option name="3: cast iron" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: cast iron"/>
               </Option>
               <Option type="Map">
-                <Option name="4: brickwork" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: brickwork"/>
               </Option>
               <Option type="Map">
-                <Option name="5: HPE" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: HPE"/>
               </Option>
               <Option type="Map">
-                <Option name="6: HDPE" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: HDPE"/>
               </Option>
               <Option type="Map">
-                <Option name="7: plate iron" value="7" type="QString"/>
+                <Option value="7" type="QString" name="7: plate iron"/>
               </Option>
               <Option type="Map">
-                <Option name="8: steel" value="8" type="QString"/>
+                <Option value="8" type="QString" name="8: steel"/>
               </Option>
             </Option>
           </Option>
@@ -158,30 +160,30 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="0: mixed" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0: mixed"/>
               </Option>
               <Option type="Map">
-                <Option name="1: rain water" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: rain water"/>
               </Option>
               <Option type="Map">
-                <Option name="2: dry weather flow" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: dry weather flow"/>
               </Option>
               <Option type="Map">
-                <Option name="3: transport" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: transport"/>
               </Option>
               <Option type="Map">
-                <Option name="4: spillway" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: spillway"/>
               </Option>
               <Option type="Map">
-                <Option name="5: sinker" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: sinker"/>
               </Option>
               <Option type="Map">
-                <Option name="6: storage" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: storage"/>
               </Option>
               <Option type="Map">
-                <Option name="7: storage tank" value="7" type="QString"/>
+                <Option value="7" type="QString" name="7: storage tank"/>
               </Option>
             </Option>
           </Option>
@@ -192,8 +194,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -202,8 +204,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -212,8 +214,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -222,21 +224,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="0: embedded" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0: embedded"/>
               </Option>
               <Option type="Map">
-                <Option name="1: isolated" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: isolated"/>
               </Option>
               <Option type="Map">
-                <Option name="2: connected" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: connected"/>
               </Option>
               <Option type="Map">
-                <Option name="3: broad crest" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: broad crest"/>
               </Option>
               <Option type="Map">
-                <Option name="4: short crest" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: short crest"/>
               </Option>
             </Option>
           </Option>
@@ -247,12 +249,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -263,8 +265,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -273,8 +275,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -283,120 +285,120 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="zoom_category"/>
-    <alias name="" index="1" field="pipe_quality"/>
-    <alias name="" index="2" field="code"/>
-    <alias name="" index="3" field="display_name"/>
-    <alias name="" index="4" field="connection_node_end_id"/>
-    <alias name="" index="5" field="dist_calc_points"/>
-    <alias name="" index="6" field="profile_num"/>
-    <alias name="" index="7" field="connection_node_start_id"/>
-    <alias name="" index="8" field="material"/>
-    <alias name="" index="9" field="sewerage_type"/>
-    <alias name="" index="10" field="original_length"/>
-    <alias name="" index="11" field="invert_level_end_point"/>
-    <alias name="" index="12" field="invert_level_start_point"/>
-    <alias name="" index="13" field="calculation_type"/>
-    <alias name="" index="14" field="friction_type"/>
-    <alias name="" index="15" field="friction_value"/>
-    <alias name="" index="16" field="cross_section_definition_id"/>
-    <alias name="" index="17" field="id"/>
+    <alias name="" field="zoom_category" index="0"/>
+    <alias name="" field="pipe_quality" index="1"/>
+    <alias name="" field="code" index="2"/>
+    <alias name="" field="display_name" index="3"/>
+    <alias name="" field="connection_node_end_id" index="4"/>
+    <alias name="" field="dist_calc_points" index="5"/>
+    <alias name="" field="profile_num" index="6"/>
+    <alias name="" field="connection_node_start_id" index="7"/>
+    <alias name="" field="material" index="8"/>
+    <alias name="" field="sewerage_type" index="9"/>
+    <alias name="" field="original_length" index="10"/>
+    <alias name="" field="invert_level_end_point" index="11"/>
+    <alias name="" field="invert_level_start_point" index="12"/>
+    <alias name="" field="calculation_type" index="13"/>
+    <alias name="" field="friction_type" index="14"/>
+    <alias name="" field="friction_value" index="15"/>
+    <alias name="" field="cross_section_definition_id" index="16"/>
+    <alias name="" field="id" index="17"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
-    <default applyOnUpdate="0" field="pipe_quality" expression=""/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
-    <default applyOnUpdate="0" field="dist_calc_points" expression="10000"/>
-    <default applyOnUpdate="0" field="profile_num" expression=""/>
-    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
-    <default applyOnUpdate="0" field="material" expression=""/>
-    <default applyOnUpdate="0" field="sewerage_type" expression="0"/>
-    <default applyOnUpdate="0" field="original_length" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_end_point" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_start_point" expression=""/>
-    <default applyOnUpdate="0" field="calculation_type" expression="1"/>
-    <default applyOnUpdate="0" field="friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="friction_value" expression=""/>
-    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default expression="3" applyOnUpdate="0" field="zoom_category"/>
+    <default expression="" applyOnUpdate="0" field="pipe_quality"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_end_id"/>
+    <default expression="10000" applyOnUpdate="0" field="dist_calc_points"/>
+    <default expression="" applyOnUpdate="0" field="profile_num"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_start_id"/>
+    <default expression="" applyOnUpdate="0" field="material"/>
+    <default expression="0" applyOnUpdate="0" field="sewerage_type"/>
+    <default expression="" applyOnUpdate="0" field="original_length"/>
+    <default expression="" applyOnUpdate="0" field="invert_level_end_point"/>
+    <default expression="" applyOnUpdate="0" field="invert_level_start_point"/>
+    <default expression="1" applyOnUpdate="0" field="calculation_type"/>
+    <default expression="2" applyOnUpdate="0" field="friction_type"/>
+    <default expression="" applyOnUpdate="0" field="friction_value"/>
+    <default expression="" applyOnUpdate="0" field="cross_section_definition_id"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_quality" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dist_calc_points" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="profile_num" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="material" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="sewerage_type" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="original_length" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_end_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_start_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_value" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_quality"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="dist_calc_points"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="profile_num"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="material"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="sewerage_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="original_length"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_end_point"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="invert_level_start_point"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="calculation_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cross_section_definition_id"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="pipe_quality" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
-    <constraint exp="" field="dist_calc_points" desc=""/>
-    <constraint exp="" field="profile_num" desc=""/>
-    <constraint exp="" field="connection_node_start_id" desc=""/>
-    <constraint exp="" field="material" desc=""/>
-    <constraint exp="" field="sewerage_type" desc=""/>
-    <constraint exp="" field="original_length" desc=""/>
-    <constraint exp="" field="invert_level_end_point" desc=""/>
-    <constraint exp="" field="invert_level_start_point" desc=""/>
-    <constraint exp="" field="calculation_type" desc=""/>
-    <constraint exp="" field="friction_type" desc=""/>
-    <constraint exp="" field="friction_value" desc=""/>
-    <constraint exp="" field="cross_section_definition_id" desc=""/>
-    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="pipe_quality"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="connection_node_end_id"/>
+    <constraint exp="" desc="" field="dist_calc_points"/>
+    <constraint exp="" desc="" field="profile_num"/>
+    <constraint exp="" desc="" field="connection_node_start_id"/>
+    <constraint exp="" desc="" field="material"/>
+    <constraint exp="" desc="" field="sewerage_type"/>
+    <constraint exp="" desc="" field="original_length"/>
+    <constraint exp="" desc="" field="invert_level_end_point"/>
+    <constraint exp="" desc="" field="invert_level_start_point"/>
+    <constraint exp="" desc="" field="calculation_type"/>
+    <constraint exp="" desc="" field="friction_type"/>
+    <constraint exp="" desc="" field="friction_value"/>
+    <constraint exp="" desc="" field="cross_section_definition_id"/>
+    <constraint exp="" desc="" field="id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="pipe_quality" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="dist_calc_points" hidden="0" width="-1" type="field"/>
-      <column name="profile_num" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="material" hidden="0" width="-1" type="field"/>
-      <column name="sewerage_type" hidden="0" width="-1" type="field"/>
-      <column name="original_length" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_end_point" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_start_point" hidden="0" width="-1" type="field"/>
-      <column name="calculation_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_value" hidden="0" width="-1" type="field"/>
-      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="pipe_quality"/>
+      <column width="-1" type="field" hidden="0" name="code"/>
+      <column width="-1" type="field" hidden="0" name="display_name"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="dist_calc_points"/>
+      <column width="-1" type="field" hidden="0" name="profile_num"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="material"/>
+      <column width="-1" type="field" hidden="0" name="sewerage_type"/>
+      <column width="-1" type="field" hidden="0" name="original_length"/>
+      <column width="-1" type="field" hidden="0" name="invert_level_end_point"/>
+      <column width="-1" type="field" hidden="0" name="invert_level_start_point"/>
+      <column width="-1" type="field" hidden="0" name="calculation_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_value"/>
+      <column width="-1" type="field" hidden="0" name="cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -427,29 +429,29 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Pipe" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="17" showLabel="1"/>
-        <attributeEditorField name="display_name" index="3" showLabel="1"/>
-        <attributeEditorField name="code" index="2" showLabel="1"/>
-        <attributeEditorField name="calculation_type" index="13" showLabel="1"/>
-        <attributeEditorField name="dist_calc_points" index="5" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Pipe" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="id" index="17"/>
+        <attributeEditorField showLabel="1" name="display_name" index="3"/>
+        <attributeEditorField showLabel="1" name="code" index="2"/>
+        <attributeEditorField showLabel="1" name="calculation_type" index="13"/>
+        <attributeEditorField showLabel="1" name="dist_calc_points" index="5"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="invert_level_start_point" index="12" showLabel="1"/>
-        <attributeEditorField name="invert_level_end_point" index="11" showLabel="1"/>
-        <attributeEditorField name="friction_value" index="15" showLabel="1"/>
-        <attributeEditorField name="friction_type" index="14" showLabel="1"/>
-        <attributeEditorField name="cross_section_definition_id" index="16" showLabel="1"/>
-        <attributeEditorField name="material" index="8" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="invert_level_start_point" index="12"/>
+        <attributeEditorField showLabel="1" name="invert_level_end_point" index="11"/>
+        <attributeEditorField showLabel="1" name="friction_value" index="15"/>
+        <attributeEditorField showLabel="1" name="friction_type" index="14"/>
+        <attributeEditorField showLabel="1" name="cross_section_definition_id" index="16"/>
+        <attributeEditorField showLabel="1" name="material" index="8"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="sewerage_type" index="9" showLabel="1"/>
-        <attributeEditorField name="zoom_category" index="0" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="sewerage_type" index="9"/>
+        <attributeEditorField showLabel="1" name="zoom_category" index="0"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="7" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="4" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="connection_node_start_id" index="7"/>
+        <attributeEditorField showLabel="1" name="connection_node_end_id" index="4"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -474,24 +476,24 @@ def my_form_open(dialog, layer, feature):
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="calculation_type" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_end_id" labelOnTop="0"/>
-    <field name="connection_node_start_id" labelOnTop="0"/>
-    <field name="cross_section_definition_id" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="dist_calc_points" labelOnTop="0"/>
-    <field name="friction_type" labelOnTop="0"/>
-    <field name="friction_value" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="invert_level_end_point" labelOnTop="0"/>
-    <field name="invert_level_start_point" labelOnTop="0"/>
-    <field name="material" labelOnTop="0"/>
-    <field name="original_length" labelOnTop="0"/>
-    <field name="pipe_quality" labelOnTop="0"/>
-    <field name="profile_num" labelOnTop="0"/>
-    <field name="sewerage_type" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="calculation_type"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_end_id"/>
+    <field labelOnTop="0" name="connection_node_start_id"/>
+    <field labelOnTop="0" name="cross_section_definition_id"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="dist_calc_points"/>
+    <field labelOnTop="0" name="friction_type"/>
+    <field labelOnTop="0" name="friction_value"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="invert_level_end_point"/>
+    <field labelOnTop="0" name="invert_level_start_point"/>
+    <field labelOnTop="0" name="material"/>
+    <field labelOnTop="0" name="original_length"/>
+    <field labelOnTop="0" name="pipe_quality"/>
+    <field labelOnTop="0" name="profile_num"/>
+    <field labelOnTop="0" name="sewerage_type"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_pipe_view.qml
+++ b/layer_styles/schematisation/v2_pipe_view.qml
@@ -1,22 +1,22 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="1" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="1" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" forceraster="0" symbollevels="0">
     <rules key="{1c4a4e03-d442-4bb0-8ffc-82b9a703e08f}">
-      <rule label="Gemengd" filter="pipe_sewerage_type = 0" symbol="0" key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}"/>
-      <rule label="RWA" filter="pipe_sewerage_type = 1" symbol="1" key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}"/>
-      <rule label="DWA" filter="pipe_sewerage_type = 2" symbol="2" key="{c8833167-878e-49b2-bd37-5019aeea2451}"/>
-      <rule label="Transport" filter="pipe_sewerage_type = 3" symbol="3" key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}"/>
-      <rule label="Bergbezinkvoorziening" filter="pipe_sewerage_type = 7" symbol="4" key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}"/>
-      <rule label="Overig" filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10" symbol="5" key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}"/>
+      <rule key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}" symbol="0" label="Gemengd" filter="pipe_sewerage_type = 0"/>
+      <rule key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}" symbol="1" label="RWA" filter="pipe_sewerage_type = 1"/>
+      <rule key="{c8833167-878e-49b2-bd37-5019aeea2451}" symbol="2" label="DWA" filter="pipe_sewerage_type = 2"/>
+      <rule key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}" symbol="3" label="Transport" filter="pipe_sewerage_type = 3"/>
+      <rule key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}" symbol="4" label="Bergbezinkvoorziening" filter="pipe_sewerage_type = 7"/>
+      <rule key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}" symbol="5" label="Overig" filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10"/>
     </rules>
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -35,15 +35,15 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="1">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -62,15 +62,15 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="2">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -89,15 +89,15 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="3">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -116,15 +116,15 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="4">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -143,15 +143,15 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="5">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -170,9 +170,9 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -181,20 +181,20 @@
   </renderer-v2>
   <labeling type="simple">
     <settings>
-      <text-style fontItalic="0" fontWordSpacing="0" useSubstitutions="0" fontFamily="MS Shell Dlg 2" multilineHeight="1" blendMode="0" fontSizeUnit="Point" fontSize="8.25" fontLetterSpacing="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" previewBkgrdColor="#ffffff" fontWeight="50" textOpacity="1" textColor="0,0,0,255" isExpression="1" namedStyle="Regular" fontStrikeout="0" fieldName="" fontUnderline="0">
-        <text-buffer bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1"/>
-        <background shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeOffsetUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeOffsetY="0" shapeOffsetX="0" shapeBorderWidth="0" shapeType="0" shapeBlendMode="0" shapeSizeUnit="MM" shapeSVGFile="" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeOpacity="1" shapeRadiiY="0" shapeRotation="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeBorderWidthUnit="MM" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeRadiiUnit="MM" shapeRadiiX="0"/>
-        <shadow shadowOffsetUnit="MM" shadowBlendMode="6" shadowUnder="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetAngle="135" shadowRadius="1.5" shadowDraw="0" shadowOffsetGlobal="1" shadowOpacity="0.7" shadowOffsetDist="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM"/>
+      <text-style previewBkgrdColor="#ffffff" fieldName="" textColor="0,0,0,255" useSubstitutions="0" blendMode="0" fontUnderline="0" fontItalic="0" textOpacity="1" namedStyle="Regular" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontWeight="50" multilineHeight="1" fontWordSpacing="0" fontSize="8.25" isExpression="1" fontCapitals="0" fontStrikeout="0" fontLetterSpacing="0" fontFamily="MS Shell Dlg 2">
+        <text-buffer bufferColor="255,255,255,255" bufferDraw="0" bufferSize="1" bufferNoFill="0" bufferOpacity="1" bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64"/>
+        <background shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeOffsetX="0" shapeRotation="0" shapeRadiiUnit="MM" shapeRadiiY="0" shapeJoinStyle="64" shapeSizeX="0" shapeSizeY="0" shapeFillColor="255,255,255,255" shapeBorderWidthUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeSVGFile="" shapeRadiiX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeDraw="0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeOpacity="1" shapeOffsetY="0"/>
+        <shadow shadowOffsetUnit="MM" shadowBlendMode="6" shadowUnder="0" shadowDraw="0" shadowColor="0,0,0,255" shadowScale="100" shadowOffsetAngle="135" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowOpacity="0.7"/>
         <substitutions/>
       </text-style>
-      <text-format formatNumbers="0" autoWrapLength="0" leftDirectionSymbol="&lt;" multilineAlign="0" placeDirectionSymbol="0" decimals="3" plussign="0" reverseDirectionSymbol="0" wrapChar="" useMaxLineLengthForAutoWrap="1" addDirectionSymbol="0" rightDirectionSymbol=">"/>
-      <placement xOffset="0" dist="0" centroidInside="0" centroidWhole="0" maxCurvedCharAngleIn="20" yOffset="0" distMapUnitScale="3x:0,0,0,0,0,0" priority="5" placement="2" offsetType="0" fitInPolygonOnly="0" distUnits="MM" preserveRotation="1" placementFlags="10" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" quadOffset="4" maxCurvedCharAngleOut="-20" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" offsetUnits="MapUnit" rotationAngle="0" repeatDistanceUnits="MM"/>
-      <rendering mergeLines="0" upsidedownLabels="0" fontLimitPixelSize="0" displayAll="0" scaleMin="1" scaleMax="10000000" fontMaxPixelSize="10000" scaleVisibility="0" obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" fontMinPixelSize="3" obstacleType="0" limitNumLabels="0" maxNumLabels="2000" drawLabels="1" zIndex="0"/>
+      <text-format addDirectionSymbol="0" decimals="3" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" reverseDirectionSymbol="0" plussign="0" wrapChar="" autoWrapLength="0" multilineAlign="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" formatNumbers="0"/>
+      <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" maxCurvedCharAngleOut="-20" placementFlags="10" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" dist="0" centroidInside="0" priority="5" rotationAngle="0" repeatDistanceUnits="MM" yOffset="0" offsetUnits="MapUnit" fitInPolygonOnly="0" maxCurvedCharAngleIn="20" xOffset="0" offsetType="0" repeatDistance="0" placement="2" centroidWhole="0" quadOffset="4" preserveRotation="1" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR"/>
+      <rendering zIndex="0" mergeLines="0" fontMaxPixelSize="10000" obstacle="1" displayAll="0" scaleMax="10000000" maxNumLabels="2000" scaleVisibility="0" limitNumLabels="0" obstacleType="0" fontMinPixelSize="3" minFeatureSize="0" fontLimitPixelSize="0" scaleMin="1" upsidedownLabels="0" drawLabels="1" labelPerPart="0" obstacleFactor="1"/>
       <dd_properties>
         <Option type="Map">
-          <Option name="name" value="" type="QString"/>
+          <Option value="" type="QString" name="name"/>
           <Option name="properties"/>
-          <Option name="type" value="collection" type="QString"/>
+          <Option value="collection" type="QString" name="type"/>
         </Option>
       </dd_properties>
     </settings>
@@ -207,18 +207,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -238,8 +238,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -248,8 +248,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -258,8 +258,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -268,8 +268,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -278,30 +278,30 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="0: mixed" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0: mixed"/>
               </Option>
               <Option type="Map">
-                <Option name="1: rain water" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: rain water"/>
               </Option>
               <Option type="Map">
-                <Option name="2: dry weather flow" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: dry weather flow"/>
               </Option>
               <Option type="Map">
-                <Option name="3: transport" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: transport"/>
               </Option>
               <Option type="Map">
-                <Option name="4: spillway" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: spillway"/>
               </Option>
               <Option type="Map">
-                <Option name="5: sinker" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: sinker"/>
               </Option>
               <Option type="Map">
-                <Option name="6: storage" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: storage"/>
               </Option>
               <Option type="Map">
-                <Option name="7: storage tank" value="7" type="QString"/>
+                <Option value="7" type="QString" name="7: storage tank"/>
               </Option>
             </Option>
           </Option>
@@ -312,21 +312,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="0: embedded" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0: embedded"/>
               </Option>
               <Option type="Map">
-                <Option name="1: isolated" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: isolated"/>
               </Option>
               <Option type="Map">
-                <Option name="2: connected" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: connected"/>
               </Option>
               <Option type="Map">
-                <Option name="3: broad crest" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: broad crest"/>
               </Option>
               <Option type="Map">
-                <Option name="4: short crest" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: short crest"/>
               </Option>
             </Option>
           </Option>
@@ -337,8 +337,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -347,8 +347,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -357,8 +357,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -367,8 +367,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -377,12 +377,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -393,8 +393,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -403,33 +403,33 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="0: Concrete" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0: concrete"/>
               </Option>
               <Option type="Map">
-                <Option name="1: pvc" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: pvc"/>
               </Option>
               <Option type="Map">
-                <Option name="2: gres" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: gres"/>
               </Option>
               <Option type="Map">
-                <Option name="3: cast iron" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: cast iron"/>
               </Option>
               <Option type="Map">
-                <Option name="4: brickwork" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: brickwork"/>
               </Option>
               <Option type="Map">
-                <Option name="5: HPE" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: HPE"/>
               </Option>
               <Option type="Map">
-                <Option name="6: HDPE" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: HDPE"/>
               </Option>
               <Option type="Map">
-                <Option name="7: plate iron" value="7" type="QString"/>
+                <Option value="7" type="QString" name="7: plate iron"/>
               </Option>
               <Option type="Map">
-                <Option name="8: steel" value="8" type="QString"/>
+                <Option value="8" type="QString" name="8: steel"/>
               </Option>
             </Option>
           </Option>
@@ -440,8 +440,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -450,8 +450,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -460,27 +460,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -491,8 +491,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -501,8 +501,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -511,8 +511,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -521,21 +521,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: rectangle" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="2: round" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: round"/>
               </Option>
               <Option type="Map">
-                <Option name="3: egg" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: egg"/>
               </Option>
               <Option type="Map">
-                <Option name="5: tabulated rectangle" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: tabulated rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="6: tabulated trapezium" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: tabulated trapezium"/>
               </Option>
             </Option>
           </Option>
@@ -546,8 +546,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -556,8 +556,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -566,150 +566,150 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="ROWID"/>
-    <alias name="id" index="1" field="pipe_id"/>
-    <alias name="display_name" index="2" field="pipe_display_name"/>
-    <alias name="code" index="3" field="pipe_code"/>
-    <alias name="profile_num" index="4" field="pipe_profile_num"/>
-    <alias name="sewerage_type" index="5" field="pipe_sewerage_type"/>
-    <alias name="calculation_type" index="6" field="pipe_calculation_type"/>
-    <alias name="invert_level_start_point" index="7" field="pipe_invert_level_start_point"/>
-    <alias name="invert_level_end_point" index="8" field="pipe_invert_level_end_point"/>
-    <alias name="cross_section_definition_id" index="9" field="pipe_cross_section_definition_id"/>
-    <alias name="friction_value" index="10" field="pipe_friction_value"/>
-    <alias name="friction_type" index="11" field="pipe_friction_type"/>
-    <alias name="dist_calc_points" index="12" field="pipe_dist_calc_points"/>
-    <alias name="material" index="13" field="pipe_material"/>
-    <alias name="pipe_quality" index="14" field="pipe_pipe_quality"/>
-    <alias name="original_length" index="15" field="pipe_original_length"/>
-    <alias name="zoom_category" index="16" field="pipe_zoom_category"/>
-    <alias name="connection_node_start_id" index="17" field="pipe_connection_node_start_id"/>
-    <alias name="connection_node_end_id" index="18" field="pipe_connection_node_end_id"/>
-    <alias name="id" index="19" field="def_id"/>
-    <alias name="shape" index="20" field="def_shape"/>
-    <alias name="width" index="21" field="def_width"/>
-    <alias name="height" index="22" field="def_height"/>
-    <alias name="code" index="23" field="def_code"/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="id" field="pipe_id" index="1"/>
+    <alias name="display_name" field="pipe_display_name" index="2"/>
+    <alias name="code" field="pipe_code" index="3"/>
+    <alias name="profile_num" field="pipe_profile_num" index="4"/>
+    <alias name="sewerage_type" field="pipe_sewerage_type" index="5"/>
+    <alias name="calculation_type" field="pipe_calculation_type" index="6"/>
+    <alias name="invert_level_start_point" field="pipe_invert_level_start_point" index="7"/>
+    <alias name="invert_level_end_point" field="pipe_invert_level_end_point" index="8"/>
+    <alias name="cross_section_definition_id" field="pipe_cross_section_definition_id" index="9"/>
+    <alias name="friction_value" field="pipe_friction_value" index="10"/>
+    <alias name="friction_type" field="pipe_friction_type" index="11"/>
+    <alias name="dist_calc_points" field="pipe_dist_calc_points" index="12"/>
+    <alias name="material" field="pipe_material" index="13"/>
+    <alias name="pipe_quality" field="pipe_pipe_quality" index="14"/>
+    <alias name="original_length" field="pipe_original_length" index="15"/>
+    <alias name="zoom_category" field="pipe_zoom_category" index="16"/>
+    <alias name="connection_node_start_id" field="pipe_connection_node_start_id" index="17"/>
+    <alias name="connection_node_end_id" field="pipe_connection_node_end_id" index="18"/>
+    <alias name="id" field="def_id" index="19"/>
+    <alias name="shape" field="def_shape" index="20"/>
+    <alias name="width" field="def_width" index="21"/>
+    <alias name="height" field="def_height" index="22"/>
+    <alias name="code" field="def_code" index="23"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="ROWID" expression=""/>
-    <default applyOnUpdate="0" field="pipe_id" expression="if(maximum(pipe_id) is null,1, maximum(pipe_id)+1)"/>
-    <default applyOnUpdate="0" field="pipe_display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="pipe_code" expression="'new'"/>
-    <default applyOnUpdate="0" field="pipe_profile_num" expression=""/>
-    <default applyOnUpdate="0" field="pipe_sewerage_type" expression="0"/>
-    <default applyOnUpdate="0" field="pipe_calculation_type" expression="1"/>
-    <default applyOnUpdate="0" field="pipe_invert_level_start_point" expression=""/>
-    <default applyOnUpdate="0" field="pipe_invert_level_end_point" expression=""/>
-    <default applyOnUpdate="0" field="pipe_cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="pipe_friction_value" expression=""/>
-    <default applyOnUpdate="0" field="pipe_friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="pipe_dist_calc_points" expression="10000"/>
-    <default applyOnUpdate="0" field="pipe_material" expression=""/>
-    <default applyOnUpdate="0" field="pipe_pipe_quality" expression=""/>
-    <default applyOnUpdate="0" field="pipe_original_length" expression=""/>
-    <default applyOnUpdate="0" field="pipe_zoom_category" expression="2"/>
-    <default applyOnUpdate="0" field="pipe_connection_node_start_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="pipe_connection_node_end_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="def_id" expression=""/>
-    <default applyOnUpdate="0" field="def_shape" expression=""/>
-    <default applyOnUpdate="0" field="def_width" expression=""/>
-    <default applyOnUpdate="0" field="def_height" expression=""/>
-    <default applyOnUpdate="0" field="def_code" expression=""/>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="if(maximum(pipe_id) is null,1, maximum(pipe_id)+1)" applyOnUpdate="0" field="pipe_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="pipe_display_name"/>
+    <default expression="'new'" applyOnUpdate="0" field="pipe_code"/>
+    <default expression="" applyOnUpdate="0" field="pipe_profile_num"/>
+    <default expression="0" applyOnUpdate="0" field="pipe_sewerage_type"/>
+    <default expression="1" applyOnUpdate="0" field="pipe_calculation_type"/>
+    <default expression="" applyOnUpdate="0" field="pipe_invert_level_start_point"/>
+    <default expression="" applyOnUpdate="0" field="pipe_invert_level_end_point"/>
+    <default expression="" applyOnUpdate="0" field="pipe_cross_section_definition_id"/>
+    <default expression="" applyOnUpdate="0" field="pipe_friction_value"/>
+    <default expression="2" applyOnUpdate="0" field="pipe_friction_type"/>
+    <default expression="10000" applyOnUpdate="0" field="pipe_dist_calc_points"/>
+    <default expression="" applyOnUpdate="0" field="pipe_material"/>
+    <default expression="" applyOnUpdate="0" field="pipe_pipe_quality"/>
+    <default expression="" applyOnUpdate="0" field="pipe_original_length"/>
+    <default expression="2" applyOnUpdate="0" field="pipe_zoom_category"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="pipe_connection_node_start_id"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="pipe_connection_node_end_id"/>
+    <default expression="" applyOnUpdate="0" field="def_id"/>
+    <default expression="" applyOnUpdate="0" field="def_shape"/>
+    <default expression="" applyOnUpdate="0" field="def_width"/>
+    <default expression="" applyOnUpdate="0" field="def_height"/>
+    <default expression="" applyOnUpdate="0" field="def_code"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_code" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_profile_num" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_sewerage_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_calculation_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_invert_level_start_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="pipe_invert_level_end_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_friction_value" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_friction_type" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_dist_calc_points" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_material" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_pipe_quality" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_original_length" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_profile_num"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_sewerage_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_calculation_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_invert_level_start_point"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="pipe_invert_level_end_point"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_cross_section_definition_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_friction_value"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_dist_calc_points"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_material"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_pipe_quality"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_original_length"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="ROWID" desc=""/>
-    <constraint exp="" field="pipe_id" desc=""/>
-    <constraint exp="" field="pipe_display_name" desc=""/>
-    <constraint exp="" field="pipe_code" desc=""/>
-    <constraint exp="" field="pipe_profile_num" desc=""/>
-    <constraint exp="" field="pipe_sewerage_type" desc=""/>
-    <constraint exp="" field="pipe_calculation_type" desc=""/>
-    <constraint exp="" field="pipe_invert_level_start_point" desc=""/>
-    <constraint exp="&quot;invert_level_end_point&quot; is not null" field="pipe_invert_level_end_point" desc=""/>
-    <constraint exp="" field="pipe_cross_section_definition_id" desc=""/>
-    <constraint exp="" field="pipe_friction_value" desc=""/>
-    <constraint exp="" field="pipe_friction_type" desc=""/>
-    <constraint exp="" field="pipe_dist_calc_points" desc=""/>
-    <constraint exp="" field="pipe_material" desc=""/>
-    <constraint exp="" field="pipe_pipe_quality" desc=""/>
-    <constraint exp="" field="pipe_original_length" desc=""/>
-    <constraint exp="" field="pipe_zoom_category" desc=""/>
-    <constraint exp="" field="pipe_connection_node_start_id" desc=""/>
-    <constraint exp="" field="pipe_connection_node_end_id" desc=""/>
-    <constraint exp="" field="def_id" desc=""/>
-    <constraint exp="" field="def_shape" desc=""/>
-    <constraint exp="" field="def_width" desc=""/>
-    <constraint exp="" field="def_height" desc=""/>
-    <constraint exp="" field="def_code" desc=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="pipe_id"/>
+    <constraint exp="" desc="" field="pipe_display_name"/>
+    <constraint exp="" desc="" field="pipe_code"/>
+    <constraint exp="" desc="" field="pipe_profile_num"/>
+    <constraint exp="" desc="" field="pipe_sewerage_type"/>
+    <constraint exp="" desc="" field="pipe_calculation_type"/>
+    <constraint exp="" desc="" field="pipe_invert_level_start_point"/>
+    <constraint exp="&quot;invert_level_end_point&quot; is not null" desc="" field="pipe_invert_level_end_point"/>
+    <constraint exp="" desc="" field="pipe_cross_section_definition_id"/>
+    <constraint exp="" desc="" field="pipe_friction_value"/>
+    <constraint exp="" desc="" field="pipe_friction_type"/>
+    <constraint exp="" desc="" field="pipe_dist_calc_points"/>
+    <constraint exp="" desc="" field="pipe_material"/>
+    <constraint exp="" desc="" field="pipe_pipe_quality"/>
+    <constraint exp="" desc="" field="pipe_original_length"/>
+    <constraint exp="" desc="" field="pipe_zoom_category"/>
+    <constraint exp="" desc="" field="pipe_connection_node_start_id"/>
+    <constraint exp="" desc="" field="pipe_connection_node_end_id"/>
+    <constraint exp="" desc="" field="def_id"/>
+    <constraint exp="" desc="" field="def_shape"/>
+    <constraint exp="" desc="" field="def_width"/>
+    <constraint exp="" desc="" field="def_height"/>
+    <constraint exp="" desc="" field="def_code"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="ROWID" hidden="0" width="-1" type="field"/>
-      <column name="pipe_id" hidden="0" width="-1" type="field"/>
-      <column name="pipe_display_name" hidden="0" width="-1" type="field"/>
-      <column name="pipe_code" hidden="0" width="-1" type="field"/>
-      <column name="pipe_profile_num" hidden="0" width="-1" type="field"/>
-      <column name="pipe_sewerage_type" hidden="0" width="-1" type="field"/>
-      <column name="pipe_calculation_type" hidden="0" width="-1" type="field"/>
-      <column name="pipe_invert_level_start_point" hidden="0" width="-1" type="field"/>
-      <column name="pipe_invert_level_end_point" hidden="0" width="-1" type="field"/>
-      <column name="pipe_cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="pipe_friction_value" hidden="0" width="-1" type="field"/>
-      <column name="pipe_friction_type" hidden="0" width="-1" type="field"/>
-      <column name="pipe_dist_calc_points" hidden="0" width="-1" type="field"/>
-      <column name="pipe_material" hidden="0" width="-1" type="field"/>
-      <column name="pipe_pipe_quality" hidden="0" width="-1" type="field"/>
-      <column name="pipe_original_length" hidden="0" width="-1" type="field"/>
-      <column name="pipe_zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="pipe_connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="pipe_connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="def_id" hidden="0" width="-1" type="field"/>
-      <column name="def_shape" hidden="0" width="-1" type="field"/>
-      <column name="def_width" hidden="0" width="-1" type="field"/>
-      <column name="def_height" hidden="0" width="-1" type="field"/>
-      <column name="def_code" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="pipe_id"/>
+      <column width="-1" type="field" hidden="0" name="pipe_display_name"/>
+      <column width="-1" type="field" hidden="0" name="pipe_code"/>
+      <column width="-1" type="field" hidden="0" name="pipe_profile_num"/>
+      <column width="-1" type="field" hidden="0" name="pipe_sewerage_type"/>
+      <column width="-1" type="field" hidden="0" name="pipe_calculation_type"/>
+      <column width="-1" type="field" hidden="0" name="pipe_invert_level_start_point"/>
+      <column width="-1" type="field" hidden="0" name="pipe_invert_level_end_point"/>
+      <column width="-1" type="field" hidden="0" name="pipe_cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="pipe_friction_value"/>
+      <column width="-1" type="field" hidden="0" name="pipe_friction_type"/>
+      <column width="-1" type="field" hidden="0" name="pipe_dist_calc_points"/>
+      <column width="-1" type="field" hidden="0" name="pipe_material"/>
+      <column width="-1" type="field" hidden="0" name="pipe_pipe_quality"/>
+      <column width="-1" type="field" hidden="0" name="pipe_original_length"/>
+      <column width="-1" type="field" hidden="0" name="pipe_zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="pipe_connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="pipe_connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="def_id"/>
+      <column width="-1" type="field" hidden="0" name="def_shape"/>
+      <column width="-1" type="field" hidden="0" name="def_width"/>
+      <column width="-1" type="field" hidden="0" name="def_height"/>
+      <column width="-1" type="field" hidden="0" name="def_code"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -738,35 +738,35 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Pipe view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="pipe_id" index="1" showLabel="1"/>
-        <attributeEditorField name="pipe_display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="pipe_code" index="3" showLabel="1"/>
-        <attributeEditorField name="pipe_calculation_type" index="6" showLabel="1"/>
-        <attributeEditorField name="pipe_dist_calc_points" index="12" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Pipe view" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="pipe_id" index="1"/>
+        <attributeEditorField showLabel="1" name="pipe_display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="pipe_code" index="3"/>
+        <attributeEditorField showLabel="1" name="pipe_calculation_type" index="6"/>
+        <attributeEditorField showLabel="1" name="pipe_dist_calc_points" index="12"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="pipe_invert_level_start_point" index="7" showLabel="1"/>
-        <attributeEditorField name="pipe_invert_level_end_point" index="8" showLabel="1"/>
-        <attributeEditorField name="pipe_friction_value" index="10" showLabel="1"/>
-        <attributeEditorField name="pipe_friction_type" index="11" showLabel="1"/>
-        <attributeEditorField name="pipe_material" index="13" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="pipe_invert_level_start_point" index="7"/>
+        <attributeEditorField showLabel="1" name="pipe_invert_level_end_point" index="8"/>
+        <attributeEditorField showLabel="1" name="pipe_friction_value" index="10"/>
+        <attributeEditorField showLabel="1" name="pipe_friction_type" index="11"/>
+        <attributeEditorField showLabel="1" name="pipe_material" index="13"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Cross section definition" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="pipe_cross_section_definition_id" index="9" showLabel="1"/>
-        <attributeEditorField name="def_shape" index="20" showLabel="1"/>
-        <attributeEditorField name="def_width" index="21" showLabel="1"/>
-        <attributeEditorField name="def_height" index="22" showLabel="1"/>
-        <attributeEditorField name="def_code" index="23" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section definition" columnCount="1">
+        <attributeEditorField showLabel="1" name="pipe_cross_section_definition_id" index="9"/>
+        <attributeEditorField showLabel="1" name="def_shape" index="20"/>
+        <attributeEditorField showLabel="1" name="def_width" index="21"/>
+        <attributeEditorField showLabel="1" name="def_height" index="22"/>
+        <attributeEditorField showLabel="1" name="def_code" index="23"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="pipe_sewerage_type" index="5" showLabel="1"/>
-        <attributeEditorField name="pipe_zoom_category" index="16" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="pipe_sewerage_type" index="5"/>
+        <attributeEditorField showLabel="1" name="pipe_zoom_category" index="16"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="pipe_connection_node_start_id" index="17" showLabel="1"/>
-        <attributeEditorField name="pipe_connection_node_end_id" index="18" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="pipe_connection_node_start_id" index="17"/>
+        <attributeEditorField showLabel="1" name="pipe_connection_node_end_id" index="18"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -797,30 +797,30 @@ def my_form_open(dialog, layer, feature):
     <field name="pipe_zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="def_code" labelOnTop="0"/>
-    <field name="def_height" labelOnTop="0"/>
-    <field name="def_id" labelOnTop="0"/>
-    <field name="def_shape" labelOnTop="0"/>
-    <field name="def_width" labelOnTop="0"/>
-    <field name="pipe_calculation_type" labelOnTop="0"/>
-    <field name="pipe_code" labelOnTop="0"/>
-    <field name="pipe_connection_node_end_id" labelOnTop="0"/>
-    <field name="pipe_connection_node_start_id" labelOnTop="0"/>
-    <field name="pipe_cross_section_definition_id" labelOnTop="0"/>
-    <field name="pipe_display_name" labelOnTop="0"/>
-    <field name="pipe_dist_calc_points" labelOnTop="0"/>
-    <field name="pipe_friction_type" labelOnTop="0"/>
-    <field name="pipe_friction_value" labelOnTop="0"/>
-    <field name="pipe_id" labelOnTop="0"/>
-    <field name="pipe_invert_level_end_point" labelOnTop="0"/>
-    <field name="pipe_invert_level_start_point" labelOnTop="0"/>
-    <field name="pipe_material" labelOnTop="0"/>
-    <field name="pipe_original_length" labelOnTop="0"/>
-    <field name="pipe_pipe_quality" labelOnTop="0"/>
-    <field name="pipe_profile_num" labelOnTop="0"/>
-    <field name="pipe_sewerage_type" labelOnTop="0"/>
-    <field name="pipe_zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="def_code"/>
+    <field labelOnTop="0" name="def_height"/>
+    <field labelOnTop="0" name="def_id"/>
+    <field labelOnTop="0" name="def_shape"/>
+    <field labelOnTop="0" name="def_width"/>
+    <field labelOnTop="0" name="pipe_calculation_type"/>
+    <field labelOnTop="0" name="pipe_code"/>
+    <field labelOnTop="0" name="pipe_connection_node_end_id"/>
+    <field labelOnTop="0" name="pipe_connection_node_start_id"/>
+    <field labelOnTop="0" name="pipe_cross_section_definition_id"/>
+    <field labelOnTop="0" name="pipe_display_name"/>
+    <field labelOnTop="0" name="pipe_dist_calc_points"/>
+    <field labelOnTop="0" name="pipe_friction_type"/>
+    <field labelOnTop="0" name="pipe_friction_value"/>
+    <field labelOnTop="0" name="pipe_id"/>
+    <field labelOnTop="0" name="pipe_invert_level_end_point"/>
+    <field labelOnTop="0" name="pipe_invert_level_start_point"/>
+    <field labelOnTop="0" name="pipe_material"/>
+    <field labelOnTop="0" name="pipe_original_length"/>
+    <field labelOnTop="0" name="pipe_pipe_quality"/>
+    <field labelOnTop="0" name="pipe_profile_num"/>
+    <field labelOnTop="0" name="pipe_sewerage_type"/>
+    <field labelOnTop="0" name="pipe_zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_pipe_view.qml
+++ b/layer_styles/schematisation/v2_pipe_view.qml
@@ -1,91 +1,25 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.6-Essen" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="ROWID">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_profile_num">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_sewerage_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_calculation_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_invert_level_start_point">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_invert_level_end_point">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_cross_section_definition_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_friction_value">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_friction_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_dist_calc_points">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_material">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_pipe_quality">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_original_length">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_connection_node_start_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="pipe_connection_node_end_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_shape">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_width">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_height">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0">
+<qgis labelsEnabled="1" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" symbollevels="0">
     <rules key="{1c4a4e03-d442-4bb0-8ffc-82b9a703e08f}">
-      <rule filter="pipe_sewerage_type = 0" key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}" symbol="0" label="Gemengd"/>
-      <rule filter="pipe_sewerage_type = 1" key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}" symbol="1" label="RWA"/>
-      <rule filter="pipe_sewerage_type = 2" key="{c8833167-878e-49b2-bd37-5019aeea2451}" symbol="2" label="DWA"/>
-      <rule filter="pipe_sewerage_type = 3" key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}" symbol="3" label="Transport"/>
-      <rule filter="pipe_sewerage_type = 7" key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}" symbol="4" label="Bergbezinkvoorziening"/>
-      <rule filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10" key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}" symbol="5" label="Overig"/>
+      <rule label="Gemengd" filter="pipe_sewerage_type = 0" symbol="0" key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}"/>
+      <rule label="RWA" filter="pipe_sewerage_type = 1" symbol="1" key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}"/>
+      <rule label="DWA" filter="pipe_sewerage_type = 2" symbol="2" key="{c8833167-878e-49b2-bd37-5019aeea2451}"/>
+      <rule label="Transport" filter="pipe_sewerage_type = 3" symbol="3" key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}"/>
+      <rule label="Bergbezinkvoorziening" filter="pipe_sewerage_type = 7" symbol="4" key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}"/>
+      <rule label="Overig" filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10" symbol="5" key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}"/>
     </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -94,17 +28,25 @@
           <prop k="line_width" v="0.4"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="1">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="1" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -113,17 +55,25 @@
           <prop k="line_width" v="0.4"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="2">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="2" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -132,17 +82,25 @@
           <prop k="line_width" v="0.4"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="3">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="3" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -151,17 +109,25 @@
           <prop k="line_width" v="0.7"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="4">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="4" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -170,17 +136,25 @@
           <prop k="line_width" v="2"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="5">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="5" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -189,215 +163,560 @@
           <prop k="line_width" v="0.4"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
-  <labeling type="simple"/>
+  <labeling type="simple">
+    <settings>
+      <text-style fontItalic="0" fontWordSpacing="0" useSubstitutions="0" fontFamily="MS Shell Dlg 2" multilineHeight="1" blendMode="0" fontSizeUnit="Point" fontSize="8.25" fontLetterSpacing="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" previewBkgrdColor="#ffffff" fontWeight="50" textOpacity="1" textColor="0,0,0,255" isExpression="1" namedStyle="Regular" fontStrikeout="0" fieldName="" fontUnderline="0">
+        <text-buffer bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1"/>
+        <background shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeOffsetUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeOffsetY="0" shapeOffsetX="0" shapeBorderWidth="0" shapeType="0" shapeBlendMode="0" shapeSizeUnit="MM" shapeSVGFile="" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeOpacity="1" shapeRadiiY="0" shapeRotation="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeBorderWidthUnit="MM" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeRadiiUnit="MM" shapeRadiiX="0"/>
+        <shadow shadowOffsetUnit="MM" shadowBlendMode="6" shadowUnder="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetAngle="135" shadowRadius="1.5" shadowDraw="0" shadowOffsetGlobal="1" shadowOpacity="0.7" shadowOffsetDist="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM"/>
+        <substitutions/>
+      </text-style>
+      <text-format formatNumbers="0" autoWrapLength="0" leftDirectionSymbol="&lt;" multilineAlign="0" placeDirectionSymbol="0" decimals="3" plussign="0" reverseDirectionSymbol="0" wrapChar="" useMaxLineLengthForAutoWrap="1" addDirectionSymbol="0" rightDirectionSymbol=">"/>
+      <placement xOffset="0" dist="0" centroidInside="0" centroidWhole="0" maxCurvedCharAngleIn="20" yOffset="0" distMapUnitScale="3x:0,0,0,0,0,0" priority="5" placement="2" offsetType="0" fitInPolygonOnly="0" distUnits="MM" preserveRotation="1" placementFlags="10" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" quadOffset="4" maxCurvedCharAngleOut="-20" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" offsetUnits="MapUnit" rotationAngle="0" repeatDistanceUnits="MM"/>
+      <rendering mergeLines="0" upsidedownLabels="0" fontLimitPixelSize="0" displayAll="0" scaleMin="1" scaleMax="10000000" fontMaxPixelSize="10000" scaleVisibility="0" obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" fontMinPixelSize="3" obstacleType="0" limitNumLabels="0" maxNumLabels="2000" drawLabels="1" zIndex="0"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+    </settings>
+  </labeling>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="true"/>
-    <property key="labeling/enabled" value="true"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="0">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_profile_num">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_sewerage_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="0: mixed" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1: rain water" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: dry weather flow" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: transport" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: spillway" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: sinker" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: storage" value="6" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="7: storage tank" value="7" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_calculation_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="0: embedded" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1: isolated" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: connected" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: broad crest" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: short crest" value="4" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_invert_level_start_point">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_invert_level_end_point">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_cross_section_definition_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_friction_value">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_friction_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: Chezy" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: Manning" value="2" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_dist_calc_points">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_material">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="0: Concrete" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1: pvc" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: gres" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: cast iron" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: brickwork" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: HPE" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: HDPE" value="6" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="7: plate iron" value="7" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="8: steel" value="8" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_pipe_quality">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_original_length">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pipe_connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: rectangle" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: round" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: egg" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: tabulated rectangle" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: tabulated trapezium" value="6" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_height">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="ROWID"/>
+    <alias name="id" index="1" field="pipe_id"/>
+    <alias name="display_name" index="2" field="pipe_display_name"/>
+    <alias name="code" index="3" field="pipe_code"/>
+    <alias name="profile_num" index="4" field="pipe_profile_num"/>
+    <alias name="sewerage_type" index="5" field="pipe_sewerage_type"/>
+    <alias name="calculation_type" index="6" field="pipe_calculation_type"/>
+    <alias name="invert_level_start_point" index="7" field="pipe_invert_level_start_point"/>
+    <alias name="invert_level_end_point" index="8" field="pipe_invert_level_end_point"/>
+    <alias name="cross_section_definition_id" index="9" field="pipe_cross_section_definition_id"/>
+    <alias name="friction_value" index="10" field="pipe_friction_value"/>
+    <alias name="friction_type" index="11" field="pipe_friction_type"/>
+    <alias name="dist_calc_points" index="12" field="pipe_dist_calc_points"/>
+    <alias name="material" index="13" field="pipe_material"/>
+    <alias name="pipe_quality" index="14" field="pipe_pipe_quality"/>
+    <alias name="original_length" index="15" field="pipe_original_length"/>
+    <alias name="zoom_category" index="16" field="pipe_zoom_category"/>
+    <alias name="connection_node_start_id" index="17" field="pipe_connection_node_start_id"/>
+    <alias name="connection_node_end_id" index="18" field="pipe_connection_node_end_id"/>
+    <alias name="id" index="19" field="def_id"/>
+    <alias name="shape" index="20" field="def_shape"/>
+    <alias name="width" index="21" field="def_width"/>
+    <alias name="height" index="22" field="def_height"/>
+    <alias name="code" index="23" field="def_code"/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform>.</editform>
+  <defaults>
+    <default applyOnUpdate="0" field="ROWID" expression=""/>
+    <default applyOnUpdate="0" field="pipe_id" expression="if(maximum(pipe_id) is null,1, maximum(pipe_id)+1)"/>
+    <default applyOnUpdate="0" field="pipe_display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="pipe_code" expression="'new'"/>
+    <default applyOnUpdate="0" field="pipe_profile_num" expression=""/>
+    <default applyOnUpdate="0" field="pipe_sewerage_type" expression="0"/>
+    <default applyOnUpdate="0" field="pipe_calculation_type" expression="1"/>
+    <default applyOnUpdate="0" field="pipe_invert_level_start_point" expression=""/>
+    <default applyOnUpdate="0" field="pipe_invert_level_end_point" expression=""/>
+    <default applyOnUpdate="0" field="pipe_cross_section_definition_id" expression=""/>
+    <default applyOnUpdate="0" field="pipe_friction_value" expression=""/>
+    <default applyOnUpdate="0" field="pipe_friction_type" expression="2"/>
+    <default applyOnUpdate="0" field="pipe_dist_calc_points" expression="10000"/>
+    <default applyOnUpdate="0" field="pipe_material" expression=""/>
+    <default applyOnUpdate="0" field="pipe_pipe_quality" expression=""/>
+    <default applyOnUpdate="0" field="pipe_original_length" expression=""/>
+    <default applyOnUpdate="0" field="pipe_zoom_category" expression="2"/>
+    <default applyOnUpdate="0" field="pipe_connection_node_start_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="pipe_connection_node_end_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="def_id" expression=""/>
+    <default applyOnUpdate="0" field="def_shape" expression=""/>
+    <default applyOnUpdate="0" field="def_width" expression=""/>
+    <default applyOnUpdate="0" field="def_height" expression=""/>
+    <default applyOnUpdate="0" field="def_code" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_code" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_profile_num" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_sewerage_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_calculation_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_invert_level_start_point" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="pipe_invert_level_end_point" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_cross_section_definition_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_friction_value" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_friction_type" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_dist_calc_points" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_material" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_pipe_quality" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_original_length" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="pipe_zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_connection_node_start_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pipe_connection_node_end_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="pipe_id" desc=""/>
+    <constraint exp="" field="pipe_display_name" desc=""/>
+    <constraint exp="" field="pipe_code" desc=""/>
+    <constraint exp="" field="pipe_profile_num" desc=""/>
+    <constraint exp="" field="pipe_sewerage_type" desc=""/>
+    <constraint exp="" field="pipe_calculation_type" desc=""/>
+    <constraint exp="" field="pipe_invert_level_start_point" desc=""/>
+    <constraint exp="&quot;invert_level_end_point&quot; is not null" field="pipe_invert_level_end_point" desc=""/>
+    <constraint exp="" field="pipe_cross_section_definition_id" desc=""/>
+    <constraint exp="" field="pipe_friction_value" desc=""/>
+    <constraint exp="" field="pipe_friction_type" desc=""/>
+    <constraint exp="" field="pipe_dist_calc_points" desc=""/>
+    <constraint exp="" field="pipe_material" desc=""/>
+    <constraint exp="" field="pipe_pipe_quality" desc=""/>
+    <constraint exp="" field="pipe_original_length" desc=""/>
+    <constraint exp="" field="pipe_zoom_category" desc=""/>
+    <constraint exp="" field="pipe_connection_node_start_id" desc=""/>
+    <constraint exp="" field="pipe_connection_node_end_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+    <columns>
+      <column name="ROWID" hidden="0" width="-1" type="field"/>
+      <column name="pipe_id" hidden="0" width="-1" type="field"/>
+      <column name="pipe_display_name" hidden="0" width="-1" type="field"/>
+      <column name="pipe_code" hidden="0" width="-1" type="field"/>
+      <column name="pipe_profile_num" hidden="0" width="-1" type="field"/>
+      <column name="pipe_sewerage_type" hidden="0" width="-1" type="field"/>
+      <column name="pipe_calculation_type" hidden="0" width="-1" type="field"/>
+      <column name="pipe_invert_level_start_point" hidden="0" width="-1" type="field"/>
+      <column name="pipe_invert_level_end_point" hidden="0" width="-1" type="field"/>
+      <column name="pipe_cross_section_definition_id" hidden="0" width="-1" type="field"/>
+      <column name="pipe_friction_value" hidden="0" width="-1" type="field"/>
+      <column name="pipe_friction_type" hidden="0" width="-1" type="field"/>
+      <column name="pipe_dist_calc_points" hidden="0" width="-1" type="field"/>
+      <column name="pipe_material" hidden="0" width="-1" type="field"/>
+      <column name="pipe_pipe_quality" hidden="0" width="-1" type="field"/>
+      <column name="pipe_original_length" hidden="0" width="-1" type="field"/>
+      <column name="pipe_zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="pipe_connection_node_start_id" hidden="0" width="-1" type="field"/>
+      <column name="pipe_connection_node_end_id" hidden="0" width="-1" type="field"/>
+      <column name="def_id" hidden="0" width="-1" type="field"/>
+      <column name="def_shape" hidden="0" width="-1" type="field"/>
+      <column name="def_width" hidden="0" width="-1" type="field"/>
+      <column name="def_height" hidden="0" width="-1" type="field"/>
+      <column name="def_code" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -417,11 +736,94 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Pipe view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="pipe_id" index="1" showLabel="1"/>
+        <attributeEditorField name="pipe_display_name" index="2" showLabel="1"/>
+        <attributeEditorField name="pipe_code" index="3" showLabel="1"/>
+        <attributeEditorField name="pipe_calculation_type" index="6" showLabel="1"/>
+        <attributeEditorField name="pipe_dist_calc_points" index="12" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="pipe_invert_level_start_point" index="7" showLabel="1"/>
+        <attributeEditorField name="pipe_invert_level_end_point" index="8" showLabel="1"/>
+        <attributeEditorField name="pipe_friction_value" index="10" showLabel="1"/>
+        <attributeEditorField name="pipe_friction_type" index="11" showLabel="1"/>
+        <attributeEditorField name="pipe_material" index="13" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Cross section definition" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="pipe_cross_section_definition_id" index="9" showLabel="1"/>
+        <attributeEditorField name="def_shape" index="20" showLabel="1"/>
+        <attributeEditorField name="def_width" index="21" showLabel="1"/>
+        <attributeEditorField name="def_height" index="22" showLabel="1"/>
+        <attributeEditorField name="def_code" index="23" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="pipe_sewerage_type" index="5" showLabel="1"/>
+        <attributeEditorField name="pipe_zoom_category" index="16" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="pipe_connection_node_start_id" index="17" showLabel="1"/>
+        <attributeEditorField name="pipe_connection_node_end_id" index="18" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="ROWID" editable="1"/>
+    <field name="def_code" editable="0"/>
+    <field name="def_height" editable="0"/>
+    <field name="def_id" editable="1"/>
+    <field name="def_shape" editable="0"/>
+    <field name="def_width" editable="0"/>
+    <field name="pipe_calculation_type" editable="1"/>
+    <field name="pipe_code" editable="1"/>
+    <field name="pipe_connection_node_end_id" editable="0"/>
+    <field name="pipe_connection_node_start_id" editable="0"/>
+    <field name="pipe_cross_section_definition_id" editable="1"/>
+    <field name="pipe_display_name" editable="1"/>
+    <field name="pipe_dist_calc_points" editable="1"/>
+    <field name="pipe_friction_type" editable="1"/>
+    <field name="pipe_friction_value" editable="1"/>
+    <field name="pipe_id" editable="1"/>
+    <field name="pipe_invert_level_end_point" editable="1"/>
+    <field name="pipe_invert_level_start_point" editable="1"/>
+    <field name="pipe_material" editable="1"/>
+    <field name="pipe_original_length" editable="1"/>
+    <field name="pipe_pipe_quality" editable="1"/>
+    <field name="pipe_profile_num" editable="1"/>
+    <field name="pipe_sewerage_type" editable="1"/>
+    <field name="pipe_zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="def_code" labelOnTop="0"/>
+    <field name="def_height" labelOnTop="0"/>
+    <field name="def_id" labelOnTop="0"/>
+    <field name="def_shape" labelOnTop="0"/>
+    <field name="def_width" labelOnTop="0"/>
+    <field name="pipe_calculation_type" labelOnTop="0"/>
+    <field name="pipe_code" labelOnTop="0"/>
+    <field name="pipe_connection_node_end_id" labelOnTop="0"/>
+    <field name="pipe_connection_node_start_id" labelOnTop="0"/>
+    <field name="pipe_cross_section_definition_id" labelOnTop="0"/>
+    <field name="pipe_display_name" labelOnTop="0"/>
+    <field name="pipe_dist_calc_points" labelOnTop="0"/>
+    <field name="pipe_friction_type" labelOnTop="0"/>
+    <field name="pipe_friction_value" labelOnTop="0"/>
+    <field name="pipe_id" labelOnTop="0"/>
+    <field name="pipe_invert_level_end_point" labelOnTop="0"/>
+    <field name="pipe_invert_level_start_point" labelOnTop="0"/>
+    <field name="pipe_material" labelOnTop="0"/>
+    <field name="pipe_original_length" labelOnTop="0"/>
+    <field name="pipe_pipe_quality" labelOnTop="0"/>
+    <field name="pipe_profile_num" labelOnTop="0"/>
+    <field name="pipe_sewerage_type" labelOnTop="0"/>
+    <field name="pipe_zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>ROWID</previewExpression>
+  <mapTip>display_name</mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_pipe_view.qml
+++ b/layer_styles/schematisation/v2_pipe_view.qml
@@ -1,38 +1,38 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="1" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis simplifyMaxScale="1" readOnly="0" labelsEnabled="1" simplifyAlgorithm="0" maxScale="0" version="3.4.5-Madeira" simplifyDrawingHints="1" styleCategories="AllStyleCategories" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" minScale="1e+08">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="RuleRenderer" forceraster="0" symbollevels="0">
+  <renderer-v2 symbollevels="0" enableorderby="0" type="RuleRenderer" forceraster="0">
     <rules key="{1c4a4e03-d442-4bb0-8ffc-82b9a703e08f}">
-      <rule key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}" symbol="0" label="Gemengd" filter="pipe_sewerage_type = 0"/>
-      <rule key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}" symbol="1" label="RWA" filter="pipe_sewerage_type = 1"/>
-      <rule key="{c8833167-878e-49b2-bd37-5019aeea2451}" symbol="2" label="DWA" filter="pipe_sewerage_type = 2"/>
-      <rule key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}" symbol="3" label="Transport" filter="pipe_sewerage_type = 3"/>
-      <rule key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}" symbol="4" label="Bergbezinkvoorziening" filter="pipe_sewerage_type = 7"/>
-      <rule key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}" symbol="5" label="Overig" filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10"/>
+      <rule symbol="0" filter="pipe_sewerage_type = 0" key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}" label="Gemengd"/>
+      <rule symbol="1" filter="pipe_sewerage_type = 1" key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}" label="RWA"/>
+      <rule symbol="2" filter="pipe_sewerage_type = 2" key="{c8833167-878e-49b2-bd37-5019aeea2451}" label="DWA"/>
+      <rule symbol="3" filter="pipe_sewerage_type = 3" key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}" label="Transport"/>
+      <rule symbol="4" filter="pipe_sewerage_type = 7" key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}" label="Bergbezinkvoorziening"/>
+      <rule symbol="5" filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10" key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}" label="Overig"/>
     </rules>
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="255,170,0,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.4"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" type="line" clip_to_extent="1" name="0" alpha="1">
+        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="255,170,0,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.4" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" type="QString" name="name"/>
@@ -42,24 +42,24 @@
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="1">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="85,170,255,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.4"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" type="line" clip_to_extent="1" name="1" alpha="1">
+        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="85,170,255,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.4" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" type="QString" name="name"/>
@@ -69,24 +69,24 @@
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="2">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="255,0,0,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.4"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" type="line" clip_to_extent="1" name="2" alpha="1">
+        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="255,0,0,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.4" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" type="QString" name="name"/>
@@ -96,24 +96,24 @@
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="3">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="153,153,153,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.7"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" type="line" clip_to_extent="1" name="3" alpha="1">
+        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="153,153,153,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.7" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" type="QString" name="name"/>
@@ -123,24 +123,24 @@
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="4">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="92,92,92,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="2"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" type="line" clip_to_extent="1" name="4" alpha="1">
+        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="92,92,92,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="2" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" type="QString" name="name"/>
@@ -150,24 +150,24 @@
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="5">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="211,211,211,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.4"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol force_rhr="0" type="line" clip_to_extent="1" name="5" alpha="1">
+        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="0" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="211,211,211,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.4" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option value="" type="QString" name="name"/>
@@ -181,15 +181,15 @@
   </renderer-v2>
   <labeling type="simple">
     <settings>
-      <text-style previewBkgrdColor="#ffffff" fieldName="" textColor="0,0,0,255" useSubstitutions="0" blendMode="0" fontUnderline="0" fontItalic="0" textOpacity="1" namedStyle="Regular" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontWeight="50" multilineHeight="1" fontWordSpacing="0" fontSize="8.25" isExpression="1" fontCapitals="0" fontStrikeout="0" fontLetterSpacing="0" fontFamily="MS Shell Dlg 2">
-        <text-buffer bufferColor="255,255,255,255" bufferDraw="0" bufferSize="1" bufferNoFill="0" bufferOpacity="1" bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64"/>
-        <background shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeOffsetX="0" shapeRotation="0" shapeRadiiUnit="MM" shapeRadiiY="0" shapeJoinStyle="64" shapeSizeX="0" shapeSizeY="0" shapeFillColor="255,255,255,255" shapeBorderWidthUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeSVGFile="" shapeRadiiX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeDraw="0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeOpacity="1" shapeOffsetY="0"/>
-        <shadow shadowOffsetUnit="MM" shadowBlendMode="6" shadowUnder="0" shadowDraw="0" shadowColor="0,0,0,255" shadowScale="100" shadowOffsetAngle="135" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowOpacity="0.7"/>
+      <text-style fontFamily="MS Shell Dlg 2" textOpacity="1" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" blendMode="0" fontStrikeout="0" previewBkgrdColor="#ffffff" isExpression="1" fontItalic="0" useSubstitutions="0" fontUnderline="0" fontCapitals="0" fontSizeUnit="Point" fieldName="" fontLetterSpacing="0" fontSize="8.25" fontWordSpacing="0" textColor="0,0,0,255" namedStyle="Regular">
+        <text-buffer bufferSize="1" bufferSizeUnits="MM" bufferOpacity="1" bufferDraw="0" bufferColor="255,255,255,255" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferNoFill="0"/>
+        <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeSizeUnit="MM" shapeBorderWidth="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotation="0" shapeSVGFile="" shapeSizeType="0" shapeRadiiY="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeOpacity="1" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeOffsetY="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeDraw="0" shapeRadiiX="0" shapeRadiiUnit="MM" shapeBorderWidthUnit="MM" shapeFillColor="255,255,255,255"/>
+        <shadow shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowScale="100" shadowColor="0,0,0,255" shadowUnder="0" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowRadiusUnit="MM" shadowBlendMode="6"/>
         <substitutions/>
       </text-style>
-      <text-format addDirectionSymbol="0" decimals="3" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" reverseDirectionSymbol="0" plussign="0" wrapChar="" autoWrapLength="0" multilineAlign="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" formatNumbers="0"/>
-      <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" maxCurvedCharAngleOut="-20" placementFlags="10" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" dist="0" centroidInside="0" priority="5" rotationAngle="0" repeatDistanceUnits="MM" yOffset="0" offsetUnits="MapUnit" fitInPolygonOnly="0" maxCurvedCharAngleIn="20" xOffset="0" offsetType="0" repeatDistance="0" placement="2" centroidWhole="0" quadOffset="4" preserveRotation="1" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR"/>
-      <rendering zIndex="0" mergeLines="0" fontMaxPixelSize="10000" obstacle="1" displayAll="0" scaleMax="10000000" maxNumLabels="2000" scaleVisibility="0" limitNumLabels="0" obstacleType="0" fontMinPixelSize="3" minFeatureSize="0" fontLimitPixelSize="0" scaleMin="1" upsidedownLabels="0" drawLabels="1" labelPerPart="0" obstacleFactor="1"/>
+      <text-format placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" formatNumbers="0" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" multilineAlign="0" reverseDirectionSymbol="0" wrapChar="" addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0"/>
+      <placement distUnits="MM" yOffset="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="2" maxCurvedCharAngleOut="-20" quadOffset="4" centroidInside="0" repeatDistanceUnits="MM" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" repeatDistance="0" dist="0" offsetType="0" offsetUnits="MapUnit" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" priority="5" xOffset="0" rotationAngle="0" distMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" maxCurvedCharAngleIn="20" preserveRotation="1" centroidWhole="0"/>
+      <rendering upsidedownLabels="0" obstacle="1" fontMinPixelSize="3" minFeatureSize="0" fontMaxPixelSize="10000" obstacleType="0" obstacleFactor="1" maxNumLabels="2000" labelPerPart="0" fontLimitPixelSize="0" mergeLines="0" zIndex="0" scaleMax="10000000" displayAll="0" scaleMin="1" scaleVisibility="0" limitNumLabels="0" drawLabels="1"/>
       <dd_properties>
         <Option type="Map">
           <Option value="" type="QString" name="name"/>
@@ -207,13 +207,13 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
-      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory scaleBasedVisibility="0" height="15" lineSizeType="MM" rotationOffset="270" width="15" minimumSize="0" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" penWidth="0" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" barWidth="5" enabled="0" diagramOrientation="Up" backgroundColor="#ffffff" penAlpha="255" sizeType="MM" penColor="#000000" opacity="1" labelPlacementMethod="XHeight" minScaleDenominator="0" maxScaleDenominator="1e+08">
+      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute field="" color="#000000" label=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
+  <DiagramLayerSettings dist="0" placement="2" priority="0" obstacle="0" zIndex="0" showAll="1" linePlacementFlags="2">
     <properties>
       <Option type="Map">
         <Option value="" type="QString" name="name"/>
@@ -222,7 +222,7 @@
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -574,141 +574,141 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="ROWID" index="0"/>
-    <alias name="id" field="pipe_id" index="1"/>
-    <alias name="display_name" field="pipe_display_name" index="2"/>
-    <alias name="code" field="pipe_code" index="3"/>
-    <alias name="profile_num" field="pipe_profile_num" index="4"/>
-    <alias name="sewerage_type" field="pipe_sewerage_type" index="5"/>
-    <alias name="calculation_type" field="pipe_calculation_type" index="6"/>
-    <alias name="invert_level_start_point" field="pipe_invert_level_start_point" index="7"/>
-    <alias name="invert_level_end_point" field="pipe_invert_level_end_point" index="8"/>
-    <alias name="cross_section_definition_id" field="pipe_cross_section_definition_id" index="9"/>
-    <alias name="friction_value" field="pipe_friction_value" index="10"/>
-    <alias name="friction_type" field="pipe_friction_type" index="11"/>
-    <alias name="dist_calc_points" field="pipe_dist_calc_points" index="12"/>
-    <alias name="material" field="pipe_material" index="13"/>
-    <alias name="pipe_quality" field="pipe_pipe_quality" index="14"/>
-    <alias name="original_length" field="pipe_original_length" index="15"/>
-    <alias name="zoom_category" field="pipe_zoom_category" index="16"/>
-    <alias name="connection_node_start_id" field="pipe_connection_node_start_id" index="17"/>
-    <alias name="connection_node_end_id" field="pipe_connection_node_end_id" index="18"/>
-    <alias name="id" field="def_id" index="19"/>
-    <alias name="shape" field="def_shape" index="20"/>
-    <alias name="width" field="def_width" index="21"/>
-    <alias name="height" field="def_height" index="22"/>
-    <alias name="code" field="def_code" index="23"/>
+    <alias field="ROWID" index="0" name=""/>
+    <alias field="pipe_id" index="1" name="id"/>
+    <alias field="pipe_display_name" index="2" name="display_name"/>
+    <alias field="pipe_code" index="3" name="code"/>
+    <alias field="pipe_profile_num" index="4" name="profile_num"/>
+    <alias field="pipe_sewerage_type" index="5" name="sewerage_type"/>
+    <alias field="pipe_calculation_type" index="6" name="calculation_type"/>
+    <alias field="pipe_invert_level_start_point" index="7" name="invert_level_start_point"/>
+    <alias field="pipe_invert_level_end_point" index="8" name="invert_level_end_point"/>
+    <alias field="pipe_cross_section_definition_id" index="9" name="cross_section_definition_id"/>
+    <alias field="pipe_friction_value" index="10" name="friction_value"/>
+    <alias field="pipe_friction_type" index="11" name="friction_type"/>
+    <alias field="pipe_dist_calc_points" index="12" name="dist_calc_points"/>
+    <alias field="pipe_material" index="13" name="material"/>
+    <alias field="pipe_pipe_quality" index="14" name="pipe_quality"/>
+    <alias field="pipe_original_length" index="15" name="original_length"/>
+    <alias field="pipe_zoom_category" index="16" name="zoom_category"/>
+    <alias field="pipe_connection_node_start_id" index="17" name="connection_node_start_id"/>
+    <alias field="pipe_connection_node_end_id" index="18" name="connection_node_end_id"/>
+    <alias field="def_id" index="19" name="id"/>
+    <alias field="def_shape" index="20" name="shape"/>
+    <alias field="def_width" index="21" name="width"/>
+    <alias field="def_height" index="22" name="height"/>
+    <alias field="def_code" index="23" name="code"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="if(maximum(pipe_id) is null,1, maximum(pipe_id)+1)" applyOnUpdate="0" field="pipe_id"/>
-    <default expression="'new'" applyOnUpdate="0" field="pipe_display_name"/>
-    <default expression="'new'" applyOnUpdate="0" field="pipe_code"/>
-    <default expression="" applyOnUpdate="0" field="pipe_profile_num"/>
-    <default expression="0" applyOnUpdate="0" field="pipe_sewerage_type"/>
-    <default expression="1" applyOnUpdate="0" field="pipe_calculation_type"/>
-    <default expression="" applyOnUpdate="0" field="pipe_invert_level_start_point"/>
-    <default expression="" applyOnUpdate="0" field="pipe_invert_level_end_point"/>
-    <default expression="" applyOnUpdate="0" field="pipe_cross_section_definition_id"/>
-    <default expression="" applyOnUpdate="0" field="pipe_friction_value"/>
-    <default expression="2" applyOnUpdate="0" field="pipe_friction_type"/>
-    <default expression="10000" applyOnUpdate="0" field="pipe_dist_calc_points"/>
-    <default expression="" applyOnUpdate="0" field="pipe_material"/>
-    <default expression="" applyOnUpdate="0" field="pipe_pipe_quality"/>
-    <default expression="" applyOnUpdate="0" field="pipe_original_length"/>
-    <default expression="2" applyOnUpdate="0" field="pipe_zoom_category"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="pipe_connection_node_start_id"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="pipe_connection_node_end_id"/>
-    <default expression="" applyOnUpdate="0" field="def_id"/>
-    <default expression="" applyOnUpdate="0" field="def_shape"/>
-    <default expression="" applyOnUpdate="0" field="def_width"/>
-    <default expression="" applyOnUpdate="0" field="def_height"/>
-    <default expression="" applyOnUpdate="0" field="def_code"/>
+    <default field="ROWID" applyOnUpdate="0" expression=""/>
+    <default field="pipe_id" applyOnUpdate="0" expression="if(maximum(pipe_id) is null,1, maximum(pipe_id)+1)"/>
+    <default field="pipe_display_name" applyOnUpdate="0" expression="'new'"/>
+    <default field="pipe_code" applyOnUpdate="0" expression="'new'"/>
+    <default field="pipe_profile_num" applyOnUpdate="0" expression=""/>
+    <default field="pipe_sewerage_type" applyOnUpdate="0" expression=""/>
+    <default field="pipe_calculation_type" applyOnUpdate="0" expression="1"/>
+    <default field="pipe_invert_level_start_point" applyOnUpdate="0" expression=""/>
+    <default field="pipe_invert_level_end_point" applyOnUpdate="0" expression=""/>
+    <default field="pipe_cross_section_definition_id" applyOnUpdate="0" expression=""/>
+    <default field="pipe_friction_value" applyOnUpdate="0" expression=""/>
+    <default field="pipe_friction_type" applyOnUpdate="0" expression="2"/>
+    <default field="pipe_dist_calc_points" applyOnUpdate="0" expression="10000"/>
+    <default field="pipe_material" applyOnUpdate="0" expression=""/>
+    <default field="pipe_pipe_quality" applyOnUpdate="0" expression=""/>
+    <default field="pipe_original_length" applyOnUpdate="0" expression=""/>
+    <default field="pipe_zoom_category" applyOnUpdate="0" expression="2"/>
+    <default field="pipe_connection_node_start_id" applyOnUpdate="0" expression="'filled automatically'"/>
+    <default field="pipe_connection_node_end_id" applyOnUpdate="0" expression="'filled automatically'"/>
+    <default field="def_id" applyOnUpdate="0" expression=""/>
+    <default field="def_shape" applyOnUpdate="0" expression=""/>
+    <default field="def_width" applyOnUpdate="0" expression=""/>
+    <default field="def_height" applyOnUpdate="0" expression=""/>
+    <default field="def_code" applyOnUpdate="0" expression=""/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_profile_num"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_sewerage_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_calculation_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_invert_level_start_point"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="pipe_invert_level_end_point"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_cross_section_definition_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_friction_value"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_friction_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_dist_calc_points"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_material"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_pipe_quality"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_original_length"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pipe_zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_connection_node_start_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pipe_connection_node_end_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
+    <constraint notnull_strength="0" constraints="0" field="ROWID" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_display_name" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_code" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_profile_num" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_sewerage_type" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_calculation_type" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_invert_level_start_point" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="5" field="pipe_invert_level_end_point" unique_strength="0" exp_strength="2"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_cross_section_definition_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_friction_value" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_friction_type" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_dist_calc_points" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_material" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_pipe_quality" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_original_length" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="pipe_zoom_category" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_connection_node_start_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="pipe_connection_node_end_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" field="def_id" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="def_shape" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="def_width" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="def_height" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="def_code" unique_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="pipe_id"/>
-    <constraint exp="" desc="" field="pipe_display_name"/>
-    <constraint exp="" desc="" field="pipe_code"/>
-    <constraint exp="" desc="" field="pipe_profile_num"/>
-    <constraint exp="" desc="" field="pipe_sewerage_type"/>
-    <constraint exp="" desc="" field="pipe_calculation_type"/>
-    <constraint exp="" desc="" field="pipe_invert_level_start_point"/>
-    <constraint exp="&quot;invert_level_end_point&quot; is not null" desc="" field="pipe_invert_level_end_point"/>
-    <constraint exp="" desc="" field="pipe_cross_section_definition_id"/>
-    <constraint exp="" desc="" field="pipe_friction_value"/>
-    <constraint exp="" desc="" field="pipe_friction_type"/>
-    <constraint exp="" desc="" field="pipe_dist_calc_points"/>
-    <constraint exp="" desc="" field="pipe_material"/>
-    <constraint exp="" desc="" field="pipe_pipe_quality"/>
-    <constraint exp="" desc="" field="pipe_original_length"/>
-    <constraint exp="" desc="" field="pipe_zoom_category"/>
-    <constraint exp="" desc="" field="pipe_connection_node_start_id"/>
-    <constraint exp="" desc="" field="pipe_connection_node_end_id"/>
-    <constraint exp="" desc="" field="def_id"/>
-    <constraint exp="" desc="" field="def_shape"/>
-    <constraint exp="" desc="" field="def_width"/>
-    <constraint exp="" desc="" field="def_height"/>
-    <constraint exp="" desc="" field="def_code"/>
+    <constraint field="ROWID" desc="" exp=""/>
+    <constraint field="pipe_id" desc="" exp=""/>
+    <constraint field="pipe_display_name" desc="" exp=""/>
+    <constraint field="pipe_code" desc="" exp=""/>
+    <constraint field="pipe_profile_num" desc="" exp=""/>
+    <constraint field="pipe_sewerage_type" desc="" exp=""/>
+    <constraint field="pipe_calculation_type" desc="" exp=""/>
+    <constraint field="pipe_invert_level_start_point" desc="" exp=""/>
+    <constraint field="pipe_invert_level_end_point" desc="" exp="&quot;invert_level_end_point&quot; is not null"/>
+    <constraint field="pipe_cross_section_definition_id" desc="" exp=""/>
+    <constraint field="pipe_friction_value" desc="" exp=""/>
+    <constraint field="pipe_friction_type" desc="" exp=""/>
+    <constraint field="pipe_dist_calc_points" desc="" exp=""/>
+    <constraint field="pipe_material" desc="" exp=""/>
+    <constraint field="pipe_pipe_quality" desc="" exp=""/>
+    <constraint field="pipe_original_length" desc="" exp=""/>
+    <constraint field="pipe_zoom_category" desc="" exp=""/>
+    <constraint field="pipe_connection_node_start_id" desc="" exp=""/>
+    <constraint field="pipe_connection_node_end_id" desc="" exp=""/>
+    <constraint field="def_id" desc="" exp=""/>
+    <constraint field="def_shape" desc="" exp=""/>
+    <constraint field="def_width" desc="" exp=""/>
+    <constraint field="def_height" desc="" exp=""/>
+    <constraint field="def_code" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="ROWID"/>
-      <column width="-1" type="field" hidden="0" name="pipe_id"/>
-      <column width="-1" type="field" hidden="0" name="pipe_display_name"/>
-      <column width="-1" type="field" hidden="0" name="pipe_code"/>
-      <column width="-1" type="field" hidden="0" name="pipe_profile_num"/>
-      <column width="-1" type="field" hidden="0" name="pipe_sewerage_type"/>
-      <column width="-1" type="field" hidden="0" name="pipe_calculation_type"/>
-      <column width="-1" type="field" hidden="0" name="pipe_invert_level_start_point"/>
-      <column width="-1" type="field" hidden="0" name="pipe_invert_level_end_point"/>
-      <column width="-1" type="field" hidden="0" name="pipe_cross_section_definition_id"/>
-      <column width="-1" type="field" hidden="0" name="pipe_friction_value"/>
-      <column width="-1" type="field" hidden="0" name="pipe_friction_type"/>
-      <column width="-1" type="field" hidden="0" name="pipe_dist_calc_points"/>
-      <column width="-1" type="field" hidden="0" name="pipe_material"/>
-      <column width="-1" type="field" hidden="0" name="pipe_pipe_quality"/>
-      <column width="-1" type="field" hidden="0" name="pipe_original_length"/>
-      <column width="-1" type="field" hidden="0" name="pipe_zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="pipe_connection_node_start_id"/>
-      <column width="-1" type="field" hidden="0" name="pipe_connection_node_end_id"/>
-      <column width="-1" type="field" hidden="0" name="def_id"/>
-      <column width="-1" type="field" hidden="0" name="def_shape"/>
-      <column width="-1" type="field" hidden="0" name="def_width"/>
-      <column width="-1" type="field" hidden="0" name="def_height"/>
-      <column width="-1" type="field" hidden="0" name="def_code"/>
+      <column width="-1" type="field" name="ROWID" hidden="0"/>
+      <column width="-1" type="field" name="pipe_id" hidden="0"/>
+      <column width="-1" type="field" name="pipe_display_name" hidden="0"/>
+      <column width="-1" type="field" name="pipe_code" hidden="0"/>
+      <column width="-1" type="field" name="pipe_profile_num" hidden="0"/>
+      <column width="-1" type="field" name="pipe_sewerage_type" hidden="0"/>
+      <column width="-1" type="field" name="pipe_calculation_type" hidden="0"/>
+      <column width="-1" type="field" name="pipe_invert_level_start_point" hidden="0"/>
+      <column width="-1" type="field" name="pipe_invert_level_end_point" hidden="0"/>
+      <column width="-1" type="field" name="pipe_cross_section_definition_id" hidden="0"/>
+      <column width="-1" type="field" name="pipe_friction_value" hidden="0"/>
+      <column width="-1" type="field" name="pipe_friction_type" hidden="0"/>
+      <column width="-1" type="field" name="pipe_dist_calc_points" hidden="0"/>
+      <column width="-1" type="field" name="pipe_material" hidden="0"/>
+      <column width="-1" type="field" name="pipe_pipe_quality" hidden="0"/>
+      <column width="-1" type="field" name="pipe_original_length" hidden="0"/>
+      <column width="-1" type="field" name="pipe_zoom_category" hidden="0"/>
+      <column width="-1" type="field" name="pipe_connection_node_start_id" hidden="0"/>
+      <column width="-1" type="field" name="pipe_connection_node_end_id" hidden="0"/>
+      <column width="-1" type="field" name="def_id" hidden="0"/>
+      <column width="-1" type="field" name="def_shape" hidden="0"/>
+      <column width="-1" type="field" name="def_width" hidden="0"/>
+      <column width="-1" type="field" name="def_height" hidden="0"/>
+      <column width="-1" type="field" name="def_code" hidden="0"/>
       <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
@@ -738,63 +738,63 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Pipe view" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-        <attributeEditorField showLabel="1" name="pipe_id" index="1"/>
-        <attributeEditorField showLabel="1" name="pipe_display_name" index="2"/>
-        <attributeEditorField showLabel="1" name="pipe_code" index="3"/>
-        <attributeEditorField showLabel="1" name="pipe_calculation_type" index="6"/>
-        <attributeEditorField showLabel="1" name="pipe_dist_calc_points" index="12"/>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" columnCount="1" name="Pipe view">
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="General">
+        <attributeEditorField showLabel="1" index="1" name="pipe_id"/>
+        <attributeEditorField showLabel="1" index="2" name="pipe_display_name"/>
+        <attributeEditorField showLabel="1" index="3" name="pipe_code"/>
+        <attributeEditorField showLabel="1" index="6" name="pipe_calculation_type"/>
+        <attributeEditorField showLabel="1" index="12" name="pipe_dist_calc_points"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
-        <attributeEditorField showLabel="1" name="pipe_invert_level_start_point" index="7"/>
-        <attributeEditorField showLabel="1" name="pipe_invert_level_end_point" index="8"/>
-        <attributeEditorField showLabel="1" name="pipe_friction_value" index="10"/>
-        <attributeEditorField showLabel="1" name="pipe_friction_type" index="11"/>
-        <attributeEditorField showLabel="1" name="pipe_material" index="13"/>
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Characteristics">
+        <attributeEditorField showLabel="1" index="7" name="pipe_invert_level_start_point"/>
+        <attributeEditorField showLabel="1" index="8" name="pipe_invert_level_end_point"/>
+        <attributeEditorField showLabel="1" index="10" name="pipe_friction_value"/>
+        <attributeEditorField showLabel="1" index="11" name="pipe_friction_type"/>
+        <attributeEditorField showLabel="1" index="13" name="pipe_material"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section definition" columnCount="1">
-        <attributeEditorField showLabel="1" name="pipe_cross_section_definition_id" index="9"/>
-        <attributeEditorField showLabel="1" name="def_shape" index="20"/>
-        <attributeEditorField showLabel="1" name="def_width" index="21"/>
-        <attributeEditorField showLabel="1" name="def_height" index="22"/>
-        <attributeEditorField showLabel="1" name="def_code" index="23"/>
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Cross section definition">
+        <attributeEditorField showLabel="1" index="9" name="pipe_cross_section_definition_id"/>
+        <attributeEditorField showLabel="1" index="20" name="def_shape"/>
+        <attributeEditorField showLabel="1" index="21" name="def_width"/>
+        <attributeEditorField showLabel="1" index="22" name="def_height"/>
+        <attributeEditorField showLabel="1" index="23" name="def_code"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
-        <attributeEditorField showLabel="1" name="pipe_sewerage_type" index="5"/>
-        <attributeEditorField showLabel="1" name="pipe_zoom_category" index="16"/>
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Visualization">
+        <attributeEditorField showLabel="1" index="5" name="pipe_sewerage_type"/>
+        <attributeEditorField showLabel="1" index="16" name="pipe_zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
-        <attributeEditorField showLabel="1" name="pipe_connection_node_start_id" index="17"/>
-        <attributeEditorField showLabel="1" name="pipe_connection_node_end_id" index="18"/>
+      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Connection nodes">
+        <attributeEditorField showLabel="1" index="17" name="pipe_connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="18" name="pipe_connection_node_end_id"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="ROWID" editable="1"/>
-    <field name="def_code" editable="0"/>
-    <field name="def_height" editable="0"/>
-    <field name="def_id" editable="1"/>
-    <field name="def_shape" editable="0"/>
-    <field name="def_width" editable="0"/>
-    <field name="pipe_calculation_type" editable="1"/>
-    <field name="pipe_code" editable="1"/>
-    <field name="pipe_connection_node_end_id" editable="0"/>
-    <field name="pipe_connection_node_start_id" editable="0"/>
-    <field name="pipe_cross_section_definition_id" editable="1"/>
-    <field name="pipe_display_name" editable="1"/>
-    <field name="pipe_dist_calc_points" editable="1"/>
-    <field name="pipe_friction_type" editable="1"/>
-    <field name="pipe_friction_value" editable="1"/>
-    <field name="pipe_id" editable="1"/>
-    <field name="pipe_invert_level_end_point" editable="1"/>
-    <field name="pipe_invert_level_start_point" editable="1"/>
-    <field name="pipe_material" editable="1"/>
-    <field name="pipe_original_length" editable="1"/>
-    <field name="pipe_pipe_quality" editable="1"/>
-    <field name="pipe_profile_num" editable="1"/>
-    <field name="pipe_sewerage_type" editable="1"/>
-    <field name="pipe_zoom_category" editable="1"/>
+    <field editable="1" name="ROWID"/>
+    <field editable="0" name="def_code"/>
+    <field editable="0" name="def_height"/>
+    <field editable="1" name="def_id"/>
+    <field editable="0" name="def_shape"/>
+    <field editable="0" name="def_width"/>
+    <field editable="1" name="pipe_calculation_type"/>
+    <field editable="1" name="pipe_code"/>
+    <field editable="0" name="pipe_connection_node_end_id"/>
+    <field editable="0" name="pipe_connection_node_start_id"/>
+    <field editable="1" name="pipe_cross_section_definition_id"/>
+    <field editable="1" name="pipe_display_name"/>
+    <field editable="1" name="pipe_dist_calc_points"/>
+    <field editable="1" name="pipe_friction_type"/>
+    <field editable="1" name="pipe_friction_value"/>
+    <field editable="1" name="pipe_id"/>
+    <field editable="1" name="pipe_invert_level_end_point"/>
+    <field editable="1" name="pipe_invert_level_start_point"/>
+    <field editable="1" name="pipe_material"/>
+    <field editable="1" name="pipe_original_length"/>
+    <field editable="1" name="pipe_pipe_quality"/>
+    <field editable="1" name="pipe_profile_num"/>
+    <field editable="1" name="pipe_sewerage_type"/>
+    <field editable="1" name="pipe_zoom_category"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="ROWID"/>

--- a/layer_styles/schematisation/v2_pipe_view.qml
+++ b/layer_styles/schematisation/v2_pipe_view.qml
@@ -1,178 +1,178 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyMaxScale="1" readOnly="0" labelsEnabled="1" simplifyAlgorithm="0" maxScale="0" version="3.4.5-Madeira" simplifyDrawingHints="1" styleCategories="AllStyleCategories" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" minScale="1e+08">
+<qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="1" simplifyLocal="1" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" simplifyAlgorithm="0" readOnly="0" minScale="1e+08" version="3.4.5-Madeira" maxScale="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 symbollevels="0" enableorderby="0" type="RuleRenderer" forceraster="0">
+  <renderer-v2 forceraster="0" enableorderby="0" symbollevels="0" type="RuleRenderer">
     <rules key="{1c4a4e03-d442-4bb0-8ffc-82b9a703e08f}">
-      <rule symbol="0" filter="pipe_sewerage_type = 0" key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}" label="Gemengd"/>
-      <rule symbol="1" filter="pipe_sewerage_type = 1" key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}" label="RWA"/>
-      <rule symbol="2" filter="pipe_sewerage_type = 2" key="{c8833167-878e-49b2-bd37-5019aeea2451}" label="DWA"/>
-      <rule symbol="3" filter="pipe_sewerage_type = 3" key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}" label="Transport"/>
-      <rule symbol="4" filter="pipe_sewerage_type = 7" key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}" label="Bergbezinkvoorziening"/>
-      <rule symbol="5" filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10" key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}" label="Overig"/>
+      <rule label="Gemengd" key="{844e5e28-ad8f-43dc-ae9b-2eedeecde873}" filter="pipe_sewerage_type = 0" symbol="0"/>
+      <rule label="RWA" key="{3b41f70d-2dfe-4438-8b1a-3722a52ff82b}" filter="pipe_sewerage_type = 1" symbol="1"/>
+      <rule label="DWA" key="{c8833167-878e-49b2-bd37-5019aeea2451}" filter="pipe_sewerage_type = 2" symbol="2"/>
+      <rule label="Transport" key="{d62bccfa-4138-43ba-ab6d-51eae9f5b079}" filter="pipe_sewerage_type = 3" symbol="3"/>
+      <rule label="Bergbezinkvoorziening" key="{8eb66a66-0335-4672-a78d-1aac6c4702ff}" filter="pipe_sewerage_type = 7" symbol="4"/>
+      <rule label="Overig" key="{aa320dac-96a8-41e4-af30-3e9153ceaeae}" filter="pipe_sewerage_type = 4 OR pipe_sewerage_type = 5 OR pipe_sewerage_type = 6 OR pipe_sewerage_type > 10" symbol="5"/>
     </rules>
     <symbols>
-      <symbol force_rhr="0" type="line" clip_to_extent="1" name="0" alpha="1">
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="255,170,0,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.4" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="0" alpha="1" type="line" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="255,170,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.4"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" type="line" clip_to_extent="1" name="1" alpha="1">
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="85,170,255,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.4" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="1" alpha="1" type="line" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="85,170,255,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.4"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" type="line" clip_to_extent="1" name="2" alpha="1">
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="255,0,0,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.4" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="2" alpha="1" type="line" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="255,0,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.4"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" type="line" clip_to_extent="1" name="3" alpha="1">
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="153,153,153,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.7" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="3" alpha="1" type="line" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="153,153,153,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.7"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" type="line" clip_to_extent="1" name="4" alpha="1">
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="92,92,92,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="2" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="4" alpha="1" type="line" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="92,92,92,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="2"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" type="line" clip_to_extent="1" name="5" alpha="1">
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="0" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="211,211,211,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.4" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol name="5" alpha="1" type="line" clip_to_extent="1" force_rhr="0">
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="211,211,211,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.4"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -181,26 +181,27 @@
   </renderer-v2>
   <labeling type="simple">
     <settings>
-      <text-style fontFamily="MS Shell Dlg 2" textOpacity="1" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" blendMode="0" fontStrikeout="0" previewBkgrdColor="#ffffff" isExpression="1" fontItalic="0" useSubstitutions="0" fontUnderline="0" fontCapitals="0" fontSizeUnit="Point" fieldName="" fontLetterSpacing="0" fontSize="8.25" fontWordSpacing="0" textColor="0,0,0,255" namedStyle="Regular">
-        <text-buffer bufferSize="1" bufferSizeUnits="MM" bufferOpacity="1" bufferDraw="0" bufferColor="255,255,255,255" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferNoFill="0"/>
-        <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeSizeUnit="MM" shapeBorderWidth="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotation="0" shapeSVGFile="" shapeSizeType="0" shapeRadiiY="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeOpacity="1" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeJoinStyle="64" shapeOffsetY="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeDraw="0" shapeRadiiX="0" shapeRadiiUnit="MM" shapeBorderWidthUnit="MM" shapeFillColor="255,255,255,255"/>
-        <shadow shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowScale="100" shadowColor="0,0,0,255" shadowUnder="0" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowRadiusUnit="MM" shadowBlendMode="6"/>
+      <text-style fontLetterSpacing="0" fontStrikeout="0" textColor="0,0,0,255" namedStyle="Regular" fontFamily="MS Shell Dlg 2" isExpression="1" fontItalic="0" fontSizeUnit="Point" multilineHeight="1" useSubstitutions="0" fontCapitals="0" fieldName="" fontUnderline="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSize="8.25" fontWordSpacing="0" previewBkgrdColor="#ffffff" textOpacity="1" fontWeight="50">
+        <text-buffer bufferBlendMode="0" bufferOpacity="1" bufferColor="255,255,255,255" bufferNoFill="0" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferDraw="0" bufferJoinStyle="64"/>
+        <background shapeDraw="0" shapeOpacity="1" shapeRadiiX="0" shapeRotationType="0" shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBorderWidth="0" shapeSizeY="0" shapeOffsetY="0" shapeFillColor="255,255,255,255" shapeRadiiUnit="MM" shapeSVGFile="" shapeJoinStyle="64" shapeOffsetUnit="MM" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeSizeUnit="MM" shapeOffsetX="0" shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0"/>
+        <shadow shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowColor="0,0,0,255" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowRadiusAlphaOnly="0" shadowOpacity="0.7" shadowBlendMode="6"/>
         <substitutions/>
       </text-style>
-      <text-format placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" formatNumbers="0" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" multilineAlign="0" reverseDirectionSymbol="0" wrapChar="" addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0"/>
-      <placement distUnits="MM" yOffset="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="2" maxCurvedCharAngleOut="-20" quadOffset="4" centroidInside="0" repeatDistanceUnits="MM" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" repeatDistance="0" dist="0" offsetType="0" offsetUnits="MapUnit" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" priority="5" xOffset="0" rotationAngle="0" distMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" maxCurvedCharAngleIn="20" preserveRotation="1" centroidWhole="0"/>
-      <rendering upsidedownLabels="0" obstacle="1" fontMinPixelSize="3" minFeatureSize="0" fontMaxPixelSize="10000" obstacleType="0" obstacleFactor="1" maxNumLabels="2000" labelPerPart="0" fontLimitPixelSize="0" mergeLines="0" zIndex="0" scaleMax="10000000" displayAll="0" scaleMin="1" scaleVisibility="0" limitNumLabels="0" drawLabels="1"/>
+      <text-format reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" formatNumbers="0" addDirectionSymbol="0" decimals="3" plussign="0" wrapChar="" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1"/>
+      <placement repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" fitInPolygonOnly="0" offsetUnits="MapUnit" centroidInside="0" yOffset="0" repeatDistance="0" repeatDistanceUnits="MM" placement="2" xOffset="0" quadOffset="4" maxCurvedCharAngleIn="20" maxCurvedCharAngleOut="-20" offsetType="0" distMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" dist="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" centroidWhole="0" placementFlags="10" distUnits="MM" rotationAngle="0" priority="5"/>
+      <rendering fontLimitPixelSize="0" limitNumLabels="0" fontMinPixelSize="3" minFeatureSize="0" scaleMax="10000000" mergeLines="0" obstacleFactor="1" displayAll="0" labelPerPart="0" maxNumLabels="2000" zIndex="0" upsidedownLabels="0" fontMaxPixelSize="10000" scaleMin="1" obstacle="1" scaleVisibility="0" drawLabels="1" obstacleType="0"/>
       <dd_properties>
         <Option type="Map">
-          <Option value="" type="QString" name="name"/>
+          <Option name="name" type="QString" value=""/>
           <Option name="properties"/>
-          <Option value="collection" type="QString" name="type"/>
+          <Option name="type" type="QString" value="collection"/>
         </Option>
       </dd_properties>
     </settings>
   </labeling>
   <customproperties>
-    <property value="0" key="embeddedWidgets/count"/>
+    <property key="dualview/previewExpressions" value="ROWID"/>
+    <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
@@ -208,21 +209,21 @@
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
   <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory scaleBasedVisibility="0" height="15" lineSizeType="MM" rotationOffset="270" width="15" minimumSize="0" sizeScale="3x:0,0,0,0,0,0" backgroundAlpha="255" penWidth="0" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" barWidth="5" enabled="0" diagramOrientation="Up" backgroundColor="#ffffff" penAlpha="255" sizeType="MM" penColor="#000000" opacity="1" labelPlacementMethod="XHeight" minScaleDenominator="0" maxScaleDenominator="1e+08">
+    <DiagramCategory backgroundAlpha="255" height="15" minScaleDenominator="0" opacity="1" penColor="#000000" lineSizeType="MM" penAlpha="255" labelPlacementMethod="XHeight" diagramOrientation="Up" rotationOffset="270" maxScaleDenominator="1e+08" scaleDependency="Area" width="15" barWidth="5" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" sizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" penWidth="0" minimumSize="0" enabled="0">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute field="" color="#000000" label=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" placement="2" priority="0" obstacle="0" zIndex="0" showAll="1" linePlacementFlags="2">
+  <DiagramLayerSettings linePlacementFlags="2" showAll="1" zIndex="0" placement="2" obstacle="0" dist="0" priority="0">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option name="type" type="QString" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -238,8 +239,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -248,8 +249,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -258,8 +259,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -268,8 +269,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -278,30 +279,30 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="0" type="QString" name="0: mixed"/>
+                <Option name="0: mixed" type="QString" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1: rain water"/>
+                <Option name="1: rain water" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: dry weather flow"/>
+                <Option name="2: dry weather flow" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: transport"/>
+                <Option name="3: transport" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4: spillway"/>
+                <Option name="4: spillway" type="QString" value="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: sinker"/>
+                <Option name="5: sinker" type="QString" value="5"/>
               </Option>
               <Option type="Map">
-                <Option value="6" type="QString" name="6: storage"/>
+                <Option name="6: storage" type="QString" value="6"/>
               </Option>
               <Option type="Map">
-                <Option value="7" type="QString" name="7: storage tank"/>
+                <Option name="7: storage tank" type="QString" value="7"/>
               </Option>
             </Option>
           </Option>
@@ -312,21 +313,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="0" type="QString" name="0: embedded"/>
+                <Option name="0: embedded" type="QString" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1: isolated"/>
+                <Option name="1: isolated" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: connected"/>
+                <Option name="2: connected" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: broad crest"/>
+                <Option name="3: broad crest" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4: short crest"/>
+                <Option name="4: short crest" type="QString" value="4"/>
               </Option>
             </Option>
           </Option>
@@ -337,8 +338,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -347,8 +348,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -357,8 +358,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -367,8 +368,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -377,12 +378,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Chèzy"/>
+                <Option name="1: Chèzy" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Manning"/>
+                <Option name="2: Manning" type="QString" value="2"/>
               </Option>
             </Option>
           </Option>
@@ -393,8 +394,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -403,33 +404,33 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="0" type="QString" name="0: concrete"/>
+                <Option name="0: concrete" type="QString" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1: pvc"/>
+                <Option name="1: pvc" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: gres"/>
+                <Option name="2: gres" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: cast iron"/>
+                <Option name="3: cast iron" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4: brickwork"/>
+                <Option name="4: brickwork" type="QString" value="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: HPE"/>
+                <Option name="5: HPE" type="QString" value="5"/>
               </Option>
               <Option type="Map">
-                <Option value="6" type="QString" name="6: HDPE"/>
+                <Option name="6: HDPE" type="QString" value="6"/>
               </Option>
               <Option type="Map">
-                <Option value="7" type="QString" name="7: plate iron"/>
+                <Option name="7: plate iron" type="QString" value="7"/>
               </Option>
               <Option type="Map">
-                <Option value="8" type="QString" name="8: steel"/>
+                <Option name="8: steel" type="QString" value="8"/>
               </Option>
             </Option>
           </Option>
@@ -440,8 +441,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -450,8 +451,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -460,27 +461,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="-1" type="QString" name="-1"/>
+                <Option name="-1" type="QString" value="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" type="QString" name="0"/>
+                <Option name="0" type="QString" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1"/>
+                <Option name="1" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2"/>
+                <Option name="2" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3"/>
+                <Option name="3" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4"/>
+                <Option name="4" type="QString" value="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5"/>
+                <Option name="5" type="QString" value="5"/>
               </Option>
             </Option>
           </Option>
@@ -491,8 +492,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -501,8 +502,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -511,8 +512,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -521,21 +522,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: rectangle"/>
+                <Option name="1: rectangle" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: round"/>
+                <Option name="2: round" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: egg"/>
+                <Option name="3: egg" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: tabulated rectangle"/>
+                <Option name="5: tabulated rectangle" type="QString" value="5"/>
               </Option>
               <Option type="Map">
-                <Option value="6" type="QString" name="6: tabulated trapezium"/>
+                <Option name="6: tabulated trapezium" type="QString" value="6"/>
               </Option>
             </Option>
           </Option>
@@ -546,8 +547,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -556,8 +557,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -566,150 +567,150 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="ROWID" index="0" name=""/>
-    <alias field="pipe_id" index="1" name="id"/>
-    <alias field="pipe_display_name" index="2" name="display_name"/>
-    <alias field="pipe_code" index="3" name="code"/>
-    <alias field="pipe_profile_num" index="4" name="profile_num"/>
-    <alias field="pipe_sewerage_type" index="5" name="sewerage_type"/>
-    <alias field="pipe_calculation_type" index="6" name="calculation_type"/>
-    <alias field="pipe_invert_level_start_point" index="7" name="invert_level_start_point"/>
-    <alias field="pipe_invert_level_end_point" index="8" name="invert_level_end_point"/>
-    <alias field="pipe_cross_section_definition_id" index="9" name="cross_section_definition_id"/>
-    <alias field="pipe_friction_value" index="10" name="friction_value"/>
-    <alias field="pipe_friction_type" index="11" name="friction_type"/>
-    <alias field="pipe_dist_calc_points" index="12" name="dist_calc_points"/>
-    <alias field="pipe_material" index="13" name="material"/>
-    <alias field="pipe_pipe_quality" index="14" name="pipe_quality"/>
-    <alias field="pipe_original_length" index="15" name="original_length"/>
-    <alias field="pipe_zoom_category" index="16" name="zoom_category"/>
-    <alias field="pipe_connection_node_start_id" index="17" name="connection_node_start_id"/>
-    <alias field="pipe_connection_node_end_id" index="18" name="connection_node_end_id"/>
-    <alias field="def_id" index="19" name="id"/>
-    <alias field="def_shape" index="20" name="shape"/>
-    <alias field="def_width" index="21" name="width"/>
-    <alias field="def_height" index="22" name="height"/>
-    <alias field="def_code" index="23" name="code"/>
+    <alias field="ROWID" name="" index="0"/>
+    <alias field="pipe_id" name="id" index="1"/>
+    <alias field="pipe_display_name" name="display_name" index="2"/>
+    <alias field="pipe_code" name="code" index="3"/>
+    <alias field="pipe_profile_num" name="profile_num" index="4"/>
+    <alias field="pipe_sewerage_type" name="sewerage_type" index="5"/>
+    <alias field="pipe_calculation_type" name="calculation_type" index="6"/>
+    <alias field="pipe_invert_level_start_point" name="invert_level_start_point" index="7"/>
+    <alias field="pipe_invert_level_end_point" name="invert_level_end_point" index="8"/>
+    <alias field="pipe_cross_section_definition_id" name="cross_section_definition_id" index="9"/>
+    <alias field="pipe_friction_value" name="friction_value" index="10"/>
+    <alias field="pipe_friction_type" name="friction_type" index="11"/>
+    <alias field="pipe_dist_calc_points" name="dist_calc_points" index="12"/>
+    <alias field="pipe_material" name="material" index="13"/>
+    <alias field="pipe_pipe_quality" name="pipe_quality" index="14"/>
+    <alias field="pipe_original_length" name="original_length" index="15"/>
+    <alias field="pipe_zoom_category" name="zoom_category" index="16"/>
+    <alias field="pipe_connection_node_start_id" name="connection_node_start_id" index="17"/>
+    <alias field="pipe_connection_node_end_id" name="connection_node_end_id" index="18"/>
+    <alias field="def_id" name="id" index="19"/>
+    <alias field="def_shape" name="shape" index="20"/>
+    <alias field="def_width" name="width" index="21"/>
+    <alias field="def_height" name="height" index="22"/>
+    <alias field="def_code" name="code" index="23"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="ROWID" applyOnUpdate="0" expression=""/>
-    <default field="pipe_id" applyOnUpdate="0" expression="if(maximum(pipe_id) is null,1, maximum(pipe_id)+1)"/>
-    <default field="pipe_display_name" applyOnUpdate="0" expression="'new'"/>
-    <default field="pipe_code" applyOnUpdate="0" expression="'new'"/>
-    <default field="pipe_profile_num" applyOnUpdate="0" expression=""/>
-    <default field="pipe_sewerage_type" applyOnUpdate="0" expression=""/>
-    <default field="pipe_calculation_type" applyOnUpdate="0" expression="1"/>
-    <default field="pipe_invert_level_start_point" applyOnUpdate="0" expression=""/>
-    <default field="pipe_invert_level_end_point" applyOnUpdate="0" expression=""/>
-    <default field="pipe_cross_section_definition_id" applyOnUpdate="0" expression=""/>
-    <default field="pipe_friction_value" applyOnUpdate="0" expression=""/>
-    <default field="pipe_friction_type" applyOnUpdate="0" expression="2"/>
-    <default field="pipe_dist_calc_points" applyOnUpdate="0" expression="10000"/>
-    <default field="pipe_material" applyOnUpdate="0" expression=""/>
-    <default field="pipe_pipe_quality" applyOnUpdate="0" expression=""/>
-    <default field="pipe_original_length" applyOnUpdate="0" expression=""/>
-    <default field="pipe_zoom_category" applyOnUpdate="0" expression="2"/>
-    <default field="pipe_connection_node_start_id" applyOnUpdate="0" expression="'filled automatically'"/>
-    <default field="pipe_connection_node_end_id" applyOnUpdate="0" expression="'filled automatically'"/>
-    <default field="def_id" applyOnUpdate="0" expression=""/>
-    <default field="def_shape" applyOnUpdate="0" expression=""/>
-    <default field="def_width" applyOnUpdate="0" expression=""/>
-    <default field="def_height" applyOnUpdate="0" expression=""/>
-    <default field="def_code" applyOnUpdate="0" expression=""/>
+    <default expression="" field="ROWID" applyOnUpdate="0"/>
+    <default expression="if(maximum(pipe_id) is null,1, maximum(pipe_id)+1)" field="pipe_id" applyOnUpdate="0"/>
+    <default expression="'new'" field="pipe_display_name" applyOnUpdate="0"/>
+    <default expression="'new'" field="pipe_code" applyOnUpdate="0"/>
+    <default expression="" field="pipe_profile_num" applyOnUpdate="0"/>
+    <default expression="" field="pipe_sewerage_type" applyOnUpdate="0"/>
+    <default expression="1" field="pipe_calculation_type" applyOnUpdate="0"/>
+    <default expression="aggregate('v2_manhole_view','mean',&quot;bottom_level&quot;, intersects($geometry,start_point(geometry(@parent))))" field="pipe_invert_level_start_point" applyOnUpdate="0"/>
+    <default expression="aggregate('v2_manhole_view','mean',&quot;bottom_level&quot;, intersects($geometry,end_point(geometry(@parent))))" field="pipe_invert_level_end_point" applyOnUpdate="0"/>
+    <default expression="" field="pipe_cross_section_definition_id" applyOnUpdate="0"/>
+    <default expression="" field="pipe_friction_value" applyOnUpdate="0"/>
+    <default expression="2" field="pipe_friction_type" applyOnUpdate="0"/>
+    <default expression="10000" field="pipe_dist_calc_points" applyOnUpdate="0"/>
+    <default expression="" field="pipe_material" applyOnUpdate="0"/>
+    <default expression="" field="pipe_pipe_quality" applyOnUpdate="0"/>
+    <default expression="" field="pipe_original_length" applyOnUpdate="0"/>
+    <default expression="2" field="pipe_zoom_category" applyOnUpdate="0"/>
+    <default expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))" field="pipe_connection_node_start_id" applyOnUpdate="0"/>
+    <default expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null, 'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))" field="pipe_connection_node_end_id" applyOnUpdate="0"/>
+    <default expression="" field="def_id" applyOnUpdate="0"/>
+    <default expression="" field="def_shape" applyOnUpdate="0"/>
+    <default expression="" field="def_width" applyOnUpdate="0"/>
+    <default expression="" field="def_height" applyOnUpdate="0"/>
+    <default expression="" field="def_code" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="0" field="ROWID" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_id" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_display_name" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_code" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="pipe_profile_num" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_sewerage_type" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_calculation_type" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_invert_level_start_point" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="5" field="pipe_invert_level_end_point" unique_strength="0" exp_strength="2"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_cross_section_definition_id" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_friction_value" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_friction_type" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="pipe_dist_calc_points" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="pipe_material" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="pipe_pipe_quality" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="pipe_original_length" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="pipe_zoom_category" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="pipe_connection_node_start_id" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="pipe_connection_node_end_id" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" field="def_id" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="def_shape" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="def_width" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="def_height" unique_strength="0" exp_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" field="def_code" unique_strength="0" exp_strength="0"/>
+    <constraint field="ROWID" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="pipe_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_display_name" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_code" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_profile_num" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="pipe_sewerage_type" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_calculation_type" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_invert_level_start_point" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_invert_level_end_point" exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_cross_section_definition_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_friction_value" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_friction_type" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_dist_calc_points" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="pipe_material" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="pipe_pipe_quality" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="pipe_original_length" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="pipe_zoom_category" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="pipe_connection_node_start_id" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="pipe_connection_node_end_id" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="def_id" exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2"/>
+    <constraint field="def_shape" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="def_width" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="def_height" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
+    <constraint field="def_code" exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="ROWID" desc="" exp=""/>
-    <constraint field="pipe_id" desc="" exp=""/>
-    <constraint field="pipe_display_name" desc="" exp=""/>
-    <constraint field="pipe_code" desc="" exp=""/>
-    <constraint field="pipe_profile_num" desc="" exp=""/>
-    <constraint field="pipe_sewerage_type" desc="" exp=""/>
-    <constraint field="pipe_calculation_type" desc="" exp=""/>
-    <constraint field="pipe_invert_level_start_point" desc="" exp=""/>
-    <constraint field="pipe_invert_level_end_point" desc="" exp="&quot;invert_level_end_point&quot; is not null"/>
-    <constraint field="pipe_cross_section_definition_id" desc="" exp=""/>
-    <constraint field="pipe_friction_value" desc="" exp=""/>
-    <constraint field="pipe_friction_type" desc="" exp=""/>
-    <constraint field="pipe_dist_calc_points" desc="" exp=""/>
-    <constraint field="pipe_material" desc="" exp=""/>
-    <constraint field="pipe_pipe_quality" desc="" exp=""/>
-    <constraint field="pipe_original_length" desc="" exp=""/>
-    <constraint field="pipe_zoom_category" desc="" exp=""/>
-    <constraint field="pipe_connection_node_start_id" desc="" exp=""/>
-    <constraint field="pipe_connection_node_end_id" desc="" exp=""/>
-    <constraint field="def_id" desc="" exp=""/>
-    <constraint field="def_shape" desc="" exp=""/>
-    <constraint field="def_width" desc="" exp=""/>
-    <constraint field="def_height" desc="" exp=""/>
-    <constraint field="def_code" desc="" exp=""/>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="pipe_id" desc=""/>
+    <constraint exp="" field="pipe_display_name" desc=""/>
+    <constraint exp="" field="pipe_code" desc=""/>
+    <constraint exp="" field="pipe_profile_num" desc=""/>
+    <constraint exp="" field="pipe_sewerage_type" desc=""/>
+    <constraint exp="" field="pipe_calculation_type" desc=""/>
+    <constraint exp="" field="pipe_invert_level_start_point" desc=""/>
+    <constraint exp="&quot;invert_level_end_point&quot; is not null" field="pipe_invert_level_end_point" desc=""/>
+    <constraint exp="" field="pipe_cross_section_definition_id" desc=""/>
+    <constraint exp="" field="pipe_friction_value" desc=""/>
+    <constraint exp="" field="pipe_friction_type" desc=""/>
+    <constraint exp="" field="pipe_dist_calc_points" desc=""/>
+    <constraint exp="" field="pipe_material" desc=""/>
+    <constraint exp="" field="pipe_pipe_quality" desc=""/>
+    <constraint exp="" field="pipe_original_length" desc=""/>
+    <constraint exp="" field="pipe_zoom_category" desc=""/>
+    <constraint exp="" field="pipe_connection_node_start_id" desc=""/>
+    <constraint exp="" field="pipe_connection_node_end_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
-      <column width="-1" type="field" name="ROWID" hidden="0"/>
-      <column width="-1" type="field" name="pipe_id" hidden="0"/>
-      <column width="-1" type="field" name="pipe_display_name" hidden="0"/>
-      <column width="-1" type="field" name="pipe_code" hidden="0"/>
-      <column width="-1" type="field" name="pipe_profile_num" hidden="0"/>
-      <column width="-1" type="field" name="pipe_sewerage_type" hidden="0"/>
-      <column width="-1" type="field" name="pipe_calculation_type" hidden="0"/>
-      <column width="-1" type="field" name="pipe_invert_level_start_point" hidden="0"/>
-      <column width="-1" type="field" name="pipe_invert_level_end_point" hidden="0"/>
-      <column width="-1" type="field" name="pipe_cross_section_definition_id" hidden="0"/>
-      <column width="-1" type="field" name="pipe_friction_value" hidden="0"/>
-      <column width="-1" type="field" name="pipe_friction_type" hidden="0"/>
-      <column width="-1" type="field" name="pipe_dist_calc_points" hidden="0"/>
-      <column width="-1" type="field" name="pipe_material" hidden="0"/>
-      <column width="-1" type="field" name="pipe_pipe_quality" hidden="0"/>
-      <column width="-1" type="field" name="pipe_original_length" hidden="0"/>
-      <column width="-1" type="field" name="pipe_zoom_category" hidden="0"/>
-      <column width="-1" type="field" name="pipe_connection_node_start_id" hidden="0"/>
-      <column width="-1" type="field" name="pipe_connection_node_end_id" hidden="0"/>
-      <column width="-1" type="field" name="def_id" hidden="0"/>
-      <column width="-1" type="field" name="def_shape" hidden="0"/>
-      <column width="-1" type="field" name="def_width" hidden="0"/>
-      <column width="-1" type="field" name="def_height" hidden="0"/>
-      <column width="-1" type="field" name="def_code" hidden="0"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column name="ROWID" hidden="0" type="field" width="-1"/>
+      <column name="pipe_id" hidden="0" type="field" width="-1"/>
+      <column name="pipe_display_name" hidden="0" type="field" width="-1"/>
+      <column name="pipe_code" hidden="0" type="field" width="-1"/>
+      <column name="pipe_profile_num" hidden="0" type="field" width="-1"/>
+      <column name="pipe_sewerage_type" hidden="0" type="field" width="-1"/>
+      <column name="pipe_calculation_type" hidden="0" type="field" width="-1"/>
+      <column name="pipe_invert_level_start_point" hidden="0" type="field" width="-1"/>
+      <column name="pipe_invert_level_end_point" hidden="0" type="field" width="-1"/>
+      <column name="pipe_cross_section_definition_id" hidden="0" type="field" width="-1"/>
+      <column name="pipe_friction_value" hidden="0" type="field" width="-1"/>
+      <column name="pipe_friction_type" hidden="0" type="field" width="-1"/>
+      <column name="pipe_dist_calc_points" hidden="0" type="field" width="-1"/>
+      <column name="pipe_material" hidden="0" type="field" width="-1"/>
+      <column name="pipe_pipe_quality" hidden="0" type="field" width="-1"/>
+      <column name="pipe_original_length" hidden="0" type="field" width="-1"/>
+      <column name="pipe_zoom_category" hidden="0" type="field" width="-1"/>
+      <column name="pipe_connection_node_start_id" hidden="0" type="field" width="-1"/>
+      <column name="pipe_connection_node_end_id" hidden="0" type="field" width="-1"/>
+      <column name="def_id" hidden="0" type="field" width="-1"/>
+      <column name="def_shape" hidden="0" type="field" width="-1"/>
+      <column name="def_width" hidden="0" type="field" width="-1"/>
+      <column name="def_height" hidden="0" type="field" width="-1"/>
+      <column name="def_code" hidden="0" type="field" width="-1"/>
+      <column hidden="1" type="actions" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -738,89 +739,89 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="0" visibilityExpression="" columnCount="1" name="Pipe view">
-      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="General">
-        <attributeEditorField showLabel="1" index="1" name="pipe_id"/>
-        <attributeEditorField showLabel="1" index="2" name="pipe_display_name"/>
-        <attributeEditorField showLabel="1" index="3" name="pipe_code"/>
-        <attributeEditorField showLabel="1" index="6" name="pipe_calculation_type"/>
-        <attributeEditorField showLabel="1" index="12" name="pipe_dist_calc_points"/>
+    <attributeEditorContainer name="Pipe view" showLabel="1" columnCount="1" visibilityExpression="" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer name="General" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="pipe_id" showLabel="1" index="1"/>
+        <attributeEditorField name="pipe_display_name" showLabel="1" index="2"/>
+        <attributeEditorField name="pipe_code" showLabel="1" index="3"/>
+        <attributeEditorField name="pipe_calculation_type" showLabel="1" index="6"/>
+        <attributeEditorField name="pipe_dist_calc_points" showLabel="1" index="12"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Characteristics">
-        <attributeEditorField showLabel="1" index="7" name="pipe_invert_level_start_point"/>
-        <attributeEditorField showLabel="1" index="8" name="pipe_invert_level_end_point"/>
-        <attributeEditorField showLabel="1" index="10" name="pipe_friction_value"/>
-        <attributeEditorField showLabel="1" index="11" name="pipe_friction_type"/>
-        <attributeEditorField showLabel="1" index="13" name="pipe_material"/>
+      <attributeEditorContainer name="Characteristics" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="pipe_invert_level_start_point" showLabel="1" index="7"/>
+        <attributeEditorField name="pipe_invert_level_end_point" showLabel="1" index="8"/>
+        <attributeEditorField name="pipe_friction_value" showLabel="1" index="10"/>
+        <attributeEditorField name="pipe_friction_type" showLabel="1" index="11"/>
+        <attributeEditorField name="pipe_material" showLabel="1" index="13"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Cross section definition">
-        <attributeEditorField showLabel="1" index="9" name="pipe_cross_section_definition_id"/>
-        <attributeEditorField showLabel="1" index="20" name="def_shape"/>
-        <attributeEditorField showLabel="1" index="21" name="def_width"/>
-        <attributeEditorField showLabel="1" index="22" name="def_height"/>
-        <attributeEditorField showLabel="1" index="23" name="def_code"/>
+      <attributeEditorContainer name="Cross section definition" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="pipe_cross_section_definition_id" showLabel="1" index="9"/>
+        <attributeEditorField name="def_shape" showLabel="1" index="20"/>
+        <attributeEditorField name="def_width" showLabel="1" index="21"/>
+        <attributeEditorField name="def_height" showLabel="1" index="22"/>
+        <attributeEditorField name="def_code" showLabel="1" index="23"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Visualization">
-        <attributeEditorField showLabel="1" index="5" name="pipe_sewerage_type"/>
-        <attributeEditorField showLabel="1" index="16" name="pipe_zoom_category"/>
+      <attributeEditorContainer name="Visualization" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="pipe_sewerage_type" showLabel="1" index="5"/>
+        <attributeEditorField name="pipe_zoom_category" showLabel="1" index="16"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" groupBox="1" visibilityExpression="" columnCount="1" name="Connection nodes">
-        <attributeEditorField showLabel="1" index="17" name="pipe_connection_node_start_id"/>
-        <attributeEditorField showLabel="1" index="18" name="pipe_connection_node_end_id"/>
+      <attributeEditorContainer name="Connection nodes" showLabel="1" columnCount="1" visibilityExpression="" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField name="pipe_connection_node_start_id" showLabel="1" index="17"/>
+        <attributeEditorField name="pipe_connection_node_end_id" showLabel="1" index="18"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="ROWID"/>
-    <field editable="0" name="def_code"/>
-    <field editable="0" name="def_height"/>
-    <field editable="1" name="def_id"/>
-    <field editable="0" name="def_shape"/>
-    <field editable="0" name="def_width"/>
-    <field editable="1" name="pipe_calculation_type"/>
-    <field editable="1" name="pipe_code"/>
-    <field editable="0" name="pipe_connection_node_end_id"/>
-    <field editable="0" name="pipe_connection_node_start_id"/>
-    <field editable="1" name="pipe_cross_section_definition_id"/>
-    <field editable="1" name="pipe_display_name"/>
-    <field editable="1" name="pipe_dist_calc_points"/>
-    <field editable="1" name="pipe_friction_type"/>
-    <field editable="1" name="pipe_friction_value"/>
-    <field editable="1" name="pipe_id"/>
-    <field editable="1" name="pipe_invert_level_end_point"/>
-    <field editable="1" name="pipe_invert_level_start_point"/>
-    <field editable="1" name="pipe_material"/>
-    <field editable="1" name="pipe_original_length"/>
-    <field editable="1" name="pipe_pipe_quality"/>
-    <field editable="1" name="pipe_profile_num"/>
-    <field editable="1" name="pipe_sewerage_type"/>
-    <field editable="1" name="pipe_zoom_category"/>
+    <field name="ROWID" editable="1"/>
+    <field name="def_code" editable="0"/>
+    <field name="def_height" editable="0"/>
+    <field name="def_id" editable="1"/>
+    <field name="def_shape" editable="0"/>
+    <field name="def_width" editable="0"/>
+    <field name="pipe_calculation_type" editable="1"/>
+    <field name="pipe_code" editable="1"/>
+    <field name="pipe_connection_node_end_id" editable="0"/>
+    <field name="pipe_connection_node_start_id" editable="0"/>
+    <field name="pipe_cross_section_definition_id" editable="1"/>
+    <field name="pipe_display_name" editable="1"/>
+    <field name="pipe_dist_calc_points" editable="1"/>
+    <field name="pipe_friction_type" editable="1"/>
+    <field name="pipe_friction_value" editable="1"/>
+    <field name="pipe_id" editable="1"/>
+    <field name="pipe_invert_level_end_point" editable="1"/>
+    <field name="pipe_invert_level_start_point" editable="1"/>
+    <field name="pipe_material" editable="1"/>
+    <field name="pipe_original_length" editable="1"/>
+    <field name="pipe_pipe_quality" editable="1"/>
+    <field name="pipe_profile_num" editable="1"/>
+    <field name="pipe_sewerage_type" editable="1"/>
+    <field name="pipe_zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ROWID"/>
-    <field labelOnTop="0" name="def_code"/>
-    <field labelOnTop="0" name="def_height"/>
-    <field labelOnTop="0" name="def_id"/>
-    <field labelOnTop="0" name="def_shape"/>
-    <field labelOnTop="0" name="def_width"/>
-    <field labelOnTop="0" name="pipe_calculation_type"/>
-    <field labelOnTop="0" name="pipe_code"/>
-    <field labelOnTop="0" name="pipe_connection_node_end_id"/>
-    <field labelOnTop="0" name="pipe_connection_node_start_id"/>
-    <field labelOnTop="0" name="pipe_cross_section_definition_id"/>
-    <field labelOnTop="0" name="pipe_display_name"/>
-    <field labelOnTop="0" name="pipe_dist_calc_points"/>
-    <field labelOnTop="0" name="pipe_friction_type"/>
-    <field labelOnTop="0" name="pipe_friction_value"/>
-    <field labelOnTop="0" name="pipe_id"/>
-    <field labelOnTop="0" name="pipe_invert_level_end_point"/>
-    <field labelOnTop="0" name="pipe_invert_level_start_point"/>
-    <field labelOnTop="0" name="pipe_material"/>
-    <field labelOnTop="0" name="pipe_original_length"/>
-    <field labelOnTop="0" name="pipe_pipe_quality"/>
-    <field labelOnTop="0" name="pipe_profile_num"/>
-    <field labelOnTop="0" name="pipe_sewerage_type"/>
-    <field labelOnTop="0" name="pipe_zoom_category"/>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="def_code" labelOnTop="0"/>
+    <field name="def_height" labelOnTop="0"/>
+    <field name="def_id" labelOnTop="0"/>
+    <field name="def_shape" labelOnTop="0"/>
+    <field name="def_width" labelOnTop="0"/>
+    <field name="pipe_calculation_type" labelOnTop="0"/>
+    <field name="pipe_code" labelOnTop="0"/>
+    <field name="pipe_connection_node_end_id" labelOnTop="0"/>
+    <field name="pipe_connection_node_start_id" labelOnTop="0"/>
+    <field name="pipe_cross_section_definition_id" labelOnTop="0"/>
+    <field name="pipe_display_name" labelOnTop="0"/>
+    <field name="pipe_dist_calc_points" labelOnTop="0"/>
+    <field name="pipe_friction_type" labelOnTop="0"/>
+    <field name="pipe_friction_value" labelOnTop="0"/>
+    <field name="pipe_id" labelOnTop="0"/>
+    <field name="pipe_invert_level_end_point" labelOnTop="0"/>
+    <field name="pipe_invert_level_start_point" labelOnTop="0"/>
+    <field name="pipe_material" labelOnTop="0"/>
+    <field name="pipe_original_length" labelOnTop="0"/>
+    <field name="pipe_pipe_quality" labelOnTop="0"/>
+    <field name="pipe_profile_num" labelOnTop="0"/>
+    <field name="pipe_sewerage_type" labelOnTop="0"/>
+    <field name="pipe_zoom_category" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_pumpstation.qml
+++ b/layer_styles/schematisation/v2_pumpstation.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -11,7 +11,7 @@
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -20,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -32,25 +32,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" name="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" name="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" name="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" name="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" name="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" name="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" name="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -61,8 +61,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -71,8 +71,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -81,8 +81,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -91,8 +91,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -101,8 +101,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="CheckedState" value="1" type="QString"/>
-            <Option name="UncheckedState" value="0" type="QString"/>
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
           </Option>
         </config>
       </editWidget>
@@ -111,8 +111,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -121,8 +121,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -131,8 +131,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -141,8 +141,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -153,10 +153,10 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="1: pump reacts only on suction side" value="1" type="QString"/>
+                <Option value="1" name="1: Pump behaviour is based on water levels on the suction-side of the pump" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2: pump reacts only on delivery side" value="2" type="QString"/>
+                <Option value="2" name="2: Pump behaviour is based on water levels on the delivery-side of the pump" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -167,95 +167,95 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="upper_stop_level"/>
-    <alias name="" index="1" field="zoom_category"/>
-    <alias name="" index="2" field="code"/>
-    <alias name="" index="3" field="display_name"/>
-    <alias name="" index="4" field="connection_node_end_id"/>
-    <alias name="" index="5" field="classification"/>
-    <alias name="" index="6" field="sewerage"/>
-    <alias name="" index="7" field="lower_stop_level"/>
-    <alias name="" index="8" field="connection_node_start_id"/>
-    <alias name="" index="9" field="start_level"/>
-    <alias name="" index="10" field="capacity"/>
-    <alias name="" index="11" field="type"/>
-    <alias name="" index="12" field="id"/>
+    <alias index="0" name="" field="upper_stop_level"/>
+    <alias index="1" name="" field="zoom_category"/>
+    <alias index="2" name="" field="code"/>
+    <alias index="3" name="" field="display_name"/>
+    <alias index="4" name="" field="connection_node_end_id"/>
+    <alias index="5" name="" field="classification"/>
+    <alias index="6" name="" field="sewerage"/>
+    <alias index="7" name="" field="lower_stop_level"/>
+    <alias index="8" name="" field="connection_node_start_id"/>
+    <alias index="9" name="" field="start_level"/>
+    <alias index="10" name="" field="capacity"/>
+    <alias index="11" name="" field="type"/>
+    <alias index="12" name="" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="upper_stop_level" expression=""/>
-    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
-    <default applyOnUpdate="0" field="classification" expression=""/>
-    <default applyOnUpdate="0" field="sewerage" expression=""/>
-    <default applyOnUpdate="0" field="lower_stop_level" expression=""/>
-    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
-    <default applyOnUpdate="0" field="start_level" expression=""/>
-    <default applyOnUpdate="0" field="capacity" expression=""/>
-    <default applyOnUpdate="0" field="type" expression="1"/>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default applyOnUpdate="0" expression="" field="upper_stop_level"/>
+    <default applyOnUpdate="0" expression="3" field="zoom_category"/>
+    <default applyOnUpdate="0" expression="'new'" field="code"/>
+    <default applyOnUpdate="0" expression="'new'" field="display_name"/>
+    <default applyOnUpdate="0" expression="" field="connection_node_end_id"/>
+    <default applyOnUpdate="0" expression="" field="classification"/>
+    <default applyOnUpdate="0" expression="" field="sewerage"/>
+    <default applyOnUpdate="0" expression="" field="lower_stop_level"/>
+    <default applyOnUpdate="0" expression="" field="connection_node_start_id"/>
+    <default applyOnUpdate="0" expression="" field="start_level"/>
+    <default applyOnUpdate="0" expression="" field="capacity"/>
+    <default applyOnUpdate="0" expression="1" field="type"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1, maximum(id)+1)" field="id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="4" exp_strength="2" field="upper_stop_level" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="classification" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sewerage" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="lower_stop_level" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="start_level" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="capacity" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="type" unique_strength="0"/>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint exp_strength="2" notnull_strength="0" field="upper_stop_level" constraints="4" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="zoom_category" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="display_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="connection_node_end_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="classification" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="sewerage" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="2" field="lower_stop_level" constraints="5" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="connection_node_start_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="start_level" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="2" field="capacity" constraints="5" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="&quot;upper_stop_level&quot;>&quot;start_level&quot; or &quot;upper_stop_level&quot; is null" field="upper_stop_level" desc=""/>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
-    <constraint exp="" field="classification" desc=""/>
-    <constraint exp="" field="sewerage" desc=""/>
-    <constraint exp="&quot;lower_stop_level&quot;&lt;&quot;start_level&quot;" field="lower_stop_level" desc=""/>
-    <constraint exp="" field="connection_node_start_id" desc=""/>
-    <constraint exp="" field="start_level" desc=""/>
-    <constraint exp="&quot;capacity&quot;>=0" field="capacity" desc=""/>
-    <constraint exp="" field="type" desc=""/>
-    <constraint exp="" field="id" desc=""/>
+    <constraint exp="&quot;upper_stop_level&quot;>&quot;start_level&quot; or &quot;upper_stop_level&quot; is null" desc="" field="upper_stop_level"/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="connection_node_end_id"/>
+    <constraint exp="" desc="" field="classification"/>
+    <constraint exp="" desc="" field="sewerage"/>
+    <constraint exp="&quot;lower_stop_level&quot;&lt;&quot;start_level&quot;" desc="" field="lower_stop_level"/>
+    <constraint exp="" desc="" field="connection_node_start_id"/>
+    <constraint exp="" desc="" field="start_level"/>
+    <constraint exp="&quot;capacity&quot;>=0" desc="" field="capacity"/>
+    <constraint exp="" desc="" field="type"/>
+    <constraint exp="" desc="" field="id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column name="upper_stop_level" hidden="0" width="-1" type="field"/>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="classification" hidden="0" width="-1" type="field"/>
-      <column name="sewerage" hidden="0" width="-1" type="field"/>
-      <column name="lower_stop_level" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="start_level" hidden="0" width="-1" type="field"/>
-      <column name="capacity" hidden="0" width="-1" type="field"/>
-      <column name="type" hidden="0" width="-1" type="field"/>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" hidden="0" name="upper_stop_level" type="field"/>
+      <column width="-1" hidden="0" name="zoom_category" type="field"/>
+      <column width="-1" hidden="0" name="code" type="field"/>
+      <column width="-1" hidden="0" name="display_name" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_end_id" type="field"/>
+      <column width="-1" hidden="0" name="classification" type="field"/>
+      <column width="-1" hidden="0" name="sewerage" type="field"/>
+      <column width="-1" hidden="0" name="lower_stop_level" type="field"/>
+      <column width="-1" hidden="0" name="connection_node_start_id" type="field"/>
+      <column width="-1" hidden="0" name="start_level" type="field"/>
+      <column width="-1" hidden="0" name="capacity" type="field"/>
+      <column width="-1" hidden="0" name="type" type="field"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -286,58 +286,58 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Pumpstation" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="12" showLabel="1"/>
-        <attributeEditorField name="display_name" index="3" showLabel="1"/>
-        <attributeEditorField name="code" index="2" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Pumpstation" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="12" name="id"/>
+        <attributeEditorField showLabel="1" index="3" name="display_name"/>
+        <attributeEditorField showLabel="1" index="2" name="code"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="capacity" index="10" showLabel="1"/>
-        <attributeEditorField name="start_level" index="9" showLabel="1"/>
-        <attributeEditorField name="lower_stop_level" index="7" showLabel="1"/>
-        <attributeEditorField name="upper_stop_level" index="0" showLabel="1"/>
-        <attributeEditorField name="type" index="11" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="10" name="capacity"/>
+        <attributeEditorField showLabel="1" index="9" name="start_level"/>
+        <attributeEditorField showLabel="1" index="7" name="lower_stop_level"/>
+        <attributeEditorField showLabel="1" index="0" name="upper_stop_level"/>
+        <attributeEditorField showLabel="1" index="11" name="type"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="1" showLabel="1"/>
-        <attributeEditorField name="sewerage" index="6" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="1" name="zoom_category"/>
+        <attributeEditorField showLabel="1" index="6" name="sewerage"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="8" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="4" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Connection nodes" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="8" name="connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="4" name="connection_node_end_id"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="capacity" editable="1"/>
-    <field name="classification" editable="1"/>
-    <field name="code" editable="1"/>
-    <field name="connection_node_end_id" editable="1"/>
-    <field name="connection_node_start_id" editable="1"/>
-    <field name="display_name" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="lower_stop_level" editable="1"/>
-    <field name="sewerage" editable="1"/>
-    <field name="start_level" editable="1"/>
-    <field name="type" editable="1"/>
-    <field name="upper_stop_level" editable="1"/>
-    <field name="zoom_category" editable="1"/>
+    <field editable="1" name="capacity"/>
+    <field editable="1" name="classification"/>
+    <field editable="1" name="code"/>
+    <field editable="1" name="connection_node_end_id"/>
+    <field editable="1" name="connection_node_start_id"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="lower_stop_level"/>
+    <field editable="1" name="sewerage"/>
+    <field editable="1" name="start_level"/>
+    <field editable="1" name="type"/>
+    <field editable="1" name="upper_stop_level"/>
+    <field editable="1" name="zoom_category"/>
   </editable>
   <labelOnTop>
-    <field name="capacity" labelOnTop="0"/>
-    <field name="classification" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_end_id" labelOnTop="0"/>
-    <field name="connection_node_start_id" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="lower_stop_level" labelOnTop="0"/>
-    <field name="sewerage" labelOnTop="0"/>
-    <field name="start_level" labelOnTop="0"/>
-    <field name="type" labelOnTop="0"/>
-    <field name="upper_stop_level" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="capacity"/>
+    <field labelOnTop="0" name="classification"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_end_id"/>
+    <field labelOnTop="0" name="connection_node_start_id"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="lower_stop_level"/>
+    <field labelOnTop="0" name="sewerage"/>
+    <field labelOnTop="0" name="start_level"/>
+    <field labelOnTop="0" name="type"/>
+    <field labelOnTop="0" name="upper_stop_level"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_pumpstation.qml
+++ b/layer_styles/schematisation/v2_pumpstation.qml
@@ -1,0 +1,346 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property value="display_name" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="upper_stop_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="classification">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="sewerage">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option name="CheckedState" value="1" type="QString"/>
+            <Option name="UncheckedState" value="0" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="lower_stop_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="start_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="capacity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: pump reacts only on suction side" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: pump reacts only on delivery side" value="2" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="upper_stop_level"/>
+    <alias name="" index="1" field="zoom_category"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="display_name"/>
+    <alias name="" index="4" field="connection_node_end_id"/>
+    <alias name="" index="5" field="classification"/>
+    <alias name="" index="6" field="sewerage"/>
+    <alias name="" index="7" field="lower_stop_level"/>
+    <alias name="" index="8" field="connection_node_start_id"/>
+    <alias name="" index="9" field="start_level"/>
+    <alias name="" index="10" field="capacity"/>
+    <alias name="" index="11" field="type"/>
+    <alias name="" index="12" field="id"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default applyOnUpdate="0" field="upper_stop_level" expression=""/>
+    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
+    <default applyOnUpdate="0" field="code" expression="'new'"/>
+    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
+    <default applyOnUpdate="0" field="classification" expression=""/>
+    <default applyOnUpdate="0" field="sewerage" expression=""/>
+    <default applyOnUpdate="0" field="lower_stop_level" expression=""/>
+    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
+    <default applyOnUpdate="0" field="start_level" expression=""/>
+    <default applyOnUpdate="0" field="capacity" expression=""/>
+    <default applyOnUpdate="0" field="type" expression="1"/>
+    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="0" constraints="4" exp_strength="2" field="upper_stop_level" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="classification" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sewerage" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="lower_stop_level" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="start_level" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="5" exp_strength="2" field="capacity" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="type" unique_strength="0"/>
+    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="&quot;upper_stop_level&quot;>&quot;start_level&quot; or &quot;upper_stop_level&quot; is null" field="upper_stop_level" desc=""/>
+    <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="connection_node_end_id" desc=""/>
+    <constraint exp="" field="classification" desc=""/>
+    <constraint exp="" field="sewerage" desc=""/>
+    <constraint exp="&quot;lower_stop_level&quot;&lt;&quot;start_level&quot;" field="lower_stop_level" desc=""/>
+    <constraint exp="" field="connection_node_start_id" desc=""/>
+    <constraint exp="" field="start_level" desc=""/>
+    <constraint exp="&quot;capacity&quot;>=0" field="capacity" desc=""/>
+    <constraint exp="" field="type" desc=""/>
+    <constraint exp="" field="id" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+    <columns>
+      <column name="upper_stop_level" hidden="0" width="-1" type="field"/>
+      <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="code" hidden="0" width="-1" type="field"/>
+      <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
+      <column name="classification" hidden="0" width="-1" type="field"/>
+      <column name="sewerage" hidden="0" width="-1" type="field"/>
+      <column name="lower_stop_level" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
+      <column name="start_level" hidden="0" width="-1" type="field"/>
+      <column name="capacity" hidden="0" width="-1" type="field"/>
+      <column name="type" hidden="0" width="-1" type="field"/>
+      <column name="id" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Pumpstation" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="id" index="12" showLabel="1"/>
+        <attributeEditorField name="display_name" index="3" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="capacity" index="10" showLabel="1"/>
+        <attributeEditorField name="start_level" index="9" showLabel="1"/>
+        <attributeEditorField name="lower_stop_level" index="7" showLabel="1"/>
+        <attributeEditorField name="upper_stop_level" index="0" showLabel="1"/>
+        <attributeEditorField name="type" index="11" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="zoom_category" index="1" showLabel="1"/>
+        <attributeEditorField name="sewerage" index="6" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="connection_node_start_id" index="8" showLabel="1"/>
+        <attributeEditorField name="connection_node_end_id" index="4" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="capacity" editable="1"/>
+    <field name="classification" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="connection_node_end_id" editable="1"/>
+    <field name="connection_node_start_id" editable="1"/>
+    <field name="display_name" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="lower_stop_level" editable="1"/>
+    <field name="sewerage" editable="1"/>
+    <field name="start_level" editable="1"/>
+    <field name="type" editable="1"/>
+    <field name="upper_stop_level" editable="1"/>
+    <field name="zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="capacity" labelOnTop="0"/>
+    <field name="classification" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="connection_node_end_id" labelOnTop="0"/>
+    <field name="connection_node_start_id" labelOnTop="0"/>
+    <field name="display_name" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="lower_stop_level" labelOnTop="0"/>
+    <field name="sewerage" labelOnTop="0"/>
+    <field name="start_level" labelOnTop="0"/>
+    <field name="type" labelOnTop="0"/>
+    <field name="upper_stop_level" labelOnTop="0"/>
+    <field name="zoom_category" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_pumpstation_point_view.qml
+++ b/layer_styles/schematisation/v2_pumpstation_point_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis maxScale="-4.65661e-10" simplifyDrawingTol="1" simplifyLocal="1" readOnly="0" simplifyDrawingHints="0" version="3.4.5-Madeira" styleCategories="AllStyleCategories" minScale="1e+08" labelsEnabled="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="-4.65661e-10" labelsEnabled="0" simplifyDrawingHints="0" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" name="0" force_rhr="0" type="marker">
-        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="0">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,170,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
@@ -29,9 +29,9 @@
           <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -49,22 +49,22 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory minimumSize="0" height="15" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" penWidth="0" labelPlacementMethod="XHeight" opacity="1" width="15" sizeType="MM" enabled="0" lineSizeType="MM" penColor="#000000" maxScaleDenominator="1e+08" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" backgroundAlpha="255" penAlpha="255" barWidth="5" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0">
-      <fontProperties description="MS Shell Dlg 2,7.5,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" color="#000000" field=""/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="-4.65661e-10" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,7.5,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" zIndex="0" placement="0" showAll="1" linePlacementFlags="2" priority="0" obstacle="0">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="0" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -73,8 +73,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -83,8 +83,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -93,8 +93,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -103,8 +103,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -113,8 +113,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -123,8 +123,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="1" name="CheckedState" type="QString"/>
-            <Option value="0" name="UncheckedState" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -133,8 +133,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -143,8 +143,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -153,8 +153,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -163,8 +163,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -173,27 +173,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="-1" name="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" name="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" name="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" name="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" name="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" name="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" name="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -204,8 +204,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -214,8 +214,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -224,12 +224,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="1" name="1: Pump reacts only on suction side" type="QString"/>
+                <Option value="1" type="QString" name="1: pump reacts only on suction side"/>
               </Option>
               <Option type="Map">
-                <Option value="2" name="2: Pump reacts only on delivery side" type="QString"/>
+                <Option value="2" type="QString" name="2: pump reacts only on delivery side"/>
               </Option>
             </Option>
           </Option>
@@ -240,8 +240,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -250,110 +250,110 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="ROWID"/>
-    <alias index="1" name="id" field="pump_id"/>
-    <alias index="2" name="" field="display_name"/>
-    <alias index="3" name="" field="code"/>
-    <alias index="4" name="" field="classification"/>
-    <alias index="5" name="" field="sewerage"/>
-    <alias index="6" name="" field="start_level"/>
-    <alias index="7" name="" field="lower_stop_level"/>
-    <alias index="8" name="" field="upper_stop_level"/>
-    <alias index="9" name="" field="capacity"/>
-    <alias index="10" name="" field="zoom_category"/>
-    <alias index="11" name="" field="connection_node_start_id"/>
-    <alias index="12" name="" field="connection_node_end_id"/>
-    <alias index="13" name="" field="type"/>
-    <alias index="14" name="id" field="connection_node_id"/>
-    <alias index="15" name="" field="storage_area"/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="id" field="pump_id" index="1"/>
+    <alias name="" field="display_name" index="2"/>
+    <alias name="" field="code" index="3"/>
+    <alias name="" field="classification" index="4"/>
+    <alias name="" field="sewerage" index="5"/>
+    <alias name="" field="start_level" index="6"/>
+    <alias name="" field="lower_stop_level" index="7"/>
+    <alias name="" field="upper_stop_level" index="8"/>
+    <alias name="" field="capacity" index="9"/>
+    <alias name="" field="zoom_category" index="10"/>
+    <alias name="" field="connection_node_start_id" index="11"/>
+    <alias name="" field="connection_node_end_id" index="12"/>
+    <alias name="" field="type" index="13"/>
+    <alias name="id" field="connection_node_id" index="14"/>
+    <alias name="" field="storage_area" index="15"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" expression="" field="ROWID"/>
-    <default applyOnUpdate="0" expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" field="pump_id"/>
-    <default applyOnUpdate="0" expression="'new'" field="display_name"/>
-    <default applyOnUpdate="0" expression="'new'" field="code"/>
-    <default applyOnUpdate="0" expression="" field="classification"/>
-    <default applyOnUpdate="0" expression="" field="sewerage"/>
-    <default applyOnUpdate="0" expression="" field="start_level"/>
-    <default applyOnUpdate="0" expression="" field="lower_stop_level"/>
-    <default applyOnUpdate="0" expression="" field="upper_stop_level"/>
-    <default applyOnUpdate="0" expression="" field="capacity"/>
-    <default applyOnUpdate="0" expression="2" field="zoom_category"/>
-    <default applyOnUpdate="0" expression="'filled automatically'" field="connection_node_start_id"/>
-    <default applyOnUpdate="0" expression="'if you want to use an endpoint use v2_pumpstation_view'" field="connection_node_end_id"/>
-    <default applyOnUpdate="0" expression="1" field="type"/>
-    <default applyOnUpdate="0" expression="'filled automatically'" field="connection_node_id"/>
-    <default applyOnUpdate="0" expression="" field="storage_area"/>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" applyOnUpdate="0" field="pump_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="" applyOnUpdate="0" field="classification"/>
+    <default expression="" applyOnUpdate="0" field="sewerage"/>
+    <default expression="" applyOnUpdate="0" field="start_level"/>
+    <default expression="" applyOnUpdate="0" field="lower_stop_level"/>
+    <default expression="" applyOnUpdate="0" field="upper_stop_level"/>
+    <default expression="" applyOnUpdate="0" field="capacity"/>
+    <default expression="2" applyOnUpdate="0" field="zoom_category"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="connection_node_start_id"/>
+    <default expression="'if you want to use an endpoint use v2_pumpstation_view'" applyOnUpdate="0" field="connection_node_end_id"/>
+    <default expression="1" applyOnUpdate="0" field="type"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="connection_node_id"/>
+    <default expression="" applyOnUpdate="0" field="storage_area"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="ROWID"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_id"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="display_name"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="code"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="classification"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="sewerage"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="start_level"/>
-    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="lower_stop_level"/>
-    <constraint exp_strength="2" constraints="4" unique_strength="0" notnull_strength="0" field="upper_stop_level"/>
-    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="capacity"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="zoom_category"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="connection_node_start_id"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="connection_node_end_id"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="type"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="connection_node_id"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="storage_area"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="classification"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="sewerage"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="start_level"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="lower_stop_level"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="0" constraints="4" field="upper_stop_level"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="capacity"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="storage_area"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" exp="" field="ROWID"/>
-    <constraint desc="" exp="" field="pump_id"/>
-    <constraint desc="" exp="" field="display_name"/>
-    <constraint desc="" exp="" field="code"/>
-    <constraint desc="" exp="" field="classification"/>
-    <constraint desc="" exp="" field="sewerage"/>
-    <constraint desc="" exp="" field="start_level"/>
-    <constraint desc="" exp="&quot;lower_stop_level&quot;&lt;&quot;start_level&quot;" field="lower_stop_level"/>
-    <constraint desc="" exp="&quot;upper_stop_level&quot;>&quot;start_level&quot; or &quot;upper_stop_level&quot; is null&#xd;&#xa;" field="upper_stop_level"/>
-    <constraint desc="" exp="&quot;capacity&quot;>=0" field="capacity"/>
-    <constraint desc="" exp="" field="zoom_category"/>
-    <constraint desc="" exp="" field="connection_node_start_id"/>
-    <constraint desc="" exp="" field="connection_node_end_id"/>
-    <constraint desc="" exp="" field="type"/>
-    <constraint desc="" exp="" field="connection_node_id"/>
-    <constraint desc="" exp="" field="storage_area"/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="pump_id"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="classification"/>
+    <constraint exp="" desc="" field="sewerage"/>
+    <constraint exp="" desc="" field="start_level"/>
+    <constraint exp="&quot;lower_stop_level&quot;&lt;&quot;start_level&quot;" desc="" field="lower_stop_level"/>
+    <constraint exp="&quot;upper_stop_level&quot;>&quot;start_level&quot; or &quot;upper_stop_level&quot; is null&#xd;&#xa;" desc="" field="upper_stop_level"/>
+    <constraint exp="&quot;capacity&quot;>=0" desc="" field="capacity"/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="connection_node_start_id"/>
+    <constraint exp="" desc="" field="connection_node_end_id"/>
+    <constraint exp="" desc="" field="type"/>
+    <constraint exp="" desc="" field="connection_node_id"/>
+    <constraint exp="" desc="" field="storage_area"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column hidden="0" name="ROWID" width="-1" type="field"/>
-      <column hidden="0" name="pump_id" width="-1" type="field"/>
-      <column hidden="0" name="display_name" width="-1" type="field"/>
-      <column hidden="0" name="code" width="-1" type="field"/>
-      <column hidden="0" name="classification" width="-1" type="field"/>
-      <column hidden="0" name="sewerage" width="-1" type="field"/>
-      <column hidden="0" name="start_level" width="-1" type="field"/>
-      <column hidden="0" name="lower_stop_level" width="-1" type="field"/>
-      <column hidden="0" name="upper_stop_level" width="-1" type="field"/>
-      <column hidden="0" name="capacity" width="-1" type="field"/>
-      <column hidden="0" name="zoom_category" width="-1" type="field"/>
-      <column hidden="0" name="connection_node_start_id" width="-1" type="field"/>
-      <column hidden="0" name="connection_node_end_id" width="-1" type="field"/>
-      <column hidden="0" name="type" width="-1" type="field"/>
-      <column hidden="0" name="connection_node_id" width="-1" type="field"/>
-      <column hidden="0" name="storage_area" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="pump_id"/>
+      <column width="-1" type="field" hidden="0" name="display_name"/>
+      <column width="-1" type="field" hidden="0" name="code"/>
+      <column width="-1" type="field" hidden="0" name="classification"/>
+      <column width="-1" type="field" hidden="0" name="sewerage"/>
+      <column width="-1" type="field" hidden="0" name="start_level"/>
+      <column width="-1" type="field" hidden="0" name="lower_stop_level"/>
+      <column width="-1" type="field" hidden="0" name="upper_stop_level"/>
+      <column width="-1" type="field" hidden="0" name="capacity"/>
+      <column width="-1" type="field" hidden="0" name="zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="type"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_id"/>
+      <column width="-1" type="field" hidden="0" name="storage_area"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -384,28 +384,28 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="Pumpstation point view" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
-      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="1" name="pump_id"/>
-        <attributeEditorField showLabel="1" index="2" name="display_name"/>
-        <attributeEditorField showLabel="1" index="3" name="code"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Pumpstation point view" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="pump_id" index="1"/>
+        <attributeEditorField showLabel="1" name="display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="code" index="3"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="6" name="start_level"/>
-        <attributeEditorField showLabel="1" index="7" name="lower_stop_level"/>
-        <attributeEditorField showLabel="1" index="8" name="upper_stop_level"/>
-        <attributeEditorField showLabel="1" index="9" name="capacity"/>
-        <attributeEditorField showLabel="1" index="13" name="type"/>
-        <attributeEditorField showLabel="1" index="15" name="storage_area"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="start_level" index="6"/>
+        <attributeEditorField showLabel="1" name="lower_stop_level" index="7"/>
+        <attributeEditorField showLabel="1" name="upper_stop_level" index="8"/>
+        <attributeEditorField showLabel="1" name="capacity" index="9"/>
+        <attributeEditorField showLabel="1" name="type" index="13"/>
+        <attributeEditorField showLabel="1" name="storage_area" index="15"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="5" name="sewerage"/>
-        <attributeEditorField showLabel="1" index="10" name="zoom_category"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="sewerage" index="5"/>
+        <attributeEditorField showLabel="1" name="zoom_category" index="10"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Connection nodes" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="14" name="connection_node_id"/>
-        <attributeEditorField showLabel="1" index="11" name="connection_node_start_id"/>
-        <attributeEditorField showLabel="1" index="12" name="connection_node_end_id"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="connection_node_id" index="14"/>
+        <attributeEditorField showLabel="1" name="connection_node_start_id" index="11"/>
+        <attributeEditorField showLabel="1" name="connection_node_end_id" index="12"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -428,22 +428,22 @@ def my_form_open(dialog, layer, feature):
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="capacity" labelOnTop="0"/>
-    <field name="classification" labelOnTop="0"/>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_end_id" labelOnTop="0"/>
-    <field name="connection_node_id" labelOnTop="0"/>
-    <field name="connection_node_start_id" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="lower_stop_level" labelOnTop="0"/>
-    <field name="pump_id" labelOnTop="0"/>
-    <field name="sewerage" labelOnTop="0"/>
-    <field name="start_level" labelOnTop="0"/>
-    <field name="storage_area" labelOnTop="0"/>
-    <field name="type" labelOnTop="0"/>
-    <field name="upper_stop_level" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="capacity"/>
+    <field labelOnTop="0" name="classification"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_end_id"/>
+    <field labelOnTop="0" name="connection_node_id"/>
+    <field labelOnTop="0" name="connection_node_start_id"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="lower_stop_level"/>
+    <field labelOnTop="0" name="pump_id"/>
+    <field labelOnTop="0" name="sewerage"/>
+    <field labelOnTop="0" name="start_level"/>
+    <field labelOnTop="0" name="storage_area"/>
+    <field labelOnTop="0" name="type"/>
+    <field labelOnTop="0" name="upper_stop_level"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_pumpstation_point_view.qml
+++ b/layer_styles/schematisation/v2_pumpstation_point_view.qml
@@ -1,278 +1,366 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.4-Essen" minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="pump_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="classification">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="sewerage">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="start_level_suction_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="stop_level_suction_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="start_level_delivery_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="stop_level_delivery_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="capacity">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="connection_node_start_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="connection_node_end_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="connection_node_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="storage_area">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis maxScale="-4.65661e-10" simplifyDrawingTol="1" simplifyLocal="1" readOnly="0" simplifyDrawingHints="0" version="3.4.5-Madeira" styleCategories="AllStyleCategories" minScale="1e+08" labelsEnabled="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="marker" name="0">
-        <layer pass="0" class="SimpleMarker" locked="0">
+      <symbol alpha="1" clip_to_extent="1" name="0" force_rhr="0" type="marker">
+        <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
           <prop k="angle" v="0"/>
           <prop k="color" v="255,170,0,255"/>
           <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
           <prop k="name" v="pentagon"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="scale_method" v="diameter"/>
           <prop k="size" v="3"/>
-          <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="size_unit" v="MM"/>
           <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" name="name" type="QString"/>
+              <Option name="properties"/>
+              <Option value="collection" name="type" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="0"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property value="display_name" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="-4.65661e-10">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory minimumSize="0" height="15" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="-4.65661e-10" penWidth="0" labelPlacementMethod="XHeight" opacity="1" width="15" sizeType="MM" enabled="0" lineSizeType="MM" penColor="#000000" maxScaleDenominator="1e+08" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" backgroundAlpha="255" penAlpha="255" barWidth="5" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0">
       <fontProperties description="MS Shell Dlg 2,7.5,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings dist="0" zIndex="0" placement="0" showAll="1" linePlacementFlags="2" priority="0" obstacle="0">
+    <properties>
+      <Option type="Map">
+        <Option value="" name="name" type="QString"/>
+        <Option name="properties"/>
+        <Option value="collection" name="type" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="classification">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="sewerage">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="start_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="lower_stop_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="upper_stop_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="capacity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="-1" name="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="0" name="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="3" name="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="4" name="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="5" name="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="1" name="1: Pump reacts only on suction side" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2: Pump reacts only on delivery side" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="storage_area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="id" field="pump_id"/>
+    <alias index="2" name="" field="display_name"/>
+    <alias index="3" name="" field="code"/>
+    <alias index="4" name="" field="classification"/>
+    <alias index="5" name="" field="sewerage"/>
+    <alias index="6" name="" field="start_level"/>
+    <alias index="7" name="" field="lower_stop_level"/>
+    <alias index="8" name="" field="upper_stop_level"/>
+    <alias index="9" name="" field="capacity"/>
+    <alias index="10" name="" field="zoom_category"/>
+    <alias index="11" name="" field="connection_node_start_id"/>
+    <alias index="12" name="" field="connection_node_end_id"/>
+    <alias index="13" name="" field="type"/>
+    <alias index="14" name="id" field="connection_node_id"/>
+    <alias index="15" name="" field="storage_area"/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform>.</editform>
+  <defaults>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" field="pump_id"/>
+    <default applyOnUpdate="0" expression="'new'" field="display_name"/>
+    <default applyOnUpdate="0" expression="'new'" field="code"/>
+    <default applyOnUpdate="0" expression="" field="classification"/>
+    <default applyOnUpdate="0" expression="" field="sewerage"/>
+    <default applyOnUpdate="0" expression="" field="start_level"/>
+    <default applyOnUpdate="0" expression="" field="lower_stop_level"/>
+    <default applyOnUpdate="0" expression="" field="upper_stop_level"/>
+    <default applyOnUpdate="0" expression="" field="capacity"/>
+    <default applyOnUpdate="0" expression="2" field="zoom_category"/>
+    <default applyOnUpdate="0" expression="'filled automatically'" field="connection_node_start_id"/>
+    <default applyOnUpdate="0" expression="'if you want to use an endpoint use v2_pumpstation_view'" field="connection_node_end_id"/>
+    <default applyOnUpdate="0" expression="1" field="type"/>
+    <default applyOnUpdate="0" expression="'filled automatically'" field="connection_node_id"/>
+    <default applyOnUpdate="0" expression="" field="storage_area"/>
+  </defaults>
+  <constraints>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="ROWID"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_id"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="display_name"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="code"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="classification"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="sewerage"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="start_level"/>
+    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="lower_stop_level"/>
+    <constraint exp_strength="2" constraints="4" unique_strength="0" notnull_strength="0" field="upper_stop_level"/>
+    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="capacity"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="zoom_category"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="connection_node_start_id"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="connection_node_end_id"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="type"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="connection_node_id"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="storage_area"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="ROWID"/>
+    <constraint desc="" exp="" field="pump_id"/>
+    <constraint desc="" exp="" field="display_name"/>
+    <constraint desc="" exp="" field="code"/>
+    <constraint desc="" exp="" field="classification"/>
+    <constraint desc="" exp="" field="sewerage"/>
+    <constraint desc="" exp="" field="start_level"/>
+    <constraint desc="" exp="&quot;lower_stop_level&quot;&lt;&quot;start_level&quot;" field="lower_stop_level"/>
+    <constraint desc="" exp="&quot;upper_stop_level&quot;>&quot;start_level&quot; or &quot;upper_stop_level&quot; is null&#xd;&#xa;" field="upper_stop_level"/>
+    <constraint desc="" exp="&quot;capacity&quot;>=0" field="capacity"/>
+    <constraint desc="" exp="" field="zoom_category"/>
+    <constraint desc="" exp="" field="connection_node_start_id"/>
+    <constraint desc="" exp="" field="connection_node_end_id"/>
+    <constraint desc="" exp="" field="type"/>
+    <constraint desc="" exp="" field="connection_node_id"/>
+    <constraint desc="" exp="" field="storage_area"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+    <columns>
+      <column hidden="0" name="ROWID" width="-1" type="field"/>
+      <column hidden="0" name="pump_id" width="-1" type="field"/>
+      <column hidden="0" name="display_name" width="-1" type="field"/>
+      <column hidden="0" name="code" width="-1" type="field"/>
+      <column hidden="0" name="classification" width="-1" type="field"/>
+      <column hidden="0" name="sewerage" width="-1" type="field"/>
+      <column hidden="0" name="start_level" width="-1" type="field"/>
+      <column hidden="0" name="lower_stop_level" width="-1" type="field"/>
+      <column hidden="0" name="upper_stop_level" width="-1" type="field"/>
+      <column hidden="0" name="capacity" width="-1" type="field"/>
+      <column hidden="0" name="zoom_category" width="-1" type="field"/>
+      <column hidden="0" name="connection_node_start_id" width="-1" type="field"/>
+      <column hidden="0" name="connection_node_end_id" width="-1" type="field"/>
+      <column hidden="0" name="type" width="-1" type="field"/>
+      <column hidden="0" name="connection_node_id" width="-1" type="field"/>
+      <column hidden="0" name="storage_area" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -294,11 +382,71 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" name="Pumpstation point view" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="1" name="pump_id"/>
+        <attributeEditorField showLabel="1" index="2" name="display_name"/>
+        <attributeEditorField showLabel="1" index="3" name="code"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="6" name="start_level"/>
+        <attributeEditorField showLabel="1" index="7" name="lower_stop_level"/>
+        <attributeEditorField showLabel="1" index="8" name="upper_stop_level"/>
+        <attributeEditorField showLabel="1" index="9" name="capacity"/>
+        <attributeEditorField showLabel="1" index="13" name="type"/>
+        <attributeEditorField showLabel="1" index="15" name="storage_area"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="5" name="sewerage"/>
+        <attributeEditorField showLabel="1" index="10" name="zoom_category"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Connection nodes" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="14" name="connection_node_id"/>
+        <attributeEditorField showLabel="1" index="11" name="connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="12" name="connection_node_end_id"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="ROWID" editable="1"/>
+    <field name="capacity" editable="1"/>
+    <field name="classification" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="connection_node_end_id" editable="0"/>
+    <field name="connection_node_id" editable="0"/>
+    <field name="connection_node_start_id" editable="0"/>
+    <field name="display_name" editable="1"/>
+    <field name="lower_stop_level" editable="1"/>
+    <field name="pump_id" editable="1"/>
+    <field name="sewerage" editable="1"/>
+    <field name="start_level" editable="1"/>
+    <field name="storage_area" editable="1"/>
+    <field name="type" editable="1"/>
+    <field name="upper_stop_level" editable="1"/>
+    <field name="zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="capacity" labelOnTop="0"/>
+    <field name="classification" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="connection_node_end_id" labelOnTop="0"/>
+    <field name="connection_node_id" labelOnTop="0"/>
+    <field name="connection_node_start_id" labelOnTop="0"/>
+    <field name="display_name" labelOnTop="0"/>
+    <field name="lower_stop_level" labelOnTop="0"/>
+    <field name="pump_id" labelOnTop="0"/>
+    <field name="sewerage" labelOnTop="0"/>
+    <field name="start_level" labelOnTop="0"/>
+    <field name="storage_area" labelOnTop="0"/>
+    <field name="type" labelOnTop="0"/>
+    <field name="upper_stop_level" labelOnTop="0"/>
+    <field name="zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_pumpstation_view.qml
+++ b/layer_styles/schematisation/v2_pumpstation_view.qml
@@ -1,53 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.6-Essen" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="ROWID">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="classification">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="start_level_suction_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="stop_level_suction_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="start_level_delivery_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="stop_level_delivery_side">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="capacity">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="manhole_start_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="manhole_end_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis maxScale="0" simplifyDrawingTol="1" simplifyLocal="1" readOnly="0" simplifyDrawingHints="1" version="3.4.5-Madeira" styleCategories="AllStyleCategories" minScale="1e+08" labelsEnabled="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol alpha="1" clip_to_extent="1" name="0" force_rhr="0" type="line">
+        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -56,250 +20,361 @@
           <prop k="line_width" v="0.8"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" name="name" type="QString"/>
+              <Option name="properties"/>
+              <Option value="collection" name="type" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="MarkerLine" locked="0">
+        <layer enabled="1" class="MarkerLine" pass="0" locked="0">
           <prop k="interval" v="0"/>
-          <prop k="interval_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="placement" v="centralpoint"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="rotate" v="1"/>
-          <symbol alpha="1" clip_to_extent="1" type="marker" name="@0@1">
-            <layer pass="0" class="SimpleMarker" locked="0">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" name="name" type="QString"/>
+              <Option name="properties"/>
+              <Option value="collection" name="type" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <symbol alpha="1" clip_to_extent="1" name="@0@1" force_rhr="0" type="marker">
+            <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
               <prop k="angle" v="90"/>
               <prop k="color" v="0,0,0,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
               <prop k="name" v="equilateral_triangle"/>
               <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="outline_color" v="0,0,0,255"/>
               <prop k="outline_style" v="solid"/>
               <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="outline_width_unit" v="MM"/>
               <prop k="scale_method" v="area"/>
               <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="size_unit" v="MM"/>
               <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="0">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory minimumSize="0" height="15" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="0" penWidth="0" labelPlacementMethod="XHeight" opacity="1" width="15" sizeType="MM" enabled="0" lineSizeType="MM" penColor="#000000" maxScaleDenominator="1e+08" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" backgroundAlpha="255" penAlpha="255" barWidth="5" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings dist="0" zIndex="0" placement="2" showAll="1" linePlacementFlags="2" priority="0" obstacle="0">
+    <properties>
+      <Option type="Map">
+        <Option value="" name="name" type="QString"/>
+        <Option name="properties"/>
+        <Option value="collection" name="type" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_classification">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="1" name="1: Pump reacts only on suction side" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2: Pump reacts only on delivery side" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_sewerage">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_start_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_lower_stop_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_upper_stop_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_capacity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option value="-1" name="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="0" name="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1" name="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2" name="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="3" name="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="4" name="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option value="5" name="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="pump_connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="id" field="pump_id"/>
+    <alias index="2" name="display_name" field="pump_display_name"/>
+    <alias index="3" name="code" field="pump_code"/>
+    <alias index="4" name="classification" field="pump_classification"/>
+    <alias index="5" name="type" field="pump_type"/>
+    <alias index="6" name="sewerage" field="pump_sewerage"/>
+    <alias index="7" name="start_level" field="pump_start_level"/>
+    <alias index="8" name="lower_stop_level" field="pump_lower_stop_level"/>
+    <alias index="9" name="upper_stop_level" field="pump_upper_stop_level"/>
+    <alias index="10" name="capacity" field="pump_capacity"/>
+    <alias index="11" name="zoom_category" field="pump_zoom_category"/>
+    <alias index="12" name="connection_node_start_id" field="pump_connection_node_start_id"/>
+    <alias index="13" name="connection_node_end_id" field="pump_connection_node_end_id"/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform>.</editform>
+  <defaults>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" field="pump_id"/>
+    <default applyOnUpdate="0" expression="'new'" field="pump_display_name"/>
+    <default applyOnUpdate="0" expression="'new'" field="pump_code"/>
+    <default applyOnUpdate="0" expression="" field="pump_classification"/>
+    <default applyOnUpdate="0" expression="1" field="pump_type"/>
+    <default applyOnUpdate="0" expression="" field="pump_sewerage"/>
+    <default applyOnUpdate="0" expression="" field="pump_start_level"/>
+    <default applyOnUpdate="0" expression="" field="pump_lower_stop_level"/>
+    <default applyOnUpdate="0" expression="" field="pump_upper_stop_level"/>
+    <default applyOnUpdate="0" expression="" field="pump_capacity"/>
+    <default applyOnUpdate="0" expression="2" field="pump_zoom_category"/>
+    <default applyOnUpdate="0" expression="'filled automatically'" field="pump_connection_node_start_id"/>
+    <default applyOnUpdate="0" expression="'filled automatically'" field="pump_connection_node_end_id"/>
+  </defaults>
+  <constraints>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="ROWID"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_id"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_display_name"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_code"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_classification"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_type"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_sewerage"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_start_level"/>
+    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="pump_lower_stop_level"/>
+    <constraint exp_strength="2" constraints="4" unique_strength="0" notnull_strength="0" field="pump_upper_stop_level"/>
+    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="pump_capacity"/>
+    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_zoom_category"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_start_id"/>
+    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_end_id"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="ROWID"/>
+    <constraint desc="" exp="" field="pump_id"/>
+    <constraint desc="" exp="" field="pump_display_name"/>
+    <constraint desc="" exp="" field="pump_code"/>
+    <constraint desc="" exp="" field="pump_classification"/>
+    <constraint desc="" exp="" field="pump_type"/>
+    <constraint desc="" exp="" field="pump_sewerage"/>
+    <constraint desc="" exp="" field="pump_start_level"/>
+    <constraint desc="" exp="&quot;pump_lower_stop_level&quot; &lt; &quot;pump_start_level&quot;" field="pump_lower_stop_level"/>
+    <constraint desc="" exp="&quot;pump_upper_stop_level&quot;>&quot;start_level&quot; or &quot;pump_upper_stop_level&quot; is null" field="pump_upper_stop_level"/>
+    <constraint desc="" exp="&quot;pump_capacity&quot;>=0" field="pump_capacity"/>
+    <constraint desc="" exp="" field="pump_zoom_category"/>
+    <constraint desc="" exp="" field="pump_connection_node_start_id"/>
+    <constraint desc="" exp="" field="pump_connection_node_end_id"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+    <columns>
+      <column hidden="0" name="ROWID" width="-1" type="field"/>
+      <column hidden="0" name="pump_id" width="-1" type="field"/>
+      <column hidden="0" name="pump_display_name" width="-1" type="field"/>
+      <column hidden="0" name="pump_code" width="-1" type="field"/>
+      <column hidden="0" name="pump_classification" width="-1" type="field"/>
+      <column hidden="0" name="pump_type" width="-1" type="field"/>
+      <column hidden="0" name="pump_sewerage" width="-1" type="field"/>
+      <column hidden="0" name="pump_start_level" width="-1" type="field"/>
+      <column hidden="0" name="pump_lower_stop_level" width="-1" type="field"/>
+      <column hidden="0" name="pump_upper_stop_level" width="-1" type="field"/>
+      <column hidden="0" name="pump_capacity" width="-1" type="field"/>
+      <column hidden="0" name="pump_zoom_category" width="-1" type="field"/>
+      <column hidden="0" name="pump_connection_node_start_id" width="-1" type="field"/>
+      <column hidden="0" name="pump_connection_node_end_id" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -319,11 +394,65 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" name="Pumpstation view" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="1" name="pump_id"/>
+        <attributeEditorField showLabel="1" index="2" name="pump_display_name"/>
+        <attributeEditorField showLabel="1" index="3" name="pump_code"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="7" name="pump_start_level"/>
+        <attributeEditorField showLabel="1" index="8" name="pump_lower_stop_level"/>
+        <attributeEditorField showLabel="1" index="9" name="pump_upper_stop_level"/>
+        <attributeEditorField showLabel="1" index="10" name="pump_capacity"/>
+        <attributeEditorField showLabel="1" index="5" name="pump_type"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="6" name="pump_sewerage"/>
+        <attributeEditorField showLabel="1" index="11" name="pump_zoom_category"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" name="Connection nodes" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
+        <attributeEditorField showLabel="1" index="12" name="pump_connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="13" name="pump_connection_node_end_id"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="ROWID" editable="1"/>
+    <field name="pump_capacity" editable="1"/>
+    <field name="pump_classification" editable="1"/>
+    <field name="pump_code" editable="1"/>
+    <field name="pump_connection_node_end_id" editable="0"/>
+    <field name="pump_connection_node_start_id" editable="0"/>
+    <field name="pump_display_name" editable="1"/>
+    <field name="pump_id" editable="1"/>
+    <field name="pump_lower_stop_level" editable="1"/>
+    <field name="pump_sewerage" editable="1"/>
+    <field name="pump_start_level" editable="1"/>
+    <field name="pump_type" editable="1"/>
+    <field name="pump_upper_stop_level" editable="1"/>
+    <field name="pump_zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="pump_capacity" labelOnTop="0"/>
+    <field name="pump_classification" labelOnTop="0"/>
+    <field name="pump_code" labelOnTop="0"/>
+    <field name="pump_connection_node_end_id" labelOnTop="0"/>
+    <field name="pump_connection_node_start_id" labelOnTop="0"/>
+    <field name="pump_display_name" labelOnTop="0"/>
+    <field name="pump_id" labelOnTop="0"/>
+    <field name="pump_lower_stop_level" labelOnTop="0"/>
+    <field name="pump_sewerage" labelOnTop="0"/>
+    <field name="pump_start_level" labelOnTop="0"/>
+    <field name="pump_type" labelOnTop="0"/>
+    <field name="pump_upper_stop_level" labelOnTop="0"/>
+    <field name="pump_zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>ROWID</previewExpression>
+  <mapTip>display_name</mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_pumpstation_view.qml
+++ b/layer_styles/schematisation/v2_pumpstation_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis version="3.4.5-Madeira" labelsEnabled="0" styleCategories="AllStyleCategories" simplifyLocal="1" simplifyMaxScale="1" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" maxScale="0" readOnly="0" minScale="1e+08">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+      <symbol type="line" name="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <layer enabled="1" locked="0" pass="0" class="MarkerLine">
           <prop k="interval" v="0"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
-          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
-            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <symbol type="marker" name="@0@1" force_rhr="0" alpha="1" clip_to_extent="1">
+            <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
               <prop k="angle" v="90"/>
               <prop k="color" v="0,0,0,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" type="QString" name="name"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option value="collection" type="QString" name="type"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -89,9 +89,7 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="dualview/previewExpressions">
-      <value>ROWID</value>
-    </property>
+    <property value="ROWID" key="dualview/previewExpressions"/>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
@@ -99,18 +97,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory scaleBasedVisibility="0" sizeType="MM" lineSizeType="MM" diagramOrientation="Up" barWidth="5" maxScaleDenominator="1e+08" labelPlacementMethod="XHeight" width="15" penAlpha="255" backgroundAlpha="255" penColor="#000000" penWidth="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" minimumSize="0" rotationOffset="270" minScaleDenominator="0" opacity="1" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0" enabled="0" height="15">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
+  <DiagramLayerSettings zIndex="0" obstacle="0" showAll="1" priority="0" placement="2" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option type="QString" name="name" value=""/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option type="QString" name="type" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -130,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -140,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -150,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -160,8 +158,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -172,10 +170,10 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: pump reacts only on suction side"/>
+                <Option type="QString" name="1: pump reacts only on suction side" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: pump reacts only on delivery side"/>
+                <Option type="QString" name="2: pump reacts only on delivery side" value="2"/>
               </Option>
             </Option>
           </Option>
@@ -186,8 +184,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="1" type="QString" name="CheckedState"/>
-            <Option value="0" type="QString" name="UncheckedState"/>
+            <Option type="QString" name="CheckedState" value="1"/>
+            <Option type="QString" name="UncheckedState" value="0"/>
           </Option>
         </config>
       </editWidget>
@@ -196,8 +194,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -206,8 +204,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -216,8 +214,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -226,8 +224,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -238,25 +236,25 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="-1" type="QString" name="-1"/>
+                <Option type="QString" name="-1" value="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" type="QString" name="0"/>
+                <Option type="QString" name="0" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1"/>
+                <Option type="QString" name="1" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2"/>
+                <Option type="QString" name="2" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3"/>
+                <Option type="QString" name="3" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4"/>
+                <Option type="QString" name="4" value="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5"/>
+                <Option type="QString" name="5" value="5"/>
               </Option>
             </Option>
           </Option>
@@ -267,8 +265,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -277,8 +275,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -303,74 +301,74 @@
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" applyOnUpdate="0" field="pump_id"/>
-    <default expression="'new'" applyOnUpdate="0" field="pump_display_name"/>
-    <default expression="'new'" applyOnUpdate="0" field="pump_code"/>
-    <default expression="" applyOnUpdate="0" field="pump_classification"/>
-    <default expression="1" applyOnUpdate="0" field="pump_type"/>
-    <default expression="" applyOnUpdate="0" field="pump_sewerage"/>
-    <default expression="" applyOnUpdate="0" field="pump_start_level"/>
-    <default expression="" applyOnUpdate="0" field="pump_lower_stop_level"/>
-    <default expression="" applyOnUpdate="0" field="pump_upper_stop_level"/>
-    <default expression="" applyOnUpdate="0" field="pump_capacity"/>
-    <default expression="2" applyOnUpdate="0" field="pump_zoom_category"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="pump_connection_node_start_id"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="pump_connection_node_end_id"/>
+    <default field="ROWID" applyOnUpdate="0" expression=""/>
+    <default field="pump_id" applyOnUpdate="0" expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)"/>
+    <default field="pump_display_name" applyOnUpdate="0" expression="'new'"/>
+    <default field="pump_code" applyOnUpdate="0" expression="'new'"/>
+    <default field="pump_classification" applyOnUpdate="0" expression=""/>
+    <default field="pump_type" applyOnUpdate="0" expression="1"/>
+    <default field="pump_sewerage" applyOnUpdate="0" expression=""/>
+    <default field="pump_start_level" applyOnUpdate="0" expression=""/>
+    <default field="pump_lower_stop_level" applyOnUpdate="0" expression=""/>
+    <default field="pump_upper_stop_level" applyOnUpdate="0" expression=""/>
+    <default field="pump_capacity" applyOnUpdate="0" expression=""/>
+    <default field="pump_zoom_category" applyOnUpdate="0" expression="2"/>
+    <default field="pump_connection_node_start_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))"/>
+    <default field="pump_connection_node_end_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_classification"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_sewerage"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_start_level"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="pump_lower_stop_level"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="0" constraints="4" field="pump_upper_stop_level"/>
-    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="pump_capacity"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_connection_node_start_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_connection_node_end_id"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_id" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_display_name" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_code" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_classification" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_type" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_sewerage" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_start_level" exp_strength="0"/>
+    <constraint constraints="5" unique_strength="0" notnull_strength="2" field="pump_lower_stop_level" exp_strength="2"/>
+    <constraint constraints="4" unique_strength="0" notnull_strength="0" field="pump_upper_stop_level" exp_strength="2"/>
+    <constraint constraints="5" unique_strength="0" notnull_strength="2" field="pump_capacity" exp_strength="2"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_zoom_category" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_start_id" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_end_id" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="pump_id"/>
-    <constraint exp="" desc="" field="pump_display_name"/>
-    <constraint exp="" desc="" field="pump_code"/>
-    <constraint exp="" desc="" field="pump_classification"/>
-    <constraint exp="" desc="" field="pump_type"/>
-    <constraint exp="" desc="" field="pump_sewerage"/>
-    <constraint exp="" desc="" field="pump_start_level"/>
-    <constraint exp="&quot;pump_lower_stop_level&quot; &lt; &quot;pump_start_level&quot;" desc="" field="pump_lower_stop_level"/>
-    <constraint exp="&quot;pump_upper_stop_level&quot;>&quot;start_level&quot; or &quot;pump_upper_stop_level&quot; is null" desc="" field="pump_upper_stop_level"/>
-    <constraint exp="&quot;pump_capacity&quot;>=0" desc="" field="pump_capacity"/>
-    <constraint exp="" desc="" field="pump_zoom_category"/>
-    <constraint exp="" desc="" field="pump_connection_node_start_id"/>
-    <constraint exp="" desc="" field="pump_connection_node_end_id"/>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="pump_id" desc=""/>
+    <constraint exp="" field="pump_display_name" desc=""/>
+    <constraint exp="" field="pump_code" desc=""/>
+    <constraint exp="" field="pump_classification" desc=""/>
+    <constraint exp="" field="pump_type" desc=""/>
+    <constraint exp="" field="pump_sewerage" desc=""/>
+    <constraint exp="" field="pump_start_level" desc=""/>
+    <constraint exp="&quot;pump_lower_stop_level&quot; &lt; &quot;pump_start_level&quot;" field="pump_lower_stop_level" desc=""/>
+    <constraint exp="&quot;pump_upper_stop_level&quot;>&quot;start_level&quot; or &quot;pump_upper_stop_level&quot; is null" field="pump_upper_stop_level" desc=""/>
+    <constraint exp="&quot;pump_capacity&quot;>=0" field="pump_capacity" desc=""/>
+    <constraint exp="" field="pump_zoom_category" desc=""/>
+    <constraint exp="" field="pump_connection_node_start_id" desc=""/>
+    <constraint exp="" field="pump_connection_node_end_id" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="ROWID"/>
-      <column width="-1" type="field" hidden="0" name="pump_id"/>
-      <column width="-1" type="field" hidden="0" name="pump_display_name"/>
-      <column width="-1" type="field" hidden="0" name="pump_code"/>
-      <column width="-1" type="field" hidden="0" name="pump_classification"/>
-      <column width="-1" type="field" hidden="0" name="pump_type"/>
-      <column width="-1" type="field" hidden="0" name="pump_sewerage"/>
-      <column width="-1" type="field" hidden="0" name="pump_start_level"/>
-      <column width="-1" type="field" hidden="0" name="pump_lower_stop_level"/>
-      <column width="-1" type="field" hidden="0" name="pump_upper_stop_level"/>
-      <column width="-1" type="field" hidden="0" name="pump_capacity"/>
-      <column width="-1" type="field" hidden="0" name="pump_zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="pump_connection_node_start_id"/>
-      <column width="-1" type="field" hidden="0" name="pump_connection_node_end_id"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column type="field" name="ROWID" width="-1" hidden="0"/>
+      <column type="field" name="pump_id" width="-1" hidden="0"/>
+      <column type="field" name="pump_display_name" width="-1" hidden="0"/>
+      <column type="field" name="pump_code" width="-1" hidden="0"/>
+      <column type="field" name="pump_classification" width="-1" hidden="0"/>
+      <column type="field" name="pump_type" width="-1" hidden="0"/>
+      <column type="field" name="pump_sewerage" width="-1" hidden="0"/>
+      <column type="field" name="pump_start_level" width="-1" hidden="0"/>
+      <column type="field" name="pump_lower_stop_level" width="-1" hidden="0"/>
+      <column type="field" name="pump_upper_stop_level" width="-1" hidden="0"/>
+      <column type="field" name="pump_capacity" width="-1" hidden="0"/>
+      <column type="field" name="pump_zoom_category" width="-1" hidden="0"/>
+      <column type="field" name="pump_connection_node_start_id" width="-1" hidden="0"/>
+      <column type="field" name="pump_connection_node_end_id" width="-1" hidden="0"/>
+      <column type="actions" width="-1" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -399,26 +397,26 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Pumpstation view" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-        <attributeEditorField showLabel="1" name="pump_id" index="1"/>
-        <attributeEditorField showLabel="1" name="pump_display_name" index="2"/>
-        <attributeEditorField showLabel="1" name="pump_code" index="3"/>
+    <attributeEditorContainer columnCount="1" visibilityExpression="" name="Pumpstation view" groupBox="0" visibilityExpressionEnabled="0" showLabel="1">
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="pump_id" index="1" showLabel="1"/>
+        <attributeEditorField name="pump_display_name" index="2" showLabel="1"/>
+        <attributeEditorField name="pump_code" index="3" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
-        <attributeEditorField showLabel="1" name="pump_start_level" index="7"/>
-        <attributeEditorField showLabel="1" name="pump_lower_stop_level" index="8"/>
-        <attributeEditorField showLabel="1" name="pump_upper_stop_level" index="9"/>
-        <attributeEditorField showLabel="1" name="pump_capacity" index="10"/>
-        <attributeEditorField showLabel="1" name="pump_type" index="5"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="pump_start_level" index="7" showLabel="1"/>
+        <attributeEditorField name="pump_lower_stop_level" index="8" showLabel="1"/>
+        <attributeEditorField name="pump_upper_stop_level" index="9" showLabel="1"/>
+        <attributeEditorField name="pump_capacity" index="10" showLabel="1"/>
+        <attributeEditorField name="pump_type" index="5" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
-        <attributeEditorField showLabel="1" name="pump_sewerage" index="6"/>
-        <attributeEditorField showLabel="1" name="pump_zoom_category" index="11"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="pump_sewerage" index="6" showLabel="1"/>
+        <attributeEditorField name="pump_zoom_category" index="11" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
-        <attributeEditorField showLabel="1" name="pump_connection_node_start_id" index="12"/>
-        <attributeEditorField showLabel="1" name="pump_connection_node_end_id" index="13"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Connection nodes" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="pump_connection_node_start_id" index="12" showLabel="1"/>
+        <attributeEditorField name="pump_connection_node_end_id" index="13" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_pumpstation_view.qml
+++ b/layer_styles/schematisation/v2_pumpstation_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis maxScale="0" simplifyDrawingTol="1" simplifyLocal="1" readOnly="0" simplifyDrawingHints="1" version="3.4.5-Madeira" styleCategories="AllStyleCategories" minScale="1e+08" labelsEnabled="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" name="0" force_rhr="0" type="line">
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" class="MarkerLine" pass="0" locked="0">
+        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
           <prop k="interval" v="0"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" clip_to_extent="1" name="@0@1" force_rhr="0" type="marker">
-            <layer enabled="1" class="SimpleMarker" pass="0" locked="0">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
+            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
               <prop k="angle" v="90"/>
               <prop k="color" v="0,0,0,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -89,6 +89,9 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
+    <property key="dualview/previewExpressions">
+      <value>ROWID</value>
+    </property>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
@@ -96,22 +99,22 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory minimumSize="0" height="15" scaleDependency="Area" scaleBasedVisibility="0" minScaleDenominator="0" penWidth="0" labelPlacementMethod="XHeight" opacity="1" width="15" sizeType="MM" enabled="0" lineSizeType="MM" penColor="#000000" maxScaleDenominator="1e+08" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" backgroundAlpha="255" penAlpha="255" barWidth="5" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" color="#000000" field=""/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" zIndex="0" placement="2" showAll="1" linePlacementFlags="2" priority="0" obstacle="0">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -127,8 +130,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -137,8 +140,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -147,8 +150,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -157,8 +160,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -167,12 +170,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="1" name="1: Pump reacts only on suction side" type="QString"/>
+                <Option value="1" type="QString" name="1: pump reacts only on suction side"/>
               </Option>
               <Option type="Map">
-                <Option value="2" name="2: Pump reacts only on delivery side" type="QString"/>
+                <Option value="2" type="QString" name="2: pump reacts only on delivery side"/>
               </Option>
             </Option>
           </Option>
@@ -183,8 +186,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="1" name="CheckedState" type="QString"/>
-            <Option value="0" name="UncheckedState" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -193,8 +196,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -203,8 +206,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -213,8 +216,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -223,8 +226,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -233,27 +236,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option value="-1" name="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" name="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" name="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" name="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" name="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" name="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" name="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -264,8 +267,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -274,100 +277,100 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="ROWID"/>
-    <alias index="1" name="id" field="pump_id"/>
-    <alias index="2" name="display_name" field="pump_display_name"/>
-    <alias index="3" name="code" field="pump_code"/>
-    <alias index="4" name="classification" field="pump_classification"/>
-    <alias index="5" name="type" field="pump_type"/>
-    <alias index="6" name="sewerage" field="pump_sewerage"/>
-    <alias index="7" name="start_level" field="pump_start_level"/>
-    <alias index="8" name="lower_stop_level" field="pump_lower_stop_level"/>
-    <alias index="9" name="upper_stop_level" field="pump_upper_stop_level"/>
-    <alias index="10" name="capacity" field="pump_capacity"/>
-    <alias index="11" name="zoom_category" field="pump_zoom_category"/>
-    <alias index="12" name="connection_node_start_id" field="pump_connection_node_start_id"/>
-    <alias index="13" name="connection_node_end_id" field="pump_connection_node_end_id"/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="id" field="pump_id" index="1"/>
+    <alias name="display_name" field="pump_display_name" index="2"/>
+    <alias name="code" field="pump_code" index="3"/>
+    <alias name="classification" field="pump_classification" index="4"/>
+    <alias name="type" field="pump_type" index="5"/>
+    <alias name="sewerage" field="pump_sewerage" index="6"/>
+    <alias name="start_level" field="pump_start_level" index="7"/>
+    <alias name="lower_stop_level" field="pump_lower_stop_level" index="8"/>
+    <alias name="upper_stop_level" field="pump_upper_stop_level" index="9"/>
+    <alias name="capacity" field="pump_capacity" index="10"/>
+    <alias name="zoom_category" field="pump_zoom_category" index="11"/>
+    <alias name="connection_node_start_id" field="pump_connection_node_start_id" index="12"/>
+    <alias name="connection_node_end_id" field="pump_connection_node_end_id" index="13"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" expression="" field="ROWID"/>
-    <default applyOnUpdate="0" expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" field="pump_id"/>
-    <default applyOnUpdate="0" expression="'new'" field="pump_display_name"/>
-    <default applyOnUpdate="0" expression="'new'" field="pump_code"/>
-    <default applyOnUpdate="0" expression="" field="pump_classification"/>
-    <default applyOnUpdate="0" expression="1" field="pump_type"/>
-    <default applyOnUpdate="0" expression="" field="pump_sewerage"/>
-    <default applyOnUpdate="0" expression="" field="pump_start_level"/>
-    <default applyOnUpdate="0" expression="" field="pump_lower_stop_level"/>
-    <default applyOnUpdate="0" expression="" field="pump_upper_stop_level"/>
-    <default applyOnUpdate="0" expression="" field="pump_capacity"/>
-    <default applyOnUpdate="0" expression="2" field="pump_zoom_category"/>
-    <default applyOnUpdate="0" expression="'filled automatically'" field="pump_connection_node_start_id"/>
-    <default applyOnUpdate="0" expression="'filled automatically'" field="pump_connection_node_end_id"/>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" applyOnUpdate="0" field="pump_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="pump_display_name"/>
+    <default expression="'new'" applyOnUpdate="0" field="pump_code"/>
+    <default expression="" applyOnUpdate="0" field="pump_classification"/>
+    <default expression="1" applyOnUpdate="0" field="pump_type"/>
+    <default expression="" applyOnUpdate="0" field="pump_sewerage"/>
+    <default expression="" applyOnUpdate="0" field="pump_start_level"/>
+    <default expression="" applyOnUpdate="0" field="pump_lower_stop_level"/>
+    <default expression="" applyOnUpdate="0" field="pump_upper_stop_level"/>
+    <default expression="" applyOnUpdate="0" field="pump_capacity"/>
+    <default expression="2" applyOnUpdate="0" field="pump_zoom_category"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="pump_connection_node_start_id"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="pump_connection_node_end_id"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="ROWID"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_id"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_display_name"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_code"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_classification"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_type"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_sewerage"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_start_level"/>
-    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="pump_lower_stop_level"/>
-    <constraint exp_strength="2" constraints="4" unique_strength="0" notnull_strength="0" field="pump_upper_stop_level"/>
-    <constraint exp_strength="2" constraints="5" unique_strength="0" notnull_strength="2" field="pump_capacity"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" notnull_strength="2" field="pump_zoom_category"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_start_id"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_classification"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_sewerage"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_start_level"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="pump_lower_stop_level"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="0" constraints="4" field="pump_upper_stop_level"/>
+    <constraint exp_strength="2" unique_strength="0" notnull_strength="2" constraints="5" field="pump_capacity"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="pump_zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="pump_connection_node_end_id"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" exp="" field="ROWID"/>
-    <constraint desc="" exp="" field="pump_id"/>
-    <constraint desc="" exp="" field="pump_display_name"/>
-    <constraint desc="" exp="" field="pump_code"/>
-    <constraint desc="" exp="" field="pump_classification"/>
-    <constraint desc="" exp="" field="pump_type"/>
-    <constraint desc="" exp="" field="pump_sewerage"/>
-    <constraint desc="" exp="" field="pump_start_level"/>
-    <constraint desc="" exp="&quot;pump_lower_stop_level&quot; &lt; &quot;pump_start_level&quot;" field="pump_lower_stop_level"/>
-    <constraint desc="" exp="&quot;pump_upper_stop_level&quot;>&quot;start_level&quot; or &quot;pump_upper_stop_level&quot; is null" field="pump_upper_stop_level"/>
-    <constraint desc="" exp="&quot;pump_capacity&quot;>=0" field="pump_capacity"/>
-    <constraint desc="" exp="" field="pump_zoom_category"/>
-    <constraint desc="" exp="" field="pump_connection_node_start_id"/>
-    <constraint desc="" exp="" field="pump_connection_node_end_id"/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="pump_id"/>
+    <constraint exp="" desc="" field="pump_display_name"/>
+    <constraint exp="" desc="" field="pump_code"/>
+    <constraint exp="" desc="" field="pump_classification"/>
+    <constraint exp="" desc="" field="pump_type"/>
+    <constraint exp="" desc="" field="pump_sewerage"/>
+    <constraint exp="" desc="" field="pump_start_level"/>
+    <constraint exp="&quot;pump_lower_stop_level&quot; &lt; &quot;pump_start_level&quot;" desc="" field="pump_lower_stop_level"/>
+    <constraint exp="&quot;pump_upper_stop_level&quot;>&quot;start_level&quot; or &quot;pump_upper_stop_level&quot; is null" desc="" field="pump_upper_stop_level"/>
+    <constraint exp="&quot;pump_capacity&quot;>=0" desc="" field="pump_capacity"/>
+    <constraint exp="" desc="" field="pump_zoom_category"/>
+    <constraint exp="" desc="" field="pump_connection_node_start_id"/>
+    <constraint exp="" desc="" field="pump_connection_node_end_id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column hidden="0" name="ROWID" width="-1" type="field"/>
-      <column hidden="0" name="pump_id" width="-1" type="field"/>
-      <column hidden="0" name="pump_display_name" width="-1" type="field"/>
-      <column hidden="0" name="pump_code" width="-1" type="field"/>
-      <column hidden="0" name="pump_classification" width="-1" type="field"/>
-      <column hidden="0" name="pump_type" width="-1" type="field"/>
-      <column hidden="0" name="pump_sewerage" width="-1" type="field"/>
-      <column hidden="0" name="pump_start_level" width="-1" type="field"/>
-      <column hidden="0" name="pump_lower_stop_level" width="-1" type="field"/>
-      <column hidden="0" name="pump_upper_stop_level" width="-1" type="field"/>
-      <column hidden="0" name="pump_capacity" width="-1" type="field"/>
-      <column hidden="0" name="pump_zoom_category" width="-1" type="field"/>
-      <column hidden="0" name="pump_connection_node_start_id" width="-1" type="field"/>
-      <column hidden="0" name="pump_connection_node_end_id" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="pump_id"/>
+      <column width="-1" type="field" hidden="0" name="pump_display_name"/>
+      <column width="-1" type="field" hidden="0" name="pump_code"/>
+      <column width="-1" type="field" hidden="0" name="pump_classification"/>
+      <column width="-1" type="field" hidden="0" name="pump_type"/>
+      <column width="-1" type="field" hidden="0" name="pump_sewerage"/>
+      <column width="-1" type="field" hidden="0" name="pump_start_level"/>
+      <column width="-1" type="field" hidden="0" name="pump_lower_stop_level"/>
+      <column width="-1" type="field" hidden="0" name="pump_upper_stop_level"/>
+      <column width="-1" type="field" hidden="0" name="pump_capacity"/>
+      <column width="-1" type="field" hidden="0" name="pump_zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="pump_connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="pump_connection_node_end_id"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -396,26 +399,26 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="Pumpstation view" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
-      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="1" name="pump_id"/>
-        <attributeEditorField showLabel="1" index="2" name="pump_display_name"/>
-        <attributeEditorField showLabel="1" index="3" name="pump_code"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Pumpstation view" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="pump_id" index="1"/>
+        <attributeEditorField showLabel="1" name="pump_display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="pump_code" index="3"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="7" name="pump_start_level"/>
-        <attributeEditorField showLabel="1" index="8" name="pump_lower_stop_level"/>
-        <attributeEditorField showLabel="1" index="9" name="pump_upper_stop_level"/>
-        <attributeEditorField showLabel="1" index="10" name="pump_capacity"/>
-        <attributeEditorField showLabel="1" index="5" name="pump_type"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="pump_start_level" index="7"/>
+        <attributeEditorField showLabel="1" name="pump_lower_stop_level" index="8"/>
+        <attributeEditorField showLabel="1" name="pump_upper_stop_level" index="9"/>
+        <attributeEditorField showLabel="1" name="pump_capacity" index="10"/>
+        <attributeEditorField showLabel="1" name="pump_type" index="5"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="6" name="pump_sewerage"/>
-        <attributeEditorField showLabel="1" index="11" name="pump_zoom_category"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="pump_sewerage" index="6"/>
+        <attributeEditorField showLabel="1" name="pump_zoom_category" index="11"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Connection nodes" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-        <attributeEditorField showLabel="1" index="12" name="pump_connection_node_start_id"/>
-        <attributeEditorField showLabel="1" index="13" name="pump_connection_node_end_id"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="pump_connection_node_start_id" index="12"/>
+        <attributeEditorField showLabel="1" name="pump_connection_node_end_id" index="13"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -436,20 +439,20 @@ def my_form_open(dialog, layer, feature):
     <field name="pump_zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="pump_capacity" labelOnTop="0"/>
-    <field name="pump_classification" labelOnTop="0"/>
-    <field name="pump_code" labelOnTop="0"/>
-    <field name="pump_connection_node_end_id" labelOnTop="0"/>
-    <field name="pump_connection_node_start_id" labelOnTop="0"/>
-    <field name="pump_display_name" labelOnTop="0"/>
-    <field name="pump_id" labelOnTop="0"/>
-    <field name="pump_lower_stop_level" labelOnTop="0"/>
-    <field name="pump_sewerage" labelOnTop="0"/>
-    <field name="pump_start_level" labelOnTop="0"/>
-    <field name="pump_type" labelOnTop="0"/>
-    <field name="pump_upper_stop_level" labelOnTop="0"/>
-    <field name="pump_zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="pump_capacity"/>
+    <field labelOnTop="0" name="pump_classification"/>
+    <field labelOnTop="0" name="pump_code"/>
+    <field labelOnTop="0" name="pump_connection_node_end_id"/>
+    <field labelOnTop="0" name="pump_connection_node_start_id"/>
+    <field labelOnTop="0" name="pump_display_name"/>
+    <field labelOnTop="0" name="pump_id"/>
+    <field labelOnTop="0" name="pump_lower_stop_level"/>
+    <field labelOnTop="0" name="pump_sewerage"/>
+    <field labelOnTop="0" name="pump_start_level"/>
+    <field labelOnTop="0" name="pump_type"/>
+    <field labelOnTop="0" name="pump_upper_stop_level"/>
+    <field labelOnTop="0" name="pump_zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>ROWID</previewExpression>

--- a/layer_styles/schematisation/v2_pumpstation_view.qml
+++ b/layer_styles/schematisation/v2_pumpstation_view.qml
@@ -1,13 +1,13 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.4.5-Madeira" labelsEnabled="0" styleCategories="AllStyleCategories" simplifyLocal="1" simplifyMaxScale="1" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" maxScale="0" readOnly="0" minScale="1e+08">
+<qgis maxScale="0" labelsEnabled="0" readOnly="0" version="3.4.11-Madeira" simplifyMaxScale="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" simplifyAlgorithm="0" minScale="1e+8" simplifyDrawingTol="1" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol type="line" name="0" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol clip_to_extent="1" alpha="1" name="0" type="line" force_rhr="0">
         <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="0"/>
@@ -27,9 +27,9 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -48,12 +48,12 @@
           <prop k="rotate" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol type="marker" name="@0@1" force_rhr="0" alpha="1" clip_to_extent="1">
+          <symbol clip_to_extent="1" alpha="1" name="@0@1" type="marker" force_rhr="0">
             <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
               <prop k="angle" v="90"/>
               <prop k="color" v="0,0,0,255"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -97,22 +97,22 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory scaleBasedVisibility="0" sizeType="MM" lineSizeType="MM" diagramOrientation="Up" barWidth="5" maxScaleDenominator="1e+08" labelPlacementMethod="XHeight" width="15" penAlpha="255" backgroundAlpha="255" penColor="#000000" penWidth="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" minimumSize="0" rotationOffset="270" minScaleDenominator="0" opacity="1" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0" enabled="0" height="15">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" barWidth="5" backgroundColor="#ffffff" height="15" enabled="0" lineSizeType="MM" width="15" labelPlacementMethod="XHeight" backgroundAlpha="255" scaleDependency="Area" rotationOffset="270" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" penAlpha="255" penColor="#000000" minScaleDenominator="0" lineSizeScale="3x:0,0,0,0,0,0" sizeType="MM" scaleBasedVisibility="0" minimumSize="0" maxScaleDenominator="1e+8">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute label="" color="#000000" field=""/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings zIndex="0" obstacle="0" showAll="1" priority="0" placement="2" dist="0" linePlacementFlags="2">
+  <DiagramLayerSettings showAll="1" zIndex="0" placement="2" priority="0" obstacle="0" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option type="QString" name="name" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option type="QString" name="type" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -128,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -138,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -148,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -158,8 +158,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -168,12 +168,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" name="1: pump reacts only on suction side" value="1"/>
+                <Option value="1" name="1: Pump behaviour is based on water levels on the suction-side of the pump" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="2: pump reacts only on delivery side" value="2"/>
+                <Option value="2" name="2: Pump behaviour is based on water levels on the delivery-side of the pump" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -184,8 +184,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option type="QString" name="CheckedState" value="1"/>
-            <Option type="QString" name="UncheckedState" value="0"/>
+            <Option value="1" name="CheckedState" type="QString"/>
+            <Option value="0" name="UncheckedState" type="QString"/>
           </Option>
         </config>
       </editWidget>
@@ -194,8 +194,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -204,8 +204,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -214,8 +214,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -224,8 +224,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -234,27 +234,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" name="-1" value="-1"/>
+                <Option value="-1" name="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="0" value="0"/>
+                <Option value="0" name="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="1" value="1"/>
+                <Option value="1" name="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="2" value="2"/>
+                <Option value="2" name="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="3" value="3"/>
+                <Option value="3" name="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="4" value="4"/>
+                <Option value="4" name="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="5" value="5"/>
+                <Option value="5" name="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -265,8 +265,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -275,78 +275,78 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="ROWID" index="0"/>
-    <alias name="id" field="pump_id" index="1"/>
-    <alias name="display_name" field="pump_display_name" index="2"/>
-    <alias name="code" field="pump_code" index="3"/>
-    <alias name="classification" field="pump_classification" index="4"/>
-    <alias name="type" field="pump_type" index="5"/>
-    <alias name="sewerage" field="pump_sewerage" index="6"/>
-    <alias name="start_level" field="pump_start_level" index="7"/>
-    <alias name="lower_stop_level" field="pump_lower_stop_level" index="8"/>
-    <alias name="upper_stop_level" field="pump_upper_stop_level" index="9"/>
-    <alias name="capacity" field="pump_capacity" index="10"/>
-    <alias name="zoom_category" field="pump_zoom_category" index="11"/>
-    <alias name="connection_node_start_id" field="pump_connection_node_start_id" index="12"/>
-    <alias name="connection_node_end_id" field="pump_connection_node_end_id" index="13"/>
+    <alias index="0" name="" field="ROWID"/>
+    <alias index="1" name="id" field="pump_id"/>
+    <alias index="2" name="display_name" field="pump_display_name"/>
+    <alias index="3" name="code" field="pump_code"/>
+    <alias index="4" name="classification" field="pump_classification"/>
+    <alias index="5" name="type" field="pump_type"/>
+    <alias index="6" name="sewerage" field="pump_sewerage"/>
+    <alias index="7" name="start_level" field="pump_start_level"/>
+    <alias index="8" name="lower_stop_level" field="pump_lower_stop_level"/>
+    <alias index="9" name="upper_stop_level" field="pump_upper_stop_level"/>
+    <alias index="10" name="capacity" field="pump_capacity"/>
+    <alias index="11" name="zoom_category" field="pump_zoom_category"/>
+    <alias index="12" name="connection_node_start_id" field="pump_connection_node_start_id"/>
+    <alias index="13" name="connection_node_end_id" field="pump_connection_node_end_id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default field="ROWID" applyOnUpdate="0" expression=""/>
-    <default field="pump_id" applyOnUpdate="0" expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)"/>
-    <default field="pump_display_name" applyOnUpdate="0" expression="'new'"/>
-    <default field="pump_code" applyOnUpdate="0" expression="'new'"/>
-    <default field="pump_classification" applyOnUpdate="0" expression=""/>
-    <default field="pump_type" applyOnUpdate="0" expression="1"/>
-    <default field="pump_sewerage" applyOnUpdate="0" expression=""/>
-    <default field="pump_start_level" applyOnUpdate="0" expression=""/>
-    <default field="pump_lower_stop_level" applyOnUpdate="0" expression=""/>
-    <default field="pump_upper_stop_level" applyOnUpdate="0" expression=""/>
-    <default field="pump_capacity" applyOnUpdate="0" expression=""/>
-    <default field="pump_zoom_category" applyOnUpdate="0" expression="2"/>
-    <default field="pump_connection_node_start_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))"/>
-    <default field="pump_connection_node_end_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))"/>
+    <default applyOnUpdate="0" expression="" field="ROWID"/>
+    <default applyOnUpdate="0" expression="if(maximum(pump_id) is null,1, maximum(pump_id)+1)" field="pump_id"/>
+    <default applyOnUpdate="0" expression="'new'" field="pump_display_name"/>
+    <default applyOnUpdate="0" expression="'new'" field="pump_code"/>
+    <default applyOnUpdate="0" expression="" field="pump_classification"/>
+    <default applyOnUpdate="0" expression="1" field="pump_type"/>
+    <default applyOnUpdate="0" expression="" field="pump_sewerage"/>
+    <default applyOnUpdate="0" expression="" field="pump_start_level"/>
+    <default applyOnUpdate="0" expression="" field="pump_lower_stop_level"/>
+    <default applyOnUpdate="0" expression="" field="pump_upper_stop_level"/>
+    <default applyOnUpdate="0" expression="" field="pump_capacity"/>
+    <default applyOnUpdate="0" expression="2" field="pump_zoom_category"/>
+    <default applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))" field="pump_connection_node_start_id"/>
+    <default applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))" field="pump_connection_node_end_id"/>
   </defaults>
   <constraints>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_id" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_display_name" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_code" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_classification" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_type" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_sewerage" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_start_level" exp_strength="0"/>
-    <constraint constraints="5" unique_strength="0" notnull_strength="2" field="pump_lower_stop_level" exp_strength="2"/>
-    <constraint constraints="4" unique_strength="0" notnull_strength="0" field="pump_upper_stop_level" exp_strength="2"/>
-    <constraint constraints="5" unique_strength="0" notnull_strength="2" field="pump_capacity" exp_strength="2"/>
-    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="pump_zoom_category" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_start_id" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="pump_connection_node_end_id" exp_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="ROWID" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="pump_id" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="pump_display_name" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="pump_code" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="pump_classification" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="pump_type" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="pump_sewerage" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="pump_start_level" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="2" field="pump_lower_stop_level" constraints="5" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="0" field="pump_upper_stop_level" constraints="4" unique_strength="0"/>
+    <constraint exp_strength="2" notnull_strength="2" field="pump_capacity" constraints="5" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="pump_zoom_category" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="pump_connection_node_start_id" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="pump_connection_node_end_id" constraints="0" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="ROWID" desc=""/>
-    <constraint exp="" field="pump_id" desc=""/>
-    <constraint exp="" field="pump_display_name" desc=""/>
-    <constraint exp="" field="pump_code" desc=""/>
-    <constraint exp="" field="pump_classification" desc=""/>
-    <constraint exp="" field="pump_type" desc=""/>
-    <constraint exp="" field="pump_sewerage" desc=""/>
-    <constraint exp="" field="pump_start_level" desc=""/>
-    <constraint exp="&quot;pump_lower_stop_level&quot; &lt; &quot;pump_start_level&quot;" field="pump_lower_stop_level" desc=""/>
-    <constraint exp="&quot;pump_upper_stop_level&quot;>&quot;start_level&quot; or &quot;pump_upper_stop_level&quot; is null" field="pump_upper_stop_level" desc=""/>
-    <constraint exp="&quot;pump_capacity&quot;>=0" field="pump_capacity" desc=""/>
-    <constraint exp="" field="pump_zoom_category" desc=""/>
-    <constraint exp="" field="pump_connection_node_start_id" desc=""/>
-    <constraint exp="" field="pump_connection_node_end_id" desc=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="pump_id"/>
+    <constraint exp="" desc="" field="pump_display_name"/>
+    <constraint exp="" desc="" field="pump_code"/>
+    <constraint exp="" desc="" field="pump_classification"/>
+    <constraint exp="" desc="" field="pump_type"/>
+    <constraint exp="" desc="" field="pump_sewerage"/>
+    <constraint exp="" desc="" field="pump_start_level"/>
+    <constraint exp="&quot;pump_lower_stop_level&quot; &lt; &quot;pump_start_level&quot;" desc="" field="pump_lower_stop_level"/>
+    <constraint exp="&quot;pump_upper_stop_level&quot;>&quot;start_level&quot; or &quot;pump_upper_stop_level&quot; is null" desc="" field="pump_upper_stop_level"/>
+    <constraint exp="&quot;pump_capacity&quot;>=0" desc="" field="pump_capacity"/>
+    <constraint exp="" desc="" field="pump_zoom_category"/>
+    <constraint exp="" desc="" field="pump_connection_node_start_id"/>
+    <constraint exp="" desc="" field="pump_connection_node_end_id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
@@ -354,21 +354,21 @@
   </attributeactions>
   <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column type="field" name="ROWID" width="-1" hidden="0"/>
-      <column type="field" name="pump_id" width="-1" hidden="0"/>
-      <column type="field" name="pump_display_name" width="-1" hidden="0"/>
-      <column type="field" name="pump_code" width="-1" hidden="0"/>
-      <column type="field" name="pump_classification" width="-1" hidden="0"/>
-      <column type="field" name="pump_type" width="-1" hidden="0"/>
-      <column type="field" name="pump_sewerage" width="-1" hidden="0"/>
-      <column type="field" name="pump_start_level" width="-1" hidden="0"/>
-      <column type="field" name="pump_lower_stop_level" width="-1" hidden="0"/>
-      <column type="field" name="pump_upper_stop_level" width="-1" hidden="0"/>
-      <column type="field" name="pump_capacity" width="-1" hidden="0"/>
-      <column type="field" name="pump_zoom_category" width="-1" hidden="0"/>
-      <column type="field" name="pump_connection_node_start_id" width="-1" hidden="0"/>
-      <column type="field" name="pump_connection_node_end_id" width="-1" hidden="0"/>
-      <column type="actions" width="-1" hidden="1"/>
+      <column width="-1" hidden="0" name="ROWID" type="field"/>
+      <column width="-1" hidden="0" name="pump_id" type="field"/>
+      <column width="-1" hidden="0" name="pump_display_name" type="field"/>
+      <column width="-1" hidden="0" name="pump_code" type="field"/>
+      <column width="-1" hidden="0" name="pump_classification" type="field"/>
+      <column width="-1" hidden="0" name="pump_type" type="field"/>
+      <column width="-1" hidden="0" name="pump_sewerage" type="field"/>
+      <column width="-1" hidden="0" name="pump_start_level" type="field"/>
+      <column width="-1" hidden="0" name="pump_lower_stop_level" type="field"/>
+      <column width="-1" hidden="0" name="pump_upper_stop_level" type="field"/>
+      <column width="-1" hidden="0" name="pump_capacity" type="field"/>
+      <column width="-1" hidden="0" name="pump_zoom_category" type="field"/>
+      <column width="-1" hidden="0" name="pump_connection_node_start_id" type="field"/>
+      <column width="-1" hidden="0" name="pump_connection_node_end_id" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -397,44 +397,44 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer columnCount="1" visibilityExpression="" name="Pumpstation view" groupBox="0" visibilityExpressionEnabled="0" showLabel="1">
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="pump_id" index="1" showLabel="1"/>
-        <attributeEditorField name="pump_display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="pump_code" index="3" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Pumpstation view" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="1" name="pump_id"/>
+        <attributeEditorField showLabel="1" index="2" name="pump_display_name"/>
+        <attributeEditorField showLabel="1" index="3" name="pump_code"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="pump_start_level" index="7" showLabel="1"/>
-        <attributeEditorField name="pump_lower_stop_level" index="8" showLabel="1"/>
-        <attributeEditorField name="pump_upper_stop_level" index="9" showLabel="1"/>
-        <attributeEditorField name="pump_capacity" index="10" showLabel="1"/>
-        <attributeEditorField name="pump_type" index="5" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="7" name="pump_start_level"/>
+        <attributeEditorField showLabel="1" index="8" name="pump_lower_stop_level"/>
+        <attributeEditorField showLabel="1" index="9" name="pump_upper_stop_level"/>
+        <attributeEditorField showLabel="1" index="10" name="pump_capacity"/>
+        <attributeEditorField showLabel="1" index="5" name="pump_type"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="pump_sewerage" index="6" showLabel="1"/>
-        <attributeEditorField name="pump_zoom_category" index="11" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="6" name="pump_sewerage"/>
+        <attributeEditorField showLabel="1" index="11" name="pump_zoom_category"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Connection nodes" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
-        <attributeEditorField name="pump_connection_node_start_id" index="12" showLabel="1"/>
-        <attributeEditorField name="pump_connection_node_end_id" index="13" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="Connection nodes" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorField showLabel="1" index="12" name="pump_connection_node_start_id"/>
+        <attributeEditorField showLabel="1" index="13" name="pump_connection_node_end_id"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="ROWID" editable="1"/>
-    <field name="pump_capacity" editable="1"/>
-    <field name="pump_classification" editable="1"/>
-    <field name="pump_code" editable="1"/>
-    <field name="pump_connection_node_end_id" editable="0"/>
-    <field name="pump_connection_node_start_id" editable="0"/>
-    <field name="pump_display_name" editable="1"/>
-    <field name="pump_id" editable="1"/>
-    <field name="pump_lower_stop_level" editable="1"/>
-    <field name="pump_sewerage" editable="1"/>
-    <field name="pump_start_level" editable="1"/>
-    <field name="pump_type" editable="1"/>
-    <field name="pump_upper_stop_level" editable="1"/>
-    <field name="pump_zoom_category" editable="1"/>
+    <field editable="1" name="ROWID"/>
+    <field editable="1" name="pump_capacity"/>
+    <field editable="1" name="pump_classification"/>
+    <field editable="1" name="pump_code"/>
+    <field editable="0" name="pump_connection_node_end_id"/>
+    <field editable="0" name="pump_connection_node_start_id"/>
+    <field editable="1" name="pump_display_name"/>
+    <field editable="1" name="pump_id"/>
+    <field editable="1" name="pump_lower_stop_level"/>
+    <field editable="1" name="pump_sewerage"/>
+    <field editable="1" name="pump_start_level"/>
+    <field editable="1" name="pump_type"/>
+    <field editable="1" name="pump_upper_stop_level"/>
+    <field editable="1" name="pump_zoom_category"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="ROWID"/>

--- a/layer_styles/schematisation/v2_simple_infiltration.qml
+++ b/layer_styles/schematisation/v2_simple_infiltration.qml
@@ -1,16 +1,19 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis hasScaleBasedVisibilityFlag="0" version="3.4.5-Madeira" readOnly="0" maxScale="0" minScale="1e+08" styleCategories="AllStyleCategories">
+<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property key="dualview/previewExpressions">
+      <value>id</value>
+    </property>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -19,8 +22,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -29,8 +32,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -39,8 +42,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -49,8 +52,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -59,8 +62,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -69,8 +72,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -87,20 +90,20 @@
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="id" expression=""/>
-    <default applyOnUpdate="0" field="infiltration_rate" expression=""/>
-    <default applyOnUpdate="0" field="infiltration_rate_file" expression=""/>
-    <default applyOnUpdate="0" field="infiltration_surface_option" expression=""/>
-    <default applyOnUpdate="0" field="max_infiltration_capacity_file" expression=""/>
-    <default applyOnUpdate="0" field="display_name" expression=""/>
+    <default expression="if(maximum(id) is null,1,maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="0" applyOnUpdate="0" field="infiltration_rate"/>
+    <default expression="" applyOnUpdate="0" field="infiltration_rate_file"/>
+    <default expression="" applyOnUpdate="0" field="infiltration_surface_option"/>
+    <default expression="" applyOnUpdate="0" field="max_infiltration_capacity_file"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" field="id" constraints="3" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" field="infiltration_rate" constraints="1" notnull_strength="2" exp_strength="0"/>
-    <constraint unique_strength="0" field="infiltration_rate_file" constraints="0" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" field="infiltration_surface_option" constraints="0" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" field="max_infiltration_capacity_file" constraints="0" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" field="display_name" constraints="1" notnull_strength="2" exp_strength="0"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="infiltration_rate"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="infiltration_rate_file"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="infiltration_surface_option"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="max_infiltration_capacity_file"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" desc="" field="id"/>
@@ -112,17 +115,17 @@
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column type="field" name="id" width="-1" hidden="0"/>
-      <column type="field" name="infiltration_rate" width="-1" hidden="0"/>
-      <column type="field" name="infiltration_rate_file" width="-1" hidden="0"/>
-      <column type="field" name="infiltration_surface_option" width="-1" hidden="0"/>
-      <column type="field" name="max_infiltration_capacity_file" width="-1" hidden="0"/>
-      <column type="field" name="display_name" width="-1" hidden="0"/>
-      <column type="actions" width="-1" hidden="1"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" hidden="0" name="infiltration_rate"/>
+      <column width="-1" type="field" hidden="0" name="infiltration_rate_file"/>
+      <column width="-1" type="field" hidden="0" name="infiltration_surface_option"/>
+      <column width="-1" type="field" hidden="0" name="max_infiltration_capacity_file"/>
+      <column width="-1" type="field" hidden="0" name="display_name"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -153,12 +156,14 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="id" index="0" showLabel="1"/>
-    <attributeEditorField name="display_name" index="5" showLabel="1"/>
-    <attributeEditorField name="infiltration_rate" index="1" showLabel="1"/>
-    <attributeEditorField name="infiltration_rate_file" index="2" showLabel="1"/>
-    <attributeEditorField name="infiltration_surface_option" index="3" showLabel="1"/>
-    <attributeEditorField name="max_infiltration_capacity_file" index="4" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+      <attributeEditorField showLabel="1" name="id" index="0"/>
+      <attributeEditorField showLabel="1" name="display_name" index="5"/>
+      <attributeEditorField showLabel="1" name="infiltration_rate" index="1"/>
+      <attributeEditorField showLabel="1" name="infiltration_rate_file" index="2"/>
+      <attributeEditorField showLabel="1" name="max_infiltration_capacity_file" index="4"/>
+      <attributeEditorField showLabel="1" name="infiltration_surface_option" index="3"/>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
     <field name="display_name" editable="1"/>
@@ -169,12 +174,12 @@ def my_form_open(dialog, layer, feature):
     <field name="max_infiltration_capacity_file" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="infiltration_rate" labelOnTop="0"/>
-    <field name="infiltration_rate_file" labelOnTop="0"/>
-    <field name="infiltration_surface_option" labelOnTop="0"/>
-    <field name="max_infiltration_capacity_file" labelOnTop="0"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="infiltration_rate"/>
+    <field labelOnTop="0" name="infiltration_rate_file"/>
+    <field labelOnTop="0" name="infiltration_surface_option"/>
+    <field labelOnTop="0" name="max_infiltration_capacity_file"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>id</previewExpression>

--- a/layer_styles/schematisation/v2_simple_infiltration.qml
+++ b/layer_styles/schematisation/v2_simple_infiltration.qml
@@ -1,19 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis maxScale="0" readOnly="0" version="3.4.11-Madeira" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property key="dualview/previewExpressions">
-      <value>id</value>
-    </property>
+    <property value="id" key="dualview/previewExpressions"/>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -22,8 +20,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -32,8 +30,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -42,8 +40,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -52,8 +50,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -62,8 +60,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -72,38 +70,38 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="id" index="0"/>
-    <alias name="" field="infiltration_rate" index="1"/>
-    <alias name="" field="infiltration_rate_file" index="2"/>
-    <alias name="" field="infiltration_surface_option" index="3"/>
-    <alias name="" field="max_infiltration_capacity_file" index="4"/>
-    <alias name="" field="display_name" index="5"/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="infiltration_rate"/>
+    <alias index="2" name="" field="infiltration_rate_file"/>
+    <alias index="3" name="" field="infiltration_surface_option"/>
+    <alias index="4" name="" field="max_infiltration_capacity_file"/>
+    <alias index="5" name="" field="display_name"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="if(maximum(id) is null,1,maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="0" applyOnUpdate="0" field="infiltration_rate"/>
-    <default expression="" applyOnUpdate="0" field="infiltration_rate_file"/>
-    <default expression="" applyOnUpdate="0" field="infiltration_surface_option"/>
-    <default expression="" applyOnUpdate="0" field="max_infiltration_capacity_file"/>
-    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default applyOnUpdate="0" expression="if(maximum(id) is null,1,maximum(id)+1)" field="id"/>
+    <default applyOnUpdate="0" expression="" field="infiltration_rate"/>
+    <default applyOnUpdate="0" expression="" field="infiltration_rate_file"/>
+    <default applyOnUpdate="0" expression="0" field="infiltration_surface_option"/>
+    <default applyOnUpdate="0" expression="" field="max_infiltration_capacity_file"/>
+    <default applyOnUpdate="0" expression="'new'" field="display_name"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="infiltration_rate"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="infiltration_rate_file"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="infiltration_surface_option"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="max_infiltration_capacity_file"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
+    <constraint exp_strength="0" notnull_strength="1" field="id" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" notnull_strength="2" field="infiltration_rate" constraints="1" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="infiltration_rate_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="infiltration_surface_option" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="0" field="max_infiltration_capacity_file" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="0" notnull_strength="2" field="display_name" constraints="1" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" desc="" field="id"/>
@@ -117,15 +115,15 @@
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="id"/>
-      <column width="-1" type="field" hidden="0" name="infiltration_rate"/>
-      <column width="-1" type="field" hidden="0" name="infiltration_rate_file"/>
-      <column width="-1" type="field" hidden="0" name="infiltration_surface_option"/>
-      <column width="-1" type="field" hidden="0" name="max_infiltration_capacity_file"/>
-      <column width="-1" type="field" hidden="0" name="display_name"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column width="-1" hidden="0" name="id" type="field"/>
+      <column width="-1" hidden="0" name="infiltration_rate" type="field"/>
+      <column width="-1" hidden="0" name="infiltration_rate_file" type="field"/>
+      <column width="-1" hidden="0" name="infiltration_surface_option" type="field"/>
+      <column width="-1" hidden="0" name="max_infiltration_capacity_file" type="field"/>
+      <column width="-1" hidden="0" name="display_name" type="field"/>
+      <column width="-1" hidden="1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -156,22 +154,22 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-      <attributeEditorField showLabel="1" name="id" index="0"/>
-      <attributeEditorField showLabel="1" name="display_name" index="5"/>
-      <attributeEditorField showLabel="1" name="infiltration_rate" index="1"/>
-      <attributeEditorField showLabel="1" name="infiltration_rate_file" index="2"/>
-      <attributeEditorField showLabel="1" name="max_infiltration_capacity_file" index="4"/>
-      <attributeEditorField showLabel="1" name="infiltration_surface_option" index="3"/>
+    <attributeEditorContainer showLabel="1" columnCount="1" visibilityExpression="" name="General" groupBox="0" visibilityExpressionEnabled="0">
+      <attributeEditorField showLabel="1" index="0" name="id"/>
+      <attributeEditorField showLabel="1" index="5" name="display_name"/>
+      <attributeEditorField showLabel="1" index="1" name="infiltration_rate"/>
+      <attributeEditorField showLabel="1" index="2" name="infiltration_rate_file"/>
+      <attributeEditorField showLabel="1" index="4" name="max_infiltration_capacity_file"/>
+      <attributeEditorField showLabel="1" index="3" name="infiltration_surface_option"/>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="display_name" editable="1"/>
-    <field name="id" editable="1"/>
-    <field name="infiltration_rate" editable="1"/>
-    <field name="infiltration_rate_file" editable="1"/>
-    <field name="infiltration_surface_option" editable="1"/>
-    <field name="max_infiltration_capacity_file" editable="1"/>
+    <field editable="1" name="display_name"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="infiltration_rate"/>
+    <field editable="1" name="infiltration_rate_file"/>
+    <field editable="1" name="infiltration_surface_option"/>
+    <field editable="1" name="max_infiltration_capacity_file"/>
   </editable>
   <labelOnTop>
     <field labelOnTop="0" name="display_name"/>

--- a/layer_styles/schematisation/v2_simple_infiltration.qml
+++ b/layer_styles/schematisation/v2_simple_infiltration.qml
@@ -1,0 +1,183 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis hasScaleBasedVisibilityFlag="0" version="3.4.5-Madeira" readOnly="0" maxScale="0" minScale="1e+08" styleCategories="AllStyleCategories">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_rate">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_rate_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_surface_option">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_infiltration_capacity_file">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" field="id" index="0"/>
+    <alias name="" field="infiltration_rate" index="1"/>
+    <alias name="" field="infiltration_rate_file" index="2"/>
+    <alias name="" field="infiltration_surface_option" index="3"/>
+    <alias name="" field="max_infiltration_capacity_file" index="4"/>
+    <alias name="" field="display_name" index="5"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default applyOnUpdate="0" field="id" expression=""/>
+    <default applyOnUpdate="0" field="infiltration_rate" expression=""/>
+    <default applyOnUpdate="0" field="infiltration_rate_file" expression=""/>
+    <default applyOnUpdate="0" field="infiltration_surface_option" expression=""/>
+    <default applyOnUpdate="0" field="max_infiltration_capacity_file" expression=""/>
+    <default applyOnUpdate="0" field="display_name" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" field="id" constraints="3" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" field="infiltration_rate" constraints="1" notnull_strength="2" exp_strength="0"/>
+    <constraint unique_strength="0" field="infiltration_rate_file" constraints="0" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" field="infiltration_surface_option" constraints="0" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" field="max_infiltration_capacity_file" constraints="0" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" field="display_name" constraints="1" notnull_strength="2" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" desc="" field="id"/>
+    <constraint exp="" desc="" field="infiltration_rate"/>
+    <constraint exp="" desc="" field="infiltration_rate_file"/>
+    <constraint exp="" desc="" field="infiltration_surface_option"/>
+    <constraint exp="" desc="" field="max_infiltration_capacity_file"/>
+    <constraint exp="" desc="" field="display_name"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+    <columns>
+      <column type="field" name="id" width="-1" hidden="0"/>
+      <column type="field" name="infiltration_rate" width="-1" hidden="0"/>
+      <column type="field" name="infiltration_rate_file" width="-1" hidden="0"/>
+      <column type="field" name="infiltration_surface_option" width="-1" hidden="0"/>
+      <column type="field" name="max_infiltration_capacity_file" width="-1" hidden="0"/>
+      <column type="field" name="display_name" width="-1" hidden="0"/>
+      <column type="actions" width="-1" hidden="1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorField name="id" index="0" showLabel="1"/>
+    <attributeEditorField name="display_name" index="5" showLabel="1"/>
+    <attributeEditorField name="infiltration_rate" index="1" showLabel="1"/>
+    <attributeEditorField name="infiltration_rate_file" index="2" showLabel="1"/>
+    <attributeEditorField name="infiltration_surface_option" index="3" showLabel="1"/>
+    <attributeEditorField name="max_infiltration_capacity_file" index="4" showLabel="1"/>
+  </attributeEditorForm>
+  <editable>
+    <field name="display_name" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="infiltration_rate" editable="1"/>
+    <field name="infiltration_rate_file" editable="1"/>
+    <field name="infiltration_surface_option" editable="1"/>
+    <field name="max_infiltration_capacity_file" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="display_name" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="infiltration_rate" labelOnTop="0"/>
+    <field name="infiltration_rate_file" labelOnTop="0"/>
+    <field name="infiltration_surface_option" labelOnTop="0"/>
+    <field name="max_infiltration_capacity_file" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_surface.qml
+++ b/layer_styles/schematisation/v2_surface.qml
@@ -1,30 +1,30 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" simplifyDrawingHints="1" simplifyAlgorithm="0" maxScale="0" simplifyMaxScale="1" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" minScale="1e+08" version="3.4.5-Madeira" styleCategories="AllStyleCategories" readOnly="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
+  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="fill">
-        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="244,198,119,255" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="133,112,8,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.26" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+      <symbol name="0" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="244,198,119,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="133,112,8,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option name="name" value="" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -34,29 +34,29 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>0.9</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" penAlpha="255" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" penColor="#000000" opacity="1" enabled="0" labelPlacementMethod="XHeight" penWidth="0" rotationOffset="270" lineSizeType="MM" backgroundColor="#ffffff" height="15" sizeType="MM" minScaleDenominator="0" minimumSize="0" scaleBasedVisibility="0" width="15">
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
       <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" dist="0" showAll="1" priority="0" obstacle="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings placement="0" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option name="name" value="" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option name="type" value="collection" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -65,8 +65,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -75,8 +75,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -85,8 +85,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -97,25 +97,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" type="QString" value="-1"/>
+                <Option name="-1" value="-1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="0" type="QString" value="0"/>
+                <Option name="0" value="0" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="1" type="QString" value="1"/>
+                <Option name="1" value="1" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="2" type="QString" value="2"/>
+                <Option name="2" value="2" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="3" type="QString" value="3"/>
+                <Option name="3" value="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="4" type="QString" value="4"/>
+                <Option name="4" value="4" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="5" type="QString" value="5"/>
+                <Option name="5" value="5" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -126,8 +126,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -136,8 +136,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -146,8 +146,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -156,8 +156,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -166,75 +166,75 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="id"/>
-    <alias index="1" name="" field="display_name"/>
-    <alias index="2" name="" field="code"/>
-    <alias index="3" name="" field="zoom_category"/>
-    <alias index="4" name="" field="nr_of_inhabitants"/>
-    <alias index="5" name="" field="dry_weather_flow"/>
-    <alias index="6" name="" field="function"/>
-    <alias index="7" name="" field="area"/>
-    <alias index="8" name="" field="surface_parameters_id"/>
+    <alias name="" index="0" field="id"/>
+    <alias name="" index="1" field="display_name"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="zoom_category"/>
+    <alias name="" index="4" field="nr_of_inhabitants"/>
+    <alias name="" index="5" field="dry_weather_flow"/>
+    <alias name="" index="6" field="function"/>
+    <alias name="" index="7" field="area"/>
+    <alias name="" index="8" field="surface_parameters_id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
-    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
-    <default expression="'new'" applyOnUpdate="0" field="code"/>
-    <default expression="-1" applyOnUpdate="0" field="zoom_category"/>
-    <default expression="" applyOnUpdate="0" field="nr_of_inhabitants"/>
-    <default expression="" applyOnUpdate="0" field="dry_weather_flow"/>
-    <default expression="" applyOnUpdate="0" field="function"/>
-    <default expression="round($area,1)" applyOnUpdate="0" field="area"/>
-    <default expression="" applyOnUpdate="0" field="surface_parameters_id"/>
+    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="code" expression="'new'"/>
+    <default applyOnUpdate="0" field="zoom_category" expression="-1"/>
+    <default applyOnUpdate="0" field="nr_of_inhabitants" expression=""/>
+    <default applyOnUpdate="0" field="dry_weather_flow" expression=""/>
+    <default applyOnUpdate="0" field="function" expression=""/>
+    <default applyOnUpdate="0" field="area" expression="$area"/>
+    <default applyOnUpdate="0" field="surface_parameters_id" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" field="id" exp_strength="0" notnull_strength="1" constraints="3"/>
-    <constraint unique_strength="0" field="display_name" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="code" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="zoom_category" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="nr_of_inhabitants" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="dry_weather_flow" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="function" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="area" exp_strength="0" notnull_strength="2" constraints="1"/>
-    <constraint unique_strength="0" field="surface_parameters_id" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="nr_of_inhabitants" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dry_weather_flow" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="function" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="area" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_parameters_id" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="id" exp="" desc=""/>
-    <constraint field="display_name" exp="" desc=""/>
-    <constraint field="code" exp="" desc=""/>
-    <constraint field="zoom_category" exp="" desc=""/>
-    <constraint field="nr_of_inhabitants" exp="" desc=""/>
-    <constraint field="dry_weather_flow" exp="" desc=""/>
-    <constraint field="function" exp="" desc=""/>
-    <constraint field="area" exp="" desc=""/>
-    <constraint field="surface_parameters_id" exp="" desc=""/>
+    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" field="nr_of_inhabitants" desc=""/>
+    <constraint exp="" field="dry_weather_flow" desc=""/>
+    <constraint exp="" field="function" desc=""/>
+    <constraint exp="" field="area" desc=""/>
+    <constraint exp="" field="surface_parameters_id" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
-      <column hidden="0" name="id" type="field" width="-1"/>
-      <column hidden="0" name="display_name" type="field" width="-1"/>
-      <column hidden="0" name="code" type="field" width="-1"/>
-      <column hidden="0" name="zoom_category" type="field" width="-1"/>
-      <column hidden="0" name="nr_of_inhabitants" type="field" width="-1"/>
-      <column hidden="0" name="dry_weather_flow" type="field" width="-1"/>
-      <column hidden="0" name="function" type="field" width="-1"/>
-      <column hidden="0" name="area" type="field" width="-1"/>
-      <column hidden="0" name="surface_parameters_id" type="field" width="-1"/>
-      <column hidden="1" type="actions" width="-1"/>
+      <column name="id" hidden="0" width="-1" type="field"/>
+      <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="code" hidden="0" width="-1" type="field"/>
+      <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="nr_of_inhabitants" hidden="0" width="-1" type="field"/>
+      <column name="dry_weather_flow" hidden="0" width="-1" type="field"/>
+      <column name="function" hidden="0" width="-1" type="field"/>
+      <column name="area" hidden="0" width="-1" type="field"/>
+      <column name="surface_parameters_id" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -265,25 +265,25 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="Surface" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" columnCount="1">
-      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-        <attributeEditorField showLabel="1" index="0" name="id"/>
-        <attributeEditorField showLabel="1" index="1" name="display_name"/>
-        <attributeEditorField showLabel="1" index="2" name="code"/>
+    <attributeEditorContainer name="Surface" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="id" index="0" showLabel="1"/>
+        <attributeEditorField name="display_name" index="1" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-        <attributeEditorContainer showLabel="1" name="Rain water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-          <attributeEditorField showLabel="1" index="8" name="surface_parameters_id"/>
-          <attributeEditorField showLabel="1" index="7" name="area"/>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorContainer name="Rain water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="surface_parameters_id" index="8" showLabel="1"/>
+          <attributeEditorField name="area" index="7" showLabel="1"/>
         </attributeEditorContainer>
-        <attributeEditorContainer showLabel="1" name="Municipal water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-          <attributeEditorField showLabel="1" index="4" name="nr_of_inhabitants"/>
-          <attributeEditorField showLabel="1" index="5" name="dry_weather_flow"/>
+        <attributeEditorContainer name="Municipal water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="nr_of_inhabitants" index="4" showLabel="1"/>
+          <attributeEditorField name="dry_weather_flow" index="5" showLabel="1"/>
         </attributeEditorContainer>
       </attributeEditorContainer>
-      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
-        <attributeEditorField showLabel="1" index="3" name="zoom_category"/>
-        <attributeEditorField showLabel="1" index="6" name="function"/>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="zoom_category" index="3" showLabel="1"/>
+        <attributeEditorField name="function" index="6" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_surface.qml
+++ b/layer_styles/schematisation/v2_surface.qml
@@ -1,30 +1,30 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+<qgis labelsEnabled="0" simplifyDrawingHints="1" simplifyAlgorithm="0" maxScale="0" simplifyMaxScale="1" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" minScale="1e+08" version="3.4.5-Madeira" styleCategories="AllStyleCategories" readOnly="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" forceraster="0">
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
-        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="244,198,119,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="133,112,8,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="fill">
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="244,198,119,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="133,112,8,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -34,29 +34,29 @@
     <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property value="0" key="embeddedWidgets/count"/>
+    <property key="embeddedWidgets/count" value="0"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>0.9</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" barWidth="5" backgroundAlpha="255" diagramOrientation="Up" penAlpha="255" maxScaleDenominator="1e+08" sizeScale="3x:0,0,0,0,0,0" penColor="#000000" opacity="1" enabled="0" labelPlacementMethod="XHeight" penWidth="0" rotationOffset="270" lineSizeType="MM" backgroundColor="#ffffff" height="15" sizeType="MM" minScaleDenominator="0" minimumSize="0" scaleBasedVisibility="0" width="15">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
       <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="0" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings placement="0" dist="0" showAll="1" priority="0" obstacle="0" zIndex="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
     <activeChecks/>
     <checkConfiguration/>
   </geometryOptions>
@@ -65,8 +65,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -75,8 +75,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -85,8 +85,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -97,25 +97,25 @@
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option name="-1" type="QString" value="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option name="0" type="QString" value="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option name="1" type="QString" value="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option name="2" type="QString" value="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option name="3" type="QString" value="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option name="4" type="QString" value="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option name="5" type="QString" value="5"/>
               </Option>
             </Option>
           </Option>
@@ -126,8 +126,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -136,8 +136,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -146,8 +146,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -156,8 +156,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -166,75 +166,75 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="id"/>
-    <alias name="" index="1" field="display_name"/>
-    <alias name="" index="2" field="code"/>
-    <alias name="" index="3" field="zoom_category"/>
-    <alias name="" index="4" field="nr_of_inhabitants"/>
-    <alias name="" index="5" field="dry_weather_flow"/>
-    <alias name="" index="6" field="function"/>
-    <alias name="" index="7" field="area"/>
-    <alias name="" index="8" field="surface_parameters_id"/>
+    <alias index="0" name="" field="id"/>
+    <alias index="1" name="" field="display_name"/>
+    <alias index="2" name="" field="code"/>
+    <alias index="3" name="" field="zoom_category"/>
+    <alias index="4" name="" field="nr_of_inhabitants"/>
+    <alias index="5" name="" field="dry_weather_flow"/>
+    <alias index="6" name="" field="function"/>
+    <alias index="7" name="" field="area"/>
+    <alias index="8" name="" field="surface_parameters_id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="zoom_category" expression="-1"/>
-    <default applyOnUpdate="0" field="nr_of_inhabitants" expression=""/>
-    <default applyOnUpdate="0" field="dry_weather_flow" expression=""/>
-    <default applyOnUpdate="0" field="function" expression=""/>
-    <default applyOnUpdate="0" field="area" expression="$area"/>
-    <default applyOnUpdate="0" field="surface_parameters_id" expression=""/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="-1" applyOnUpdate="0" field="zoom_category"/>
+    <default expression="" applyOnUpdate="0" field="nr_of_inhabitants"/>
+    <default expression="" applyOnUpdate="0" field="dry_weather_flow"/>
+    <default expression="" applyOnUpdate="0" field="function"/>
+    <default expression="round($area,1)" applyOnUpdate="0" field="area"/>
+    <default expression="" applyOnUpdate="0" field="surface_parameters_id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="nr_of_inhabitants" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dry_weather_flow" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="function" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="area" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_parameters_id" unique_strength="0"/>
+    <constraint unique_strength="1" field="id" exp_strength="0" notnull_strength="1" constraints="3"/>
+    <constraint unique_strength="0" field="display_name" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="code" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="zoom_category" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="nr_of_inhabitants" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="dry_weather_flow" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="function" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="area" exp_strength="0" notnull_strength="2" constraints="1"/>
+    <constraint unique_strength="0" field="surface_parameters_id" exp_strength="0" notnull_strength="2" constraints="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="id" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="nr_of_inhabitants" desc=""/>
-    <constraint exp="" field="dry_weather_flow" desc=""/>
-    <constraint exp="" field="function" desc=""/>
-    <constraint exp="" field="area" desc=""/>
-    <constraint exp="" field="surface_parameters_id" desc=""/>
+    <constraint field="id" exp="" desc=""/>
+    <constraint field="display_name" exp="" desc=""/>
+    <constraint field="code" exp="" desc=""/>
+    <constraint field="zoom_category" exp="" desc=""/>
+    <constraint field="nr_of_inhabitants" exp="" desc=""/>
+    <constraint field="dry_weather_flow" exp="" desc=""/>
+    <constraint field="function" exp="" desc=""/>
+    <constraint field="area" exp="" desc=""/>
+    <constraint field="surface_parameters_id" exp="" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
     <columns>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="nr_of_inhabitants" hidden="0" width="-1" type="field"/>
-      <column name="dry_weather_flow" hidden="0" width="-1" type="field"/>
-      <column name="function" hidden="0" width="-1" type="field"/>
-      <column name="area" hidden="0" width="-1" type="field"/>
-      <column name="surface_parameters_id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column hidden="0" name="id" type="field" width="-1"/>
+      <column hidden="0" name="display_name" type="field" width="-1"/>
+      <column hidden="0" name="code" type="field" width="-1"/>
+      <column hidden="0" name="zoom_category" type="field" width="-1"/>
+      <column hidden="0" name="nr_of_inhabitants" type="field" width="-1"/>
+      <column hidden="0" name="dry_weather_flow" type="field" width="-1"/>
+      <column hidden="0" name="function" type="field" width="-1"/>
+      <column hidden="0" name="area" type="field" width="-1"/>
+      <column hidden="0" name="surface_parameters_id" type="field" width="-1"/>
+      <column hidden="1" type="actions" width="-1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -265,25 +265,25 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Surface" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="0" showLabel="1"/>
-        <attributeEditorField name="display_name" index="1" showLabel="1"/>
-        <attributeEditorField name="code" index="2" showLabel="1"/>
+    <attributeEditorContainer showLabel="1" name="Surface" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="0" columnCount="1">
+      <attributeEditorContainer showLabel="1" name="General" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+        <attributeEditorField showLabel="1" index="0" name="id"/>
+        <attributeEditorField showLabel="1" index="1" name="display_name"/>
+        <attributeEditorField showLabel="1" index="2" name="code"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorContainer name="Rain water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-          <attributeEditorField name="surface_parameters_id" index="8" showLabel="1"/>
-          <attributeEditorField name="area" index="7" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" name="Characteristics" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+        <attributeEditorContainer showLabel="1" name="Rain water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+          <attributeEditorField showLabel="1" index="8" name="surface_parameters_id"/>
+          <attributeEditorField showLabel="1" index="7" name="area"/>
         </attributeEditorContainer>
-        <attributeEditorContainer name="Municipal water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-          <attributeEditorField name="nr_of_inhabitants" index="4" showLabel="1"/>
-          <attributeEditorField name="dry_weather_flow" index="5" showLabel="1"/>
+        <attributeEditorContainer showLabel="1" name="Municipal water" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+          <attributeEditorField showLabel="1" index="4" name="nr_of_inhabitants"/>
+          <attributeEditorField showLabel="1" index="5" name="dry_weather_flow"/>
         </attributeEditorContainer>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="3" showLabel="1"/>
-        <attributeEditorField name="function" index="6" showLabel="1"/>
+      <attributeEditorContainer showLabel="1" name="Visualization" visibilityExpressionEnabled="0" visibilityExpression="" groupBox="1" columnCount="1">
+        <attributeEditorField showLabel="1" index="3" name="zoom_category"/>
+        <attributeEditorField showLabel="1" index="6" name="function"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_surface.qml
+++ b/layer_styles/schematisation/v2_surface.qml
@@ -1,282 +1,247 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.18.22" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="nr_of_inhabitants">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="dry_weather_flow">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="function">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="area">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="surface_parameters_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="0">
-        <layer pass="0" class="SimpleFill" locked="0">
-          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+      <symbol name="0" force_rhr="0" alpha="1" type="fill" clip_to_extent="1">
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="color" v="244,198,119,255"/>
           <prop k="joinstyle" v="bevel"/>
           <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="133,112,8,255"/>
           <prop k="outline_style" v="solid"/>
           <prop k="outline_width" v="0.26"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="128"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="25"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-25"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="4294967295"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="1"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/useSubstitutions" value="false"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
+    <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>10</layerTransparency>
-  <displayfield>display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
+  <layerOpacity>0.9</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
-    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
-      <layer pass="0" class="SimpleMarker" locked="0">
-        <prop k="angle" v="0"/>
-        <prop k="color" v="255,0,0,255"/>
-        <prop k="horizontal_anchor_point" v="1"/>
-        <prop k="joinstyle" v="bevel"/>
-        <prop k="name" v="circle"/>
-        <prop k="offset" v="0,0"/>
-        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="outline_color" v="0,0,0,255"/>
-        <prop k="outline_style" v="solid"/>
-        <prop k="outline_width" v="0"/>
-        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="outline_width_unit" v="MM"/>
-        <prop k="scale_method" v="diameter"/>
-        <prop k="size" v="2"/>
-        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
-        <prop k="size_unit" v="MM"/>
-        <prop k="vertical_anchor_point" v="1"/>
-      </layer>
-    </symbol>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" showColumn="-1" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform></annotationform>
+  <DiagramLayerSettings placement="0" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="nr_of_inhabitants">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dry_weather_flow">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="function">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_parameters_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
   <aliases>
-    <alias field="id" index="0" name=""/>
-    <alias field="display_name" index="1" name=""/>
-    <alias field="code" index="2" name=""/>
-    <alias field="zoom_category" index="3" name=""/>
-    <alias field="nr_of_inhabitants" index="4" name=""/>
-    <alias field="dry_weather_flow" index="5" name=""/>
-    <alias field="function" index="6" name=""/>
-    <alias field="area" index="7" name=""/>
-    <alias field="surface_parameters_id" index="8" name=""/>
+    <alias name="" index="0" field="id"/>
+    <alias name="" index="1" field="display_name"/>
+    <alias name="" index="2" field="code"/>
+    <alias name="" index="3" field="zoom_category"/>
+    <alias name="" index="4" field="nr_of_inhabitants"/>
+    <alias name="" index="5" field="dry_weather_flow"/>
+    <alias name="" index="6" field="function"/>
+    <alias name="" index="7" field="area"/>
+    <alias name="" index="8" field="surface_parameters_id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions default="-1"/>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="267878184">
+  <defaults>
+    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="code" expression="'new'"/>
+    <default applyOnUpdate="0" field="zoom_category" expression="-1"/>
+    <default applyOnUpdate="0" field="nr_of_inhabitants" expression=""/>
+    <default applyOnUpdate="0" field="dry_weather_flow" expression=""/>
+    <default applyOnUpdate="0" field="function" expression=""/>
+    <default applyOnUpdate="0" field="area" expression="$area"/>
+    <default applyOnUpdate="0" field="surface_parameters_id" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="nr_of_inhabitants" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dry_weather_flow" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="function" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="area" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="surface_parameters_id" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="code" desc=""/>
+    <constraint exp="" field="zoom_category" desc=""/>
+    <constraint exp="" field="nr_of_inhabitants" desc=""/>
+    <constraint exp="" field="dry_weather_flow" desc=""/>
+    <constraint exp="" field="function" desc=""/>
+    <constraint exp="" field="area" desc=""/>
+    <constraint exp="" field="surface_parameters_id" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
     <columns>
-      <column width="-1" hidden="0" type="field" name="id"/>
-      <column width="-1" hidden="0" type="field" name="display_name"/>
-      <column width="-1" hidden="0" type="field" name="code"/>
-      <column width="-1" hidden="0" type="field" name="zoom_category"/>
-      <column width="-1" hidden="0" type="field" name="nr_of_inhabitants"/>
-      <column width="-1" hidden="0" type="field" name="dry_weather_flow"/>
-      <column width="-1" hidden="0" type="field" name="function"/>
-      <column width="-1" hidden="0" type="field" name="area"/>
-      <column width="-1" hidden="0" type="field" name="surface_parameters_id"/>
-      <column width="-1" hidden="1" type="actions"/>
+      <column name="id" hidden="0" width="-1" type="field"/>
+      <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="code" hidden="0" width="-1" type="field"/>
+      <column name="zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="nr_of_inhabitants" hidden="0" width="-1" type="field"/>
+      <column name="dry_weather_flow" hidden="0" width="-1" type="field"/>
+      <column name="function" hidden="0" width="-1" type="field"/>
+      <column name="area" hidden="0" width="-1" type="field"/>
+      <column name="surface_parameters_id" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
-  <editform></editform>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
@@ -298,23 +263,54 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Surface" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="id" index="0" showLabel="1"/>
+        <attributeEditorField name="display_name" index="1" showLabel="1"/>
+        <attributeEditorField name="code" index="2" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorContainer name="Rain water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="surface_parameters_id" index="8" showLabel="1"/>
+          <attributeEditorField name="area" index="7" showLabel="1"/>
+        </attributeEditorContainer>
+        <attributeEditorContainer name="Municipal water" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="nr_of_inhabitants" index="4" showLabel="1"/>
+          <attributeEditorField name="dry_weather_flow" index="5" showLabel="1"/>
+        </attributeEditorContainer>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="zoom_category" index="3" showLabel="1"/>
+        <attributeEditorField name="function" index="6" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="area" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="display_name" editable="1"/>
+    <field name="dry_weather_flow" editable="1"/>
+    <field name="function" editable="1"/>
+    <field name="id" editable="1"/>
+    <field name="nr_of_inhabitants" editable="1"/>
+    <field name="surface_parameters_id" editable="1"/>
+    <field name="zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="area" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="display_name" labelOnTop="0"/>
+    <field name="dry_weather_flow" labelOnTop="0"/>
+    <field name="function" labelOnTop="0"/>
+    <field name="id" labelOnTop="0"/>
+    <field name="nr_of_inhabitants" labelOnTop="0"/>
+    <field name="surface_parameters_id" labelOnTop="0"/>
+    <field name="zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <defaults>
-    <default field="id" expression=""/>
-    <default field="display_name" expression=""/>
-    <default field="code" expression=""/>
-    <default field="zoom_category" expression=""/>
-    <default field="nr_of_inhabitants" expression=""/>
-    <default field="dry_weather_flow" expression=""/>
-    <default field="function" expression=""/>
-    <default field="area" expression=""/>
-    <default field="surface_parameters_id" expression=""/>
-  </defaults>
-  <previewExpression></previewExpression>
+  <previewExpression>display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_surface_map.qml
+++ b/layer_styles/schematisation/v2_surface_map.qml
@@ -1,0 +1,174 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="dualview/previewExpressions" value="id"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="v2_surface" name="v2_surface"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="v2_impervious_surface" name="v2_impervious_surface"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="percentage">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="id" index="0" name=""/>
+    <alias field="surface_type" index="1" name=""/>
+    <alias field="surface_id" index="2" name=""/>
+    <alias field="connection_node_id" index="3" name=""/>
+    <alias field="percentage" index="4" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="surface_type"/>
+    <default expression="" applyOnUpdate="0" field="surface_id"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_id"/>
+    <default expression="" applyOnUpdate="0" field="percentage"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="surface_type" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="surface_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="connection_node_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="percentage" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="surface_type" exp=""/>
+    <constraint desc="" field="surface_id" exp=""/>
+    <constraint desc="" field="connection_node_id" exp=""/>
+    <constraint desc="" field="percentage" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="surface_type"/>
+      <column width="-1" hidden="0" type="field" name="surface_id"/>
+      <column width="-1" hidden="0" type="field" name="connection_node_id"/>
+      <column width="-1" hidden="0" type="field" name="percentage"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="surface_type" showLabel="1"/>
+      <attributeEditorField index="2" name="surface_id" showLabel="1"/>
+      <attributeEditorField index="3" name="connection_node_id" showLabel="1"/>
+      <attributeEditorField index="4" name="percentage" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="connection_node_id"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="percentage"/>
+    <field editable="1" name="surface_id"/>
+    <field editable="1" name="surface_type"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="connection_node_id"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="percentage"/>
+    <field labelOnTop="0" name="surface_id"/>
+    <field labelOnTop="0" name="surface_type"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_surface_parameters.qml
+++ b/layer_styles/schematisation/v2_surface_parameters.qml
@@ -1,0 +1,221 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="outflow_delay">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface_layer_thickness">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="max_infiltration_capacity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="min_infiltration_capacity">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_decay_constant">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="infiltration_recovery_constant">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="id" index="0" name=""/>
+    <alias field="outflow_delay" index="1" name=""/>
+    <alias field="surface_layer_thickness" index="2" name=""/>
+    <alias field="infiltration" index="3" name=""/>
+    <alias field="max_infiltration_capacity" index="4" name=""/>
+    <alias field="min_infiltration_capacity" index="5" name=""/>
+    <alias field="infiltration_decay_constant" index="6" name=""/>
+    <alias field="infiltration_recovery_constant" index="7" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="outflow_delay"/>
+    <default expression="" applyOnUpdate="0" field="surface_layer_thickness"/>
+    <default expression="" applyOnUpdate="0" field="infiltration"/>
+    <default expression="" applyOnUpdate="0" field="max_infiltration_capacity"/>
+    <default expression="" applyOnUpdate="0" field="min_infiltration_capacity"/>
+    <default expression="" applyOnUpdate="0" field="infiltration_decay_constant"/>
+    <default expression="" applyOnUpdate="0" field="infiltration_recovery_constant"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="outflow_delay" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="surface_layer_thickness" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="infiltration" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="max_infiltration_capacity" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="min_infiltration_capacity" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="infiltration_decay_constant" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" field="infiltration_recovery_constant" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="outflow_delay" exp=""/>
+    <constraint desc="" field="surface_layer_thickness" exp=""/>
+    <constraint desc="" field="infiltration" exp=""/>
+    <constraint desc="" field="max_infiltration_capacity" exp=""/>
+    <constraint desc="" field="min_infiltration_capacity" exp=""/>
+    <constraint desc="" field="infiltration_decay_constant" exp=""/>
+    <constraint desc="" field="infiltration_recovery_constant" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="outflow_delay"/>
+      <column width="-1" hidden="0" type="field" name="surface_layer_thickness"/>
+      <column width="-1" hidden="0" type="field" name="infiltration"/>
+      <column width="-1" hidden="0" type="field" name="max_infiltration_capacity"/>
+      <column width="-1" hidden="0" type="field" name="min_infiltration_capacity"/>
+      <column width="-1" hidden="0" type="field" name="infiltration_decay_constant"/>
+      <column width="-1" hidden="0" type="field" name="infiltration_recovery_constant"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="3" name="infiltration" showLabel="1"/>
+      <attributeEditorField index="4" name="max_infiltration_capacity" showLabel="1"/>
+      <attributeEditorField index="5" name="min_infiltration_capacity" showLabel="1"/>
+      <attributeEditorField index="6" name="infiltration_decay_constant" showLabel="1"/>
+      <attributeEditorField index="7" name="infiltration_recovery_constant" showLabel="1"/>
+      <attributeEditorField index="2" name="surface_layer_thickness" showLabel="1"/>
+      <attributeEditorField index="1" name="outflow_delay" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="id"/>
+    <field editable="1" name="infiltration"/>
+    <field editable="1" name="infiltration_decay_constant"/>
+    <field editable="1" name="infiltration_recovery_constant"/>
+    <field editable="1" name="max_infiltration_capacity"/>
+    <field editable="1" name="min_infiltration_capacity"/>
+    <field editable="1" name="outflow_delay"/>
+    <field editable="1" name="surface_layer_thickness"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="infiltration"/>
+    <field labelOnTop="0" name="infiltration_decay_constant"/>
+    <field labelOnTop="0" name="infiltration_recovery_constant"/>
+    <field labelOnTop="0" name="max_infiltration_capacity"/>
+    <field labelOnTop="0" name="min_infiltration_capacity"/>
+    <field labelOnTop="0" name="outflow_delay"/>
+    <field labelOnTop="0" name="surface_layer_thickness"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/layer_styles/schematisation/v2_weir.qml
+++ b/layer_styles/schematisation/v2_weir.qml
@@ -1,116 +1,16 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="-4.65661e-10" simplifyDrawingHints="1">
+<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
-    <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="101,101,101,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.66"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
-          <prop k="interval" v="3"/>
-          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="interval_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="placement" v="centralpoint"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="rotate" v="0"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" value="" type="QString"/>
-              <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
-            </Option>
-          </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
-              <prop k="angle" v="0"/>
-              <prop k="color" v="101,101,101,255"/>
-              <prop k="horizontal_anchor_point" v="1"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="name" v="circle"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="0,0,0,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="scale_method" v="area"/>
-              <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="size_unit" v="MM"/>
-              <prop k="vertical_anchor_point" v="1"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
-                  <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
-        </layer>
-      </symbol>
-    </symbols>
-    <rotation/>
-    <sizescale/>
-  </renderer-v2>
   <customproperties>
+    <property value="display_name" key="dualview/previewExpressions"/>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
   </customproperties>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="-4.65661e-10" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
-    </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
-    <properties>
-      <Option type="Map">
-        <Option name="name" value="" type="QString"/>
-        <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
-      </Option>
-    </properties>
-  </DiagramLayerSettings>
   <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
     <checkConfiguration/>
@@ -167,6 +67,16 @@
         </config>
       </editWidget>
     </field>
+    <field name="connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
     <field name="discharge_coefficient_negative">
       <editWidget type="TextEdit">
         <config>
@@ -177,7 +87,17 @@
         </config>
       </editWidget>
     </field>
-    <field name="dist_calc_points">
+    <field name="sewerage">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option name="CheckedState" value="1" type="QString"/>
+            <Option name="UncheckedState" value="0" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_start_id">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -187,7 +107,7 @@
         </config>
       </editWidget>
     </field>
-    <field name="connection_node_start_id">
+    <field name="crest_level">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
@@ -217,42 +137,26 @@
         </config>
       </editWidget>
     </field>
-    <field name="invert_level_end_point">
-      <editWidget type="TextEdit">
+    <field name="external">
+      <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="CheckedState" value="1" type="QString"/>
+            <Option name="UncheckedState" value="0" type="QString"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="invert_level_start_point">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field name="calculation_type">
+    <field name="crest_type">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
             <Option name="map" type="List">
               <Option type="Map">
-                <Option name="100: embedded" value="100" type="QString"/>
+                <Option name="3: Broad crested" value="3" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option name="101: isolated" value="101" type="QString"/>
-              </Option>
-              <Option type="Map">
-                <Option name="102: connected" value="102" type="QString"/>
-              </Option>
-              <Option type="Map">
-                <Option name="105: double connected" value="105" type="QString"/>
+                <Option name="4: Short crested" value="4" type="QString"/>
               </Option>
             </Option>
           </Option>
@@ -295,86 +199,76 @@
         </config>
       </editWidget>
     </field>
-    <field name="connection_node_end_id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
   </fieldConfiguration>
   <aliases>
     <alias name="" index="0" field="zoom_category"/>
     <alias name="" index="1" field="code"/>
     <alias name="" index="2" field="display_name"/>
-    <alias name="" index="3" field="discharge_coefficient_negative"/>
-    <alias name="" index="4" field="dist_calc_points"/>
-    <alias name="" index="5" field="connection_node_start_id"/>
-    <alias name="" index="6" field="discharge_coefficient_positive"/>
-    <alias name="" index="7" field="cross_section_definition_id"/>
-    <alias name="" index="8" field="invert_level_end_point"/>
-    <alias name="" index="9" field="invert_level_start_point"/>
-    <alias name="" index="10" field="calculation_type"/>
-    <alias name="" index="11" field="friction_type"/>
-    <alias name="" index="12" field="friction_value"/>
-    <alias name="" index="13" field="id"/>
-    <alias name="" index="14" field="connection_node_end_id"/>
+    <alias name="" index="3" field="connection_node_end_id"/>
+    <alias name="" index="4" field="discharge_coefficient_negative"/>
+    <alias name="" index="5" field="sewerage"/>
+    <alias name="" index="6" field="connection_node_start_id"/>
+    <alias name="" index="7" field="crest_level"/>
+    <alias name="" index="8" field="discharge_coefficient_positive"/>
+    <alias name="" index="9" field="cross_section_definition_id"/>
+    <alias name="" index="10" field="external"/>
+    <alias name="" index="11" field="crest_type"/>
+    <alias name="" index="12" field="friction_type"/>
+    <alias name="" index="13" field="friction_value"/>
+    <alias name="" index="14" field="id"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="zoom_category" expression="4"/>
+    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
     <default applyOnUpdate="0" field="code" expression="'new'"/>
     <default applyOnUpdate="0" field="display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
     <default applyOnUpdate="0" field="discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="dist_calc_points" expression="10000"/>
+    <default applyOnUpdate="0" field="sewerage" expression=""/>
     <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
+    <default applyOnUpdate="0" field="crest_level" expression=""/>
     <default applyOnUpdate="0" field="discharge_coefficient_positive" expression="0.8"/>
     <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_end_point" expression=""/>
-    <default applyOnUpdate="0" field="invert_level_start_point" expression=""/>
-    <default applyOnUpdate="0" field="calculation_type" expression="101"/>
+    <default applyOnUpdate="0" field="external" expression="1"/>
+    <default applyOnUpdate="0" field="crest_type" expression="4"/>
     <default applyOnUpdate="0" field="friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="friction_value" expression="0.0145"/>
+    <default applyOnUpdate="0" field="friction_value" expression="0.02"/>
     <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
   </defaults>
   <constraints>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="dist_calc_points" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sewerage" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_level" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_positive" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_end_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="invert_level_start_point" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="calculation_type" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="external" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_type" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_type" unique_strength="0"/>
     <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_value" unique_strength="0"/>
     <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="zoom_category" desc=""/>
     <constraint exp="" field="code" desc=""/>
     <constraint exp="" field="display_name" desc=""/>
+    <constraint exp="" field="connection_node_end_id" desc=""/>
     <constraint exp="" field="discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="dist_calc_points" desc=""/>
+    <constraint exp="" field="sewerage" desc=""/>
     <constraint exp="" field="connection_node_start_id" desc=""/>
+    <constraint exp="" field="crest_level" desc=""/>
     <constraint exp="" field="discharge_coefficient_positive" desc=""/>
     <constraint exp="" field="cross_section_definition_id" desc=""/>
-    <constraint exp="" field="invert_level_end_point" desc=""/>
-    <constraint exp="" field="invert_level_start_point" desc=""/>
-    <constraint exp="" field="calculation_type" desc=""/>
+    <constraint exp="" field="external" desc=""/>
+    <constraint exp="" field="crest_type" desc=""/>
     <constraint exp="" field="friction_type" desc=""/>
     <constraint exp="" field="friction_value" desc=""/>
     <constraint exp="" field="id" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
@@ -385,18 +279,18 @@
       <column name="zoom_category" hidden="0" width="-1" type="field"/>
       <column name="code" hidden="0" width="-1" type="field"/>
       <column name="display_name" hidden="0" width="-1" type="field"/>
+      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
       <column name="discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="dist_calc_points" hidden="0" width="-1" type="field"/>
+      <column name="sewerage" hidden="0" width="-1" type="field"/>
       <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
+      <column name="crest_level" hidden="0" width="-1" type="field"/>
       <column name="discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
       <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_end_point" hidden="0" width="-1" type="field"/>
-      <column name="invert_level_start_point" hidden="0" width="-1" type="field"/>
-      <column name="calculation_type" hidden="0" width="-1" type="field"/>
+      <column name="external" hidden="0" width="-1" type="field"/>
+      <column name="crest_type" hidden="0" width="-1" type="field"/>
       <column name="friction_type" hidden="0" width="-1" type="field"/>
       <column name="friction_value" hidden="0" width="-1" type="field"/>
       <column name="id" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
       <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
@@ -404,10 +298,10 @@
     <rowstyles/>
     <fieldstyles/>
   </conditionalstyles>
-  <editform tolerant="1">.</editform>
+  <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath>.</editforminitfilepath>
+  <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -419,7 +313,7 @@ Enter the name of the function in the "Python Init function"
 field.
 An example follows:
 """
-from PyQt4.QtGui import QWidget
+from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
@@ -428,68 +322,68 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Culvert" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+    <attributeEditorContainer name="Weir" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
       <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="13" showLabel="1"/>
+        <attributeEditorField name="id" index="14" showLabel="1"/>
         <attributeEditorField name="display_name" index="2" showLabel="1"/>
         <attributeEditorField name="code" index="1" showLabel="1"/>
-        <attributeEditorField name="calculation_type" index="10" showLabel="1"/>
-        <attributeEditorField name="dist_calc_points" index="4" showLabel="1"/>
       </attributeEditorContainer>
       <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="invert_level_start_point" index="9" showLabel="1"/>
-        <attributeEditorField name="invert_level_end_point" index="8" showLabel="1"/>
-        <attributeEditorField name="friction_value" index="12" showLabel="1"/>
-        <attributeEditorField name="friction_type" index="11" showLabel="1"/>
-        <attributeEditorField name="cross_section_definition_id" index="7" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_positive" index="6" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_negative" index="3" showLabel="1"/>
+        <attributeEditorField name="crest_level" index="7" showLabel="1"/>
+        <attributeEditorField name="crest_type" index="11" showLabel="1"/>
+        <attributeEditorField name="discharge_coefficient_positive" index="8" showLabel="1"/>
+        <attributeEditorField name="discharge_coefficient_negative" index="4" showLabel="1"/>
+        <attributeEditorField name="friction_value" index="13" showLabel="1"/>
+        <attributeEditorField name="friction_type" index="12" showLabel="1"/>
+        <attributeEditorField name="cross_section_definition_id" index="9" showLabel="1"/>
       </attributeEditorContainer>
       <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
         <attributeEditorField name="zoom_category" index="0" showLabel="1"/>
+        <attributeEditorField name="sewerage" index="5" showLabel="1"/>
+        <attributeEditorField name="external" index="10" showLabel="1"/>
       </attributeEditorContainer>
       <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="5" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="14" showLabel="1"/>
+        <attributeEditorField name="connection_node_start_id" index="6" showLabel="1"/>
+        <attributeEditorField name="connection_node_end_id" index="3" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="calculation_type" editable="1"/>
     <field name="code" editable="1"/>
     <field name="connection_node_end_id" editable="1"/>
     <field name="connection_node_start_id" editable="1"/>
+    <field name="crest_level" editable="1"/>
+    <field name="crest_type" editable="1"/>
     <field name="cross_section_definition_id" editable="1"/>
     <field name="discharge_coefficient_negative" editable="1"/>
     <field name="discharge_coefficient_positive" editable="1"/>
     <field name="display_name" editable="1"/>
-    <field name="dist_calc_points" editable="1"/>
+    <field name="external" editable="1"/>
     <field name="friction_type" editable="1"/>
     <field name="friction_value" editable="1"/>
     <field name="id" editable="1"/>
-    <field name="invert_level_end_point" editable="1"/>
-    <field name="invert_level_start_point" editable="1"/>
+    <field name="sewerage" editable="1"/>
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="calculation_type" labelOnTop="0"/>
     <field name="code" labelOnTop="0"/>
     <field name="connection_node_end_id" labelOnTop="0"/>
     <field name="connection_node_start_id" labelOnTop="0"/>
+    <field name="crest_level" labelOnTop="0"/>
+    <field name="crest_type" labelOnTop="0"/>
     <field name="cross_section_definition_id" labelOnTop="0"/>
     <field name="discharge_coefficient_negative" labelOnTop="0"/>
     <field name="discharge_coefficient_positive" labelOnTop="0"/>
     <field name="display_name" labelOnTop="0"/>
-    <field name="dist_calc_points" labelOnTop="0"/>
+    <field name="external" labelOnTop="0"/>
     <field name="friction_type" labelOnTop="0"/>
     <field name="friction_value" labelOnTop="0"/>
     <field name="id" labelOnTop="0"/>
-    <field name="invert_level_end_point" labelOnTop="0"/>
-    <field name="invert_level_start_point" labelOnTop="0"/>
+    <field name="sewerage" labelOnTop="0"/>
     <field name="zoom_category" labelOnTop="0"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>
   <mapTip></mapTip>
-  <layerGeometryType>1</layerGeometryType>
+  <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_weir.qml
+++ b/layer_styles/schematisation/v2_weir.qml
@@ -1,12 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0">
+<qgis readOnly="0" version="3.4.5-Madeira" maxScale="0" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
   <customproperties>
-    <property value="display_name" key="dualview/previewExpressions"/>
+    <property key="dualview/previewExpressions">
+      <value>display_name</value>
+    </property>
     <property value="0" key="embeddedWidgets/count"/>
     <property key="variableNames"/>
     <property key="variableValues"/>
@@ -20,27 +22,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -51,8 +53,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -61,8 +63,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -71,8 +73,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -81,8 +83,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -91,8 +93,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="CheckedState" value="1" type="QString"/>
-            <Option name="UncheckedState" value="0" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -101,8 +103,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -111,8 +113,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -121,8 +123,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -131,8 +133,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -141,8 +143,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="CheckedState" value="1" type="QString"/>
-            <Option name="UncheckedState" value="0" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -151,12 +153,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="3: Broad crested" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: broad crested"/>
               </Option>
               <Option type="Map">
-                <Option name="4: Short crested" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: short crested"/>
               </Option>
             </Option>
           </Option>
@@ -167,12 +169,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Chezy" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Manning" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -183,8 +185,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -193,105 +195,105 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="zoom_category"/>
-    <alias name="" index="1" field="code"/>
-    <alias name="" index="2" field="display_name"/>
-    <alias name="" index="3" field="connection_node_end_id"/>
-    <alias name="" index="4" field="discharge_coefficient_negative"/>
-    <alias name="" index="5" field="sewerage"/>
-    <alias name="" index="6" field="connection_node_start_id"/>
-    <alias name="" index="7" field="crest_level"/>
-    <alias name="" index="8" field="discharge_coefficient_positive"/>
-    <alias name="" index="9" field="cross_section_definition_id"/>
-    <alias name="" index="10" field="external"/>
-    <alias name="" index="11" field="crest_type"/>
-    <alias name="" index="12" field="friction_type"/>
-    <alias name="" index="13" field="friction_value"/>
-    <alias name="" index="14" field="id"/>
+    <alias name="" field="zoom_category" index="0"/>
+    <alias name="" field="code" index="1"/>
+    <alias name="" field="display_name" index="2"/>
+    <alias name="" field="connection_node_end_id" index="3"/>
+    <alias name="" field="discharge_coefficient_negative" index="4"/>
+    <alias name="" field="sewerage" index="5"/>
+    <alias name="" field="connection_node_start_id" index="6"/>
+    <alias name="" field="crest_level" index="7"/>
+    <alias name="" field="discharge_coefficient_positive" index="8"/>
+    <alias name="" field="cross_section_definition_id" index="9"/>
+    <alias name="" field="external" index="10"/>
+    <alias name="" field="crest_type" index="11"/>
+    <alias name="" field="friction_type" index="12"/>
+    <alias name="" field="friction_value" index="13"/>
+    <alias name="" field="id" index="14"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="zoom_category" expression="3"/>
-    <default applyOnUpdate="0" field="code" expression="'new'"/>
-    <default applyOnUpdate="0" field="display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="connection_node_end_id" expression=""/>
-    <default applyOnUpdate="0" field="discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="sewerage" expression=""/>
-    <default applyOnUpdate="0" field="connection_node_start_id" expression=""/>
-    <default applyOnUpdate="0" field="crest_level" expression=""/>
-    <default applyOnUpdate="0" field="discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="external" expression="1"/>
-    <default applyOnUpdate="0" field="crest_type" expression="4"/>
-    <default applyOnUpdate="0" field="friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="friction_value" expression="0.02"/>
-    <default applyOnUpdate="0" field="id" expression="if(maximum(id) is null,1, maximum(id)+1)"/>
+    <default expression="3" applyOnUpdate="0" field="zoom_category"/>
+    <default expression="'new'" applyOnUpdate="0" field="code"/>
+    <default expression="'new'" applyOnUpdate="0" field="display_name"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_end_id"/>
+    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_negative"/>
+    <default expression="" applyOnUpdate="0" field="sewerage"/>
+    <default expression="" applyOnUpdate="0" field="connection_node_start_id"/>
+    <default expression="" applyOnUpdate="0" field="crest_level"/>
+    <default expression="0.8" applyOnUpdate="0" field="discharge_coefficient_positive"/>
+    <default expression="" applyOnUpdate="0" field="cross_section_definition_id"/>
+    <default expression="1" applyOnUpdate="0" field="external"/>
+    <default expression="4" applyOnUpdate="0" field="crest_type"/>
+    <default expression="2" applyOnUpdate="0" field="friction_type"/>
+    <default expression="0.02" applyOnUpdate="0" field="friction_value"/>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="sewerage" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_level" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="external" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="crest_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="friction_value" unique_strength="0"/>
-    <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_negative"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="sewerage"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="crest_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="discharge_coefficient_positive"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="cross_section_definition_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="external"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="crest_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="friction_value"/>
+    <constraint exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3" field="id"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="zoom_category" desc=""/>
-    <constraint exp="" field="code" desc=""/>
-    <constraint exp="" field="display_name" desc=""/>
-    <constraint exp="" field="connection_node_end_id" desc=""/>
-    <constraint exp="" field="discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="sewerage" desc=""/>
-    <constraint exp="" field="connection_node_start_id" desc=""/>
-    <constraint exp="" field="crest_level" desc=""/>
-    <constraint exp="" field="discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="cross_section_definition_id" desc=""/>
-    <constraint exp="" field="external" desc=""/>
-    <constraint exp="" field="crest_type" desc=""/>
-    <constraint exp="" field="friction_type" desc=""/>
-    <constraint exp="" field="friction_value" desc=""/>
-    <constraint exp="" field="id" desc=""/>
+    <constraint exp="" desc="" field="zoom_category"/>
+    <constraint exp="" desc="" field="code"/>
+    <constraint exp="" desc="" field="display_name"/>
+    <constraint exp="" desc="" field="connection_node_end_id"/>
+    <constraint exp="" desc="" field="discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="sewerage"/>
+    <constraint exp="" desc="" field="connection_node_start_id"/>
+    <constraint exp="" desc="" field="crest_level"/>
+    <constraint exp="" desc="" field="discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="cross_section_definition_id"/>
+    <constraint exp="" desc="" field="external"/>
+    <constraint exp="" desc="" field="crest_type"/>
+    <constraint exp="" desc="" field="friction_type"/>
+    <constraint exp="" desc="" field="friction_value"/>
+    <constraint exp="" desc="" field="id"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="code" hidden="0" width="-1" type="field"/>
-      <column name="display_name" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="sewerage" hidden="0" width="-1" type="field"/>
-      <column name="connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="crest_level" hidden="0" width="-1" type="field"/>
-      <column name="discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="cross_section_definition_id" hidden="0" width="-1" type="field"/>
-      <column name="external" hidden="0" width="-1" type="field"/>
-      <column name="crest_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_type" hidden="0" width="-1" type="field"/>
-      <column name="friction_value" hidden="0" width="-1" type="field"/>
-      <column name="id" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="code"/>
+      <column width="-1" type="field" hidden="0" name="display_name"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="discharge_coefficient_negative"/>
+      <column width="-1" type="field" hidden="0" name="sewerage"/>
+      <column width="-1" type="field" hidden="0" name="connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="crest_level"/>
+      <column width="-1" type="field" hidden="0" name="discharge_coefficient_positive"/>
+      <column width="-1" type="field" hidden="0" name="cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="external"/>
+      <column width="-1" type="field" hidden="0" name="crest_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_type"/>
+      <column width="-1" type="field" hidden="0" name="friction_value"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -322,29 +324,29 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Weir" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="id" index="14" showLabel="1"/>
-        <attributeEditorField name="display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="code" index="1" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Weir" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="id" index="14"/>
+        <attributeEditorField showLabel="1" name="display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="code" index="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="crest_level" index="7" showLabel="1"/>
-        <attributeEditorField name="crest_type" index="11" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_positive" index="8" showLabel="1"/>
-        <attributeEditorField name="discharge_coefficient_negative" index="4" showLabel="1"/>
-        <attributeEditorField name="friction_value" index="13" showLabel="1"/>
-        <attributeEditorField name="friction_type" index="12" showLabel="1"/>
-        <attributeEditorField name="cross_section_definition_id" index="9" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="crest_level" index="7"/>
+        <attributeEditorField showLabel="1" name="crest_type" index="11"/>
+        <attributeEditorField showLabel="1" name="discharge_coefficient_positive" index="8"/>
+        <attributeEditorField showLabel="1" name="discharge_coefficient_negative" index="4"/>
+        <attributeEditorField showLabel="1" name="friction_value" index="13"/>
+        <attributeEditorField showLabel="1" name="friction_type" index="12"/>
+        <attributeEditorField showLabel="1" name="cross_section_definition_id" index="9"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="zoom_category" index="0" showLabel="1"/>
-        <attributeEditorField name="sewerage" index="5" showLabel="1"/>
-        <attributeEditorField name="external" index="10" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="zoom_category" index="0"/>
+        <attributeEditorField showLabel="1" name="sewerage" index="5"/>
+        <attributeEditorField showLabel="1" name="external" index="10"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="connection_node_start_id" index="6" showLabel="1"/>
-        <attributeEditorField name="connection_node_end_id" index="3" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="connection_node_start_id" index="6"/>
+        <attributeEditorField showLabel="1" name="connection_node_end_id" index="3"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -366,21 +368,21 @@ def my_form_open(dialog, layer, feature):
     <field name="zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="code" labelOnTop="0"/>
-    <field name="connection_node_end_id" labelOnTop="0"/>
-    <field name="connection_node_start_id" labelOnTop="0"/>
-    <field name="crest_level" labelOnTop="0"/>
-    <field name="crest_type" labelOnTop="0"/>
-    <field name="cross_section_definition_id" labelOnTop="0"/>
-    <field name="discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="discharge_coefficient_positive" labelOnTop="0"/>
-    <field name="display_name" labelOnTop="0"/>
-    <field name="external" labelOnTop="0"/>
-    <field name="friction_type" labelOnTop="0"/>
-    <field name="friction_value" labelOnTop="0"/>
-    <field name="id" labelOnTop="0"/>
-    <field name="sewerage" labelOnTop="0"/>
-    <field name="zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="code"/>
+    <field labelOnTop="0" name="connection_node_end_id"/>
+    <field labelOnTop="0" name="connection_node_start_id"/>
+    <field labelOnTop="0" name="crest_level"/>
+    <field labelOnTop="0" name="crest_type"/>
+    <field labelOnTop="0" name="cross_section_definition_id"/>
+    <field labelOnTop="0" name="discharge_coefficient_negative"/>
+    <field labelOnTop="0" name="discharge_coefficient_positive"/>
+    <field labelOnTop="0" name="display_name"/>
+    <field labelOnTop="0" name="external"/>
+    <field labelOnTop="0" name="friction_type"/>
+    <field labelOnTop="0" name="friction_value"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="sewerage"/>
+    <field labelOnTop="0" name="zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>display_name</previewExpression>

--- a/layer_styles/schematisation/v2_weir_view.qml
+++ b/layer_styles/schematisation/v2_weir_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
+  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
     <symbols>
-      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
+        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
+        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
+            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
               <prop k="angle" v="0"/>
               <prop k="color" v="255,0,0,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -97,18 +97,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
-      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000"/>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute color="#000000" label="" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
     <properties>
       <Option type="Map">
-        <Option name="name" value="" type="QString"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option name="type" value="collection" type="QString"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -128,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -138,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -148,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -158,8 +158,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -168,12 +168,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="3: Broad crested" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: broad crested"/>
               </Option>
               <Option type="Map">
-                <Option name="4: Short crested" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4: short crested"/>
               </Option>
             </Option>
           </Option>
@@ -184,8 +184,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -194,8 +194,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="CheckedState" value="1" type="QString"/>
-            <Option name="UncheckedState" value="0" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -204,8 +204,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -214,8 +214,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -224,8 +224,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option name="CheckedState" value="1" type="QString"/>
-            <Option name="UncheckedState" value="0" type="QString"/>
+            <Option value="1" type="QString" name="CheckedState"/>
+            <Option value="0" type="QString" name="UncheckedState"/>
           </Option>
         </config>
       </editWidget>
@@ -234,27 +234,27 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="-1" value="-1" type="QString"/>
+                <Option value="-1" type="QString" name="-1"/>
               </Option>
               <Option type="Map">
-                <Option name="0" value="0" type="QString"/>
+                <Option value="0" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option name="1" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option name="2" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option name="3" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option name="4" value="4" type="QString"/>
+                <Option value="4" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option name="5" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5"/>
               </Option>
             </Option>
           </Option>
@@ -265,8 +265,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -275,12 +275,12 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="Chezy (1)" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Chèzy"/>
               </Option>
               <Option type="Map">
-                <Option name="Manning (2)" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Manning"/>
               </Option>
             </Option>
           </Option>
@@ -291,8 +291,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -301,8 +301,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -311,8 +311,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -321,21 +321,21 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="1: Rectangle" value="1" type="QString"/>
+                <Option value="1" type="QString" name="1: Rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="2: Circle" value="2" type="QString"/>
+                <Option value="2" type="QString" name="2: Circle"/>
               </Option>
               <Option type="Map">
-                <Option name="3: Egg" value="3" type="QString"/>
+                <Option value="3" type="QString" name="3: Egg"/>
               </Option>
               <Option type="Map">
-                <Option name="5: Tabulated rectangle" value="5" type="QString"/>
+                <Option value="5" type="QString" name="5: Tabulated rectangle"/>
               </Option>
               <Option type="Map">
-                <Option name="6: Tabulated trapezium" value="6" type="QString"/>
+                <Option value="6" type="QString" name="6: Tabulated trapezium"/>
               </Option>
             </Option>
           </Option>
@@ -346,8 +346,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -356,8 +356,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -366,135 +366,135 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="ROWID"/>
-    <alias name="id" index="1" field="weir_id"/>
-    <alias name="display_name" index="2" field="weir_display_name"/>
-    <alias name="code" index="3" field="weir_code"/>
-    <alias name="crest_level" index="4" field="weir_crest_level"/>
-    <alias name="crest_type" index="5" field="weir_crest_type"/>
-    <alias name="Cross_section_definition_id" index="6" field="weir_cross_section_definition_id"/>
-    <alias name="sewerage" index="7" field="weir_sewerage"/>
-    <alias name="discharge_coefficient_positive" index="8" field="weir_discharge_coefficient_positive"/>
-    <alias name="discharge_coefficient_negative" index="9" field="weir_discharge_coefficient_negative"/>
-    <alias name="external" index="10" field="weir_external"/>
-    <alias name="zoom_category" index="11" field="weir_zoom_category"/>
-    <alias name="friction_value" index="12" field="weir_friction_value"/>
-    <alias name="friction_type" index="13" field="weir_friction_type"/>
-    <alias name="connection_node_start_id" index="14" field="weir_connection_node_start_id"/>
-    <alias name="connection_node_end_id" index="15" field="weir_connection_node_end_id"/>
-    <alias name="id" index="16" field="def_id"/>
-    <alias name="shape" index="17" field="def_shape"/>
-    <alias name="width" index="18" field="def_width"/>
-    <alias name="height" index="19" field="def_height"/>
-    <alias name="code" index="20" field="def_code"/>
+    <alias name="" field="ROWID" index="0"/>
+    <alias name="id" field="weir_id" index="1"/>
+    <alias name="display_name" field="weir_display_name" index="2"/>
+    <alias name="code" field="weir_code" index="3"/>
+    <alias name="crest_level" field="weir_crest_level" index="4"/>
+    <alias name="crest_type" field="weir_crest_type" index="5"/>
+    <alias name="Cross_section_definition_id" field="weir_cross_section_definition_id" index="6"/>
+    <alias name="sewerage" field="weir_sewerage" index="7"/>
+    <alias name="discharge_coefficient_positive" field="weir_discharge_coefficient_positive" index="8"/>
+    <alias name="discharge_coefficient_negative" field="weir_discharge_coefficient_negative" index="9"/>
+    <alias name="external" field="weir_external" index="10"/>
+    <alias name="zoom_category" field="weir_zoom_category" index="11"/>
+    <alias name="friction_value" field="weir_friction_value" index="12"/>
+    <alias name="friction_type" field="weir_friction_type" index="13"/>
+    <alias name="connection_node_start_id" field="weir_connection_node_start_id" index="14"/>
+    <alias name="connection_node_end_id" field="weir_connection_node_end_id" index="15"/>
+    <alias name="id" field="def_id" index="16"/>
+    <alias name="shape" field="def_shape" index="17"/>
+    <alias name="width" field="def_width" index="18"/>
+    <alias name="height" field="def_height" index="19"/>
+    <alias name="code" field="def_code" index="20"/>
   </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default applyOnUpdate="0" field="ROWID" expression=""/>
-    <default applyOnUpdate="0" field="weir_id" expression="if(maximum(weir_id) is null,1, maximum(weir_id)+1)"/>
-    <default applyOnUpdate="0" field="weir_display_name" expression="'new'"/>
-    <default applyOnUpdate="0" field="weir_code" expression="'new'"/>
-    <default applyOnUpdate="0" field="weir_crest_level" expression=""/>
-    <default applyOnUpdate="0" field="weir_crest_type" expression="4"/>
-    <default applyOnUpdate="0" field="weir_cross_section_definition_id" expression=""/>
-    <default applyOnUpdate="0" field="weir_sewerage" expression=""/>
-    <default applyOnUpdate="0" field="weir_discharge_coefficient_positive" expression="0.8"/>
-    <default applyOnUpdate="0" field="weir_discharge_coefficient_negative" expression="0.8"/>
-    <default applyOnUpdate="0" field="weir_external" expression="1"/>
-    <default applyOnUpdate="0" field="weir_zoom_category" expression="2"/>
-    <default applyOnUpdate="0" field="weir_friction_value" expression="0.02"/>
-    <default applyOnUpdate="0" field="weir_friction_type" expression="2"/>
-    <default applyOnUpdate="0" field="weir_connection_node_start_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="weir_connection_node_end_id" expression="'filled automatically'"/>
-    <default applyOnUpdate="0" field="def_id" expression=""/>
-    <default applyOnUpdate="0" field="def_shape" expression=""/>
-    <default applyOnUpdate="0" field="def_width" expression=""/>
-    <default applyOnUpdate="0" field="def_height" expression=""/>
-    <default applyOnUpdate="0" field="def_code" expression=""/>
+    <default expression="" applyOnUpdate="0" field="ROWID"/>
+    <default expression="if(maximum(weir_id) is null,1, maximum(weir_id)+1)" applyOnUpdate="0" field="weir_id"/>
+    <default expression="'new'" applyOnUpdate="0" field="weir_display_name"/>
+    <default expression="'new'" applyOnUpdate="0" field="weir_code"/>
+    <default expression="" applyOnUpdate="0" field="weir_crest_level"/>
+    <default expression="4" applyOnUpdate="0" field="weir_crest_type"/>
+    <default expression="" applyOnUpdate="0" field="weir_cross_section_definition_id"/>
+    <default expression="" applyOnUpdate="0" field="weir_sewerage"/>
+    <default expression="0.8" applyOnUpdate="0" field="weir_discharge_coefficient_positive"/>
+    <default expression="0.8" applyOnUpdate="0" field="weir_discharge_coefficient_negative"/>
+    <default expression="1" applyOnUpdate="0" field="weir_external"/>
+    <default expression="2" applyOnUpdate="0" field="weir_zoom_category"/>
+    <default expression="0.02" applyOnUpdate="0" field="weir_friction_value"/>
+    <default expression="2" applyOnUpdate="0" field="weir_friction_type"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="weir_connection_node_start_id"/>
+    <default expression="'filled automatically'" applyOnUpdate="0" field="weir_connection_node_end_id"/>
+    <default expression="" applyOnUpdate="0" field="def_id"/>
+    <default expression="" applyOnUpdate="0" field="def_shape"/>
+    <default expression="" applyOnUpdate="0" field="def_width"/>
+    <default expression="" applyOnUpdate="0" field="def_height"/>
+    <default expression="" applyOnUpdate="0" field="def_code"/>
   </defaults>
   <constraints>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_display_name" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_code" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_crest_level" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_crest_type" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_cross_section_definition_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_sewerage" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_discharge_coefficient_positive" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_discharge_coefficient_negative" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_external" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_zoom_category" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_friction_value" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_friction_type" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_connection_node_start_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_connection_node_end_id" unique_strength="0"/>
-    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
-    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_display_name"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_code"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_crest_level"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_crest_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_cross_section_definition_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_sewerage"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_discharge_coefficient_positive"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_discharge_coefficient_negative"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_external"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_zoom_category"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_friction_value"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_friction_type"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_connection_node_start_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_connection_node_end_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
+    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="ROWID" desc=""/>
-    <constraint exp="" field="weir_id" desc=""/>
-    <constraint exp="" field="weir_display_name" desc=""/>
-    <constraint exp="" field="weir_code" desc=""/>
-    <constraint exp="" field="weir_crest_level" desc=""/>
-    <constraint exp="" field="weir_crest_type" desc=""/>
-    <constraint exp="" field="weir_cross_section_definition_id" desc=""/>
-    <constraint exp="" field="weir_sewerage" desc=""/>
-    <constraint exp="" field="weir_discharge_coefficient_positive" desc=""/>
-    <constraint exp="" field="weir_discharge_coefficient_negative" desc=""/>
-    <constraint exp="" field="weir_external" desc=""/>
-    <constraint exp="" field="weir_zoom_category" desc=""/>
-    <constraint exp="" field="weir_friction_value" desc=""/>
-    <constraint exp="" field="weir_friction_type" desc=""/>
-    <constraint exp="" field="weir_connection_node_start_id" desc=""/>
-    <constraint exp="" field="weir_connection_node_end_id" desc=""/>
-    <constraint exp="" field="def_id" desc=""/>
-    <constraint exp="" field="def_shape" desc=""/>
-    <constraint exp="" field="def_width" desc=""/>
-    <constraint exp="" field="def_height" desc=""/>
-    <constraint exp="" field="def_code" desc=""/>
+    <constraint exp="" desc="" field="ROWID"/>
+    <constraint exp="" desc="" field="weir_id"/>
+    <constraint exp="" desc="" field="weir_display_name"/>
+    <constraint exp="" desc="" field="weir_code"/>
+    <constraint exp="" desc="" field="weir_crest_level"/>
+    <constraint exp="" desc="" field="weir_crest_type"/>
+    <constraint exp="" desc="" field="weir_cross_section_definition_id"/>
+    <constraint exp="" desc="" field="weir_sewerage"/>
+    <constraint exp="" desc="" field="weir_discharge_coefficient_positive"/>
+    <constraint exp="" desc="" field="weir_discharge_coefficient_negative"/>
+    <constraint exp="" desc="" field="weir_external"/>
+    <constraint exp="" desc="" field="weir_zoom_category"/>
+    <constraint exp="" desc="" field="weir_friction_value"/>
+    <constraint exp="" desc="" field="weir_friction_type"/>
+    <constraint exp="" desc="" field="weir_connection_node_start_id"/>
+    <constraint exp="" desc="" field="weir_connection_node_end_id"/>
+    <constraint exp="" desc="" field="def_id"/>
+    <constraint exp="" desc="" field="def_shape"/>
+    <constraint exp="" desc="" field="def_width"/>
+    <constraint exp="" desc="" field="def_height"/>
+    <constraint exp="" desc="" field="def_code"/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
     <columns>
-      <column name="ROWID" hidden="0" width="-1" type="field"/>
-      <column name="weir_id" hidden="0" width="-1" type="field"/>
-      <column name="weir_display_name" hidden="0" width="-1" type="field"/>
-      <column name="weir_code" hidden="0" width="-1" type="field"/>
-      <column name="weir_crest_level" hidden="0" width="-1" type="field"/>
-      <column name="weir_crest_type" hidden="0" width="-1" type="field"/>
-      <column name="weir_cross_section_definition_id" hidden="0" width="185" type="field"/>
-      <column name="weir_sewerage" hidden="0" width="-1" type="field"/>
-      <column name="weir_discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
-      <column name="weir_discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
-      <column name="weir_external" hidden="0" width="-1" type="field"/>
-      <column name="weir_zoom_category" hidden="0" width="-1" type="field"/>
-      <column name="weir_friction_value" hidden="0" width="-1" type="field"/>
-      <column name="weir_friction_type" hidden="0" width="-1" type="field"/>
-      <column name="weir_connection_node_start_id" hidden="0" width="-1" type="field"/>
-      <column name="weir_connection_node_end_id" hidden="0" width="-1" type="field"/>
-      <column name="def_id" hidden="0" width="-1" type="field"/>
-      <column name="def_shape" hidden="0" width="-1" type="field"/>
-      <column name="def_width" hidden="0" width="-1" type="field"/>
-      <column name="def_height" hidden="0" width="-1" type="field"/>
-      <column name="def_code" hidden="0" width="-1" type="field"/>
-      <column hidden="1" width="-1" type="actions"/>
+      <column width="-1" type="field" hidden="0" name="ROWID"/>
+      <column width="-1" type="field" hidden="0" name="weir_id"/>
+      <column width="-1" type="field" hidden="0" name="weir_display_name"/>
+      <column width="-1" type="field" hidden="0" name="weir_code"/>
+      <column width="-1" type="field" hidden="0" name="weir_crest_level"/>
+      <column width="-1" type="field" hidden="0" name="weir_crest_type"/>
+      <column width="185" type="field" hidden="0" name="weir_cross_section_definition_id"/>
+      <column width="-1" type="field" hidden="0" name="weir_sewerage"/>
+      <column width="-1" type="field" hidden="0" name="weir_discharge_coefficient_positive"/>
+      <column width="-1" type="field" hidden="0" name="weir_discharge_coefficient_negative"/>
+      <column width="-1" type="field" hidden="0" name="weir_external"/>
+      <column width="-1" type="field" hidden="0" name="weir_zoom_category"/>
+      <column width="-1" type="field" hidden="0" name="weir_friction_value"/>
+      <column width="-1" type="field" hidden="0" name="weir_friction_type"/>
+      <column width="-1" type="field" hidden="0" name="weir_connection_node_start_id"/>
+      <column width="-1" type="field" hidden="0" name="weir_connection_node_end_id"/>
+      <column width="-1" type="field" hidden="0" name="def_id"/>
+      <column width="-1" type="field" hidden="0" name="def_shape"/>
+      <column width="-1" type="field" hidden="0" name="def_width"/>
+      <column width="-1" type="field" hidden="0" name="def_height"/>
+      <column width="-1" type="field" hidden="0" name="def_code"/>
+      <column width="-1" type="actions" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -525,35 +525,35 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer name="Weir view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="weir_id" index="1" showLabel="1"/>
-        <attributeEditorField name="weir_display_name" index="2" showLabel="1"/>
-        <attributeEditorField name="weir_code" index="3" showLabel="1"/>
+    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Weir view" columnCount="1">
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
+        <attributeEditorField showLabel="1" name="weir_id" index="1"/>
+        <attributeEditorField showLabel="1" name="weir_display_name" index="2"/>
+        <attributeEditorField showLabel="1" name="weir_code" index="3"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="weir_crest_level" index="4" showLabel="1"/>
-        <attributeEditorField name="weir_crest_type" index="5" showLabel="1"/>
-        <attributeEditorField name="weir_discharge_coefficient_positive" index="8" showLabel="1"/>
-        <attributeEditorField name="weir_discharge_coefficient_negative" index="9" showLabel="1"/>
-        <attributeEditorField name="weir_friction_value" index="12" showLabel="1"/>
-        <attributeEditorField name="weir_friction_type" index="13" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
+        <attributeEditorField showLabel="1" name="weir_crest_level" index="4"/>
+        <attributeEditorField showLabel="1" name="weir_crest_type" index="5"/>
+        <attributeEditorField showLabel="1" name="weir_discharge_coefficient_positive" index="8"/>
+        <attributeEditorField showLabel="1" name="weir_discharge_coefficient_negative" index="9"/>
+        <attributeEditorField showLabel="1" name="weir_friction_value" index="12"/>
+        <attributeEditorField showLabel="1" name="weir_friction_type" index="13"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Cross section" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="weir_cross_section_definition_id" index="6" showLabel="1"/>
-        <attributeEditorField name="def_code" index="20" showLabel="1"/>
-        <attributeEditorField name="def_shape" index="17" showLabel="1"/>
-        <attributeEditorField name="def_width" index="18" showLabel="1"/>
-        <attributeEditorField name="def_height" index="19" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section" columnCount="1">
+        <attributeEditorField showLabel="1" name="weir_cross_section_definition_id" index="6"/>
+        <attributeEditorField showLabel="1" name="def_code" index="20"/>
+        <attributeEditorField showLabel="1" name="def_shape" index="17"/>
+        <attributeEditorField showLabel="1" name="def_width" index="18"/>
+        <attributeEditorField showLabel="1" name="def_height" index="19"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="weir_sewerage" index="7" showLabel="1"/>
-        <attributeEditorField name="weir_external" index="10" showLabel="1"/>
-        <attributeEditorField name="weir_zoom_category" index="11" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
+        <attributeEditorField showLabel="1" name="weir_sewerage" index="7"/>
+        <attributeEditorField showLabel="1" name="weir_external" index="10"/>
+        <attributeEditorField showLabel="1" name="weir_zoom_category" index="11"/>
       </attributeEditorContainer>
-      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
-        <attributeEditorField name="weir_connection_node_start_id" index="14" showLabel="1"/>
-        <attributeEditorField name="weir_connection_node_end_id" index="15" showLabel="1"/>
+      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
+        <attributeEditorField showLabel="1" name="weir_connection_node_start_id" index="14"/>
+        <attributeEditorField showLabel="1" name="weir_connection_node_end_id" index="15"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
@@ -581,27 +581,27 @@ def my_form_open(dialog, layer, feature):
     <field name="weir_zoom_category" editable="1"/>
   </editable>
   <labelOnTop>
-    <field name="ROWID" labelOnTop="0"/>
-    <field name="def_code" labelOnTop="0"/>
-    <field name="def_height" labelOnTop="0"/>
-    <field name="def_id" labelOnTop="0"/>
-    <field name="def_shape" labelOnTop="0"/>
-    <field name="def_width" labelOnTop="0"/>
-    <field name="weir_code" labelOnTop="0"/>
-    <field name="weir_connection_node_end_id" labelOnTop="0"/>
-    <field name="weir_connection_node_start_id" labelOnTop="0"/>
-    <field name="weir_crest_level" labelOnTop="0"/>
-    <field name="weir_crest_type" labelOnTop="0"/>
-    <field name="weir_cross_section_definition_id" labelOnTop="0"/>
-    <field name="weir_discharge_coefficient_negative" labelOnTop="0"/>
-    <field name="weir_discharge_coefficient_positive" labelOnTop="0"/>
-    <field name="weir_display_name" labelOnTop="0"/>
-    <field name="weir_external" labelOnTop="0"/>
-    <field name="weir_friction_type" labelOnTop="0"/>
-    <field name="weir_friction_value" labelOnTop="0"/>
-    <field name="weir_id" labelOnTop="0"/>
-    <field name="weir_sewerage" labelOnTop="0"/>
-    <field name="weir_zoom_category" labelOnTop="0"/>
+    <field labelOnTop="0" name="ROWID"/>
+    <field labelOnTop="0" name="def_code"/>
+    <field labelOnTop="0" name="def_height"/>
+    <field labelOnTop="0" name="def_id"/>
+    <field labelOnTop="0" name="def_shape"/>
+    <field labelOnTop="0" name="def_width"/>
+    <field labelOnTop="0" name="weir_code"/>
+    <field labelOnTop="0" name="weir_connection_node_end_id"/>
+    <field labelOnTop="0" name="weir_connection_node_start_id"/>
+    <field labelOnTop="0" name="weir_crest_level"/>
+    <field labelOnTop="0" name="weir_crest_type"/>
+    <field labelOnTop="0" name="weir_cross_section_definition_id"/>
+    <field labelOnTop="0" name="weir_discharge_coefficient_negative"/>
+    <field labelOnTop="0" name="weir_discharge_coefficient_positive"/>
+    <field labelOnTop="0" name="weir_display_name"/>
+    <field labelOnTop="0" name="weir_external"/>
+    <field labelOnTop="0" name="weir_friction_type"/>
+    <field labelOnTop="0" name="weir_friction_value"/>
+    <field labelOnTop="0" name="weir_id"/>
+    <field labelOnTop="0" name="weir_sewerage"/>
+    <field labelOnTop="0" name="weir_zoom_category"/>
   </labelOnTop>
   <widgets/>
   <previewExpression>weir_display_name</previewExpression>

--- a/layer_styles/schematisation/v2_weir_view.qml
+++ b/layer_styles/schematisation/v2_weir_view.qml
@@ -1,74 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.14.4-Essen" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
-  <edittypes>
-    <edittype widgetv2type="TextEdit" name="ROWID">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_display_name">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_code">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_crest_level">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_crest_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_cross_section_definition_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_sewerage">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_discharge_coefficient_positive">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_discharge_coefficient_negative">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_external">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_zoom_category">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_friction_value">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_friction_type">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_connection_node_start_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="weir_connection_node_end_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_id">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_shape">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_width">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-    <edittype widgetv2type="TextEdit" name="def_height">
-      <widgetv2config IsMultiline="0" fieldEditable="1" UseHtml="0" labelOnTop="0"/>
-    </edittype>
-  </edittypes>
-  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+<qgis labelsEnabled="0" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyMaxScale="1" minScale="1e+08" readOnly="0" version="3.4.5-Madeira" maxScale="0" simplifyDrawingHints="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol name="0" force_rhr="0" alpha="1" type="line" clip_to_extent="1">
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
@@ -77,250 +20,488 @@
           <prop k="line_width" v="0.66"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="MarkerLine" locked="0">
+        <layer class="MarkerLine" pass="0" locked="0" enabled="1">
           <prop k="interval" v="3"/>
-          <prop k="interval_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_along_line" v="0"/>
-          <prop k="offset_along_line_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_along_line_unit" v="MM"/>
-          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
           <prop k="placement" v="centralpoint"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="rotate" v="0"/>
-          <symbol alpha="1" clip_to_extent="1" type="marker" name="@0@1">
-            <layer pass="0" class="SimpleMarker" locked="0">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <symbol name="@0@1" force_rhr="0" alpha="1" type="marker" clip_to_extent="1">
+            <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
               <prop k="angle" v="0"/>
               <prop k="color" v="255,0,0,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
               <prop k="name" v="triangle"/>
               <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="offset_unit" v="MM"/>
               <prop k="outline_color" v="0,0,0,255"/>
               <prop k="outline_style" v="solid"/>
               <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="outline_width_unit" v="MM"/>
               <prop k="scale_method" v="area"/>
               <prop k="size" v="3"/>
-              <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="size_unit" v="MM"/>
               <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
     </symbols>
     <rotation/>
-    <sizescale scalemethod="diameter"/>
+    <sizescale/>
   </renderer-v2>
-  <labeling type="simple"/>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidInside" value="false"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/distMapUnitMaxScale" value="0"/>
-    <property key="labeling/distMapUnitMinScale" value="0"/>
-    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/drawLabels" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fitInPolygonOnly" value="false"/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value="MS Shell Dlg 2"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="8.25"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="true"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value="Normal"/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/obstacleFactor" value="1"/>
-    <property key="labeling/obstacleType" value="0"/>
-    <property key="labeling/offsetType" value="0"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/repeatDistance" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMaxScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitMinScale" value="0"/>
-    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/repeatDistanceUnit" value="1"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusMapUnitMaxScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitMinScale" value="0"/>
-    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeMapUnitMaxScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitMinScale" value="0"/>
-    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
-    <property key="labeling/zIndex" value="0"/>
-    <property key="variableNames" value="_fields_"/>
-    <property key="variableValues" value=""/>
+    <property value="weir_display_name" key="dualview/previewExpressions"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>weir_display_name</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="MS Shell Dlg 2"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <SingleCategoryDiagramRenderer diagramType="Pie">
-    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" sizeType="MM" minScaleDenominator="0">
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory lineSizeType="MM" diagramOrientation="Up" labelPlacementMethod="XHeight" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" width="15" maxScaleDenominator="1e+08" height="15" sizeType="MM" rotationOffset="270" penWidth="0" enabled="0" minimumSize="0" backgroundAlpha="255" minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" penColor="#000000" opacity="1" penAlpha="255" barWidth="5">
       <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attribute label="" field="" color="#000000"/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings yPosColumn="-1" linePlacementFlags="10" placement="2" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
-  <annotationform>.</annotationform>
+  <DiagramLayerSettings placement="2" dist="0" obstacle="0" showAll="1" priority="0" zIndex="0" linePlacementFlags="2">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="ROWID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_display_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_crest_level">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_crest_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="3: Broad crested" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4: Short crested" value="4" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_cross_section_definition_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_sewerage">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option name="CheckedState" value="1" type="QString"/>
+            <Option name="UncheckedState" value="0" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_discharge_coefficient_positive">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_discharge_coefficient_negative">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_external">
+      <editWidget type="CheckBox">
+        <config>
+          <Option type="Map">
+            <Option name="CheckedState" value="1" type="QString"/>
+            <Option name="UncheckedState" value="0" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_zoom_category">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="-1" value="-1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="0" value="0" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="1" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="4" value="4" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5" value="5" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_friction_value">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_friction_type">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="Chezy (1)" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="Manning (2)" value="2" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_connection_node_start_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="weir_connection_node_end_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_shape">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="1: Rectangle" value="1" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="2: Circle" value="2" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="3: Egg" value="3" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="5: Tabulated rectangle" value="5" type="QString"/>
+              </Option>
+              <Option type="Map">
+                <Option name="6: Tabulated trapezium" value="6" type="QString"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_width">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_height">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="def_code">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="ROWID"/>
+    <alias name="id" index="1" field="weir_id"/>
+    <alias name="display_name" index="2" field="weir_display_name"/>
+    <alias name="code" index="3" field="weir_code"/>
+    <alias name="crest_level" index="4" field="weir_crest_level"/>
+    <alias name="crest_type" index="5" field="weir_crest_type"/>
+    <alias name="Cross_section_definition_id" index="6" field="weir_cross_section_definition_id"/>
+    <alias name="sewerage" index="7" field="weir_sewerage"/>
+    <alias name="discharge_coefficient_positive" index="8" field="weir_discharge_coefficient_positive"/>
+    <alias name="discharge_coefficient_negative" index="9" field="weir_discharge_coefficient_negative"/>
+    <alias name="external" index="10" field="weir_external"/>
+    <alias name="zoom_category" index="11" field="weir_zoom_category"/>
+    <alias name="friction_value" index="12" field="weir_friction_value"/>
+    <alias name="friction_type" index="13" field="weir_friction_type"/>
+    <alias name="connection_node_start_id" index="14" field="weir_connection_node_start_id"/>
+    <alias name="connection_node_end_id" index="15" field="weir_connection_node_end_id"/>
+    <alias name="id" index="16" field="def_id"/>
+    <alias name="shape" index="17" field="def_shape"/>
+    <alias name="width" index="18" field="def_width"/>
+    <alias name="height" index="19" field="def_height"/>
+    <alias name="code" index="20" field="def_code"/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
-  <editform>.</editform>
+  <defaults>
+    <default applyOnUpdate="0" field="ROWID" expression=""/>
+    <default applyOnUpdate="0" field="weir_id" expression="if(maximum(weir_id) is null,1, maximum(weir_id)+1)"/>
+    <default applyOnUpdate="0" field="weir_display_name" expression="'new'"/>
+    <default applyOnUpdate="0" field="weir_code" expression="'new'"/>
+    <default applyOnUpdate="0" field="weir_crest_level" expression=""/>
+    <default applyOnUpdate="0" field="weir_crest_type" expression="4"/>
+    <default applyOnUpdate="0" field="weir_cross_section_definition_id" expression=""/>
+    <default applyOnUpdate="0" field="weir_sewerage" expression=""/>
+    <default applyOnUpdate="0" field="weir_discharge_coefficient_positive" expression="0.8"/>
+    <default applyOnUpdate="0" field="weir_discharge_coefficient_negative" expression="0.8"/>
+    <default applyOnUpdate="0" field="weir_external" expression="1"/>
+    <default applyOnUpdate="0" field="weir_zoom_category" expression="2"/>
+    <default applyOnUpdate="0" field="weir_friction_value" expression="0.02"/>
+    <default applyOnUpdate="0" field="weir_friction_type" expression="2"/>
+    <default applyOnUpdate="0" field="weir_connection_node_start_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="weir_connection_node_end_id" expression="'filled automatically'"/>
+    <default applyOnUpdate="0" field="def_id" expression=""/>
+    <default applyOnUpdate="0" field="def_shape" expression=""/>
+    <default applyOnUpdate="0" field="def_width" expression=""/>
+    <default applyOnUpdate="0" field="def_height" expression=""/>
+    <default applyOnUpdate="0" field="def_code" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="ROWID" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_display_name" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_code" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_crest_level" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_crest_type" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_cross_section_definition_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_sewerage" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_discharge_coefficient_positive" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_discharge_coefficient_negative" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_external" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_zoom_category" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_friction_value" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="weir_friction_type" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_connection_node_start_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="weir_connection_node_end_id" unique_strength="0"/>
+    <constraint notnull_strength="2" constraints="1" exp_strength="0" field="def_id" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_shape" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_width" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_height" unique_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" exp_strength="0" field="def_code" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="weir_id" desc=""/>
+    <constraint exp="" field="weir_display_name" desc=""/>
+    <constraint exp="" field="weir_code" desc=""/>
+    <constraint exp="" field="weir_crest_level" desc=""/>
+    <constraint exp="" field="weir_crest_type" desc=""/>
+    <constraint exp="" field="weir_cross_section_definition_id" desc=""/>
+    <constraint exp="" field="weir_sewerage" desc=""/>
+    <constraint exp="" field="weir_discharge_coefficient_positive" desc=""/>
+    <constraint exp="" field="weir_discharge_coefficient_negative" desc=""/>
+    <constraint exp="" field="weir_external" desc=""/>
+    <constraint exp="" field="weir_zoom_category" desc=""/>
+    <constraint exp="" field="weir_friction_value" desc=""/>
+    <constraint exp="" field="weir_friction_type" desc=""/>
+    <constraint exp="" field="weir_connection_node_start_id" desc=""/>
+    <constraint exp="" field="weir_connection_node_end_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+    <columns>
+      <column name="ROWID" hidden="0" width="-1" type="field"/>
+      <column name="weir_id" hidden="0" width="-1" type="field"/>
+      <column name="weir_display_name" hidden="0" width="-1" type="field"/>
+      <column name="weir_code" hidden="0" width="-1" type="field"/>
+      <column name="weir_crest_level" hidden="0" width="-1" type="field"/>
+      <column name="weir_crest_type" hidden="0" width="-1" type="field"/>
+      <column name="weir_cross_section_definition_id" hidden="0" width="185" type="field"/>
+      <column name="weir_sewerage" hidden="0" width="-1" type="field"/>
+      <column name="weir_discharge_coefficient_positive" hidden="0" width="-1" type="field"/>
+      <column name="weir_discharge_coefficient_negative" hidden="0" width="-1" type="field"/>
+      <column name="weir_external" hidden="0" width="-1" type="field"/>
+      <column name="weir_zoom_category" hidden="0" width="-1" type="field"/>
+      <column name="weir_friction_value" hidden="0" width="-1" type="field"/>
+      <column name="weir_friction_type" hidden="0" width="-1" type="field"/>
+      <column name="weir_connection_node_start_id" hidden="0" width="-1" type="field"/>
+      <column name="weir_connection_node_end_id" hidden="0" width="-1" type="field"/>
+      <column name="def_id" hidden="0" width="-1" type="field"/>
+      <column name="def_shape" hidden="0" width="-1" type="field"/>
+      <column name="def_width" hidden="0" width="-1" type="field"/>
+      <column name="def_height" hidden="0" width="-1" type="field"/>
+      <column name="def_code" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1">.</editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath>.</editforminitfilepath>
@@ -342,11 +523,88 @@ def my_form_open(dialog, layer, feature):
 	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer name="Weir view" groupBox="0" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+      <attributeEditorContainer name="General" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="weir_id" index="1" showLabel="1"/>
+        <attributeEditorField name="weir_display_name" index="2" showLabel="1"/>
+        <attributeEditorField name="weir_code" index="3" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Characteristics" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="weir_crest_level" index="4" showLabel="1"/>
+        <attributeEditorField name="weir_crest_type" index="5" showLabel="1"/>
+        <attributeEditorField name="weir_discharge_coefficient_positive" index="8" showLabel="1"/>
+        <attributeEditorField name="weir_discharge_coefficient_negative" index="9" showLabel="1"/>
+        <attributeEditorField name="weir_friction_value" index="12" showLabel="1"/>
+        <attributeEditorField name="weir_friction_type" index="13" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Cross section" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="weir_cross_section_definition_id" index="6" showLabel="1"/>
+        <attributeEditorField name="def_code" index="20" showLabel="1"/>
+        <attributeEditorField name="def_shape" index="17" showLabel="1"/>
+        <attributeEditorField name="def_width" index="18" showLabel="1"/>
+        <attributeEditorField name="def_height" index="19" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Visualization" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="weir_sewerage" index="7" showLabel="1"/>
+        <attributeEditorField name="weir_external" index="10" showLabel="1"/>
+        <attributeEditorField name="weir_zoom_category" index="11" showLabel="1"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="Connection nodes" groupBox="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+        <attributeEditorField name="weir_connection_node_start_id" index="14" showLabel="1"/>
+        <attributeEditorField name="weir_connection_node_end_id" index="15" showLabel="1"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="ROWID" editable="1"/>
+    <field name="def_code" editable="0"/>
+    <field name="def_height" editable="0"/>
+    <field name="def_id" editable="0"/>
+    <field name="def_shape" editable="0"/>
+    <field name="def_width" editable="0"/>
+    <field name="weir_code" editable="1"/>
+    <field name="weir_connection_node_end_id" editable="0"/>
+    <field name="weir_connection_node_start_id" editable="0"/>
+    <field name="weir_crest_level" editable="1"/>
+    <field name="weir_crest_type" editable="1"/>
+    <field name="weir_cross_section_definition_id" editable="1"/>
+    <field name="weir_discharge_coefficient_negative" editable="1"/>
+    <field name="weir_discharge_coefficient_positive" editable="1"/>
+    <field name="weir_display_name" editable="1"/>
+    <field name="weir_external" editable="1"/>
+    <field name="weir_friction_type" editable="1"/>
+    <field name="weir_friction_value" editable="1"/>
+    <field name="weir_id" editable="1"/>
+    <field name="weir_sewerage" editable="1"/>
+    <field name="weir_zoom_category" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="ROWID" labelOnTop="0"/>
+    <field name="def_code" labelOnTop="0"/>
+    <field name="def_height" labelOnTop="0"/>
+    <field name="def_id" labelOnTop="0"/>
+    <field name="def_shape" labelOnTop="0"/>
+    <field name="def_width" labelOnTop="0"/>
+    <field name="weir_code" labelOnTop="0"/>
+    <field name="weir_connection_node_end_id" labelOnTop="0"/>
+    <field name="weir_connection_node_start_id" labelOnTop="0"/>
+    <field name="weir_crest_level" labelOnTop="0"/>
+    <field name="weir_crest_type" labelOnTop="0"/>
+    <field name="weir_cross_section_definition_id" labelOnTop="0"/>
+    <field name="weir_discharge_coefficient_negative" labelOnTop="0"/>
+    <field name="weir_discharge_coefficient_positive" labelOnTop="0"/>
+    <field name="weir_display_name" labelOnTop="0"/>
+    <field name="weir_external" labelOnTop="0"/>
+    <field name="weir_friction_type" labelOnTop="0"/>
+    <field name="weir_friction_value" labelOnTop="0"/>
+    <field name="weir_id" labelOnTop="0"/>
+    <field name="weir_sewerage" labelOnTop="0"/>
+    <field name="weir_zoom_category" labelOnTop="0"/>
+  </labelOnTop>
   <widgets/>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
+  <previewExpression>weir_display_name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/layer_styles/schematisation/v2_weir_view.qml
+++ b/layer_styles/schematisation/v2_weir_view.qml
@@ -1,14 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" simplifyDrawingTol="1" version="3.4.5-Madeira" simplifyAlgorithm="0" simplifyMaxScale="1" maxScale="0" labelsEnabled="0" simplifyDrawingHints="1" simplifyLocal="1" styleCategories="AllStyleCategories" minScale="1e+08" hasScaleBasedVisibilityFlag="0">
+<qgis version="3.4.5-Madeira" labelsEnabled="0" styleCategories="AllStyleCategories" simplifyLocal="1" simplifyMaxScale="1" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" maxScale="0" readOnly="0" minScale="1e+08">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
   </flags>
-  <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+  <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="line" alpha="1" name="0">
-        <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+      <symbol type="line" name="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <layer enabled="1" locked="0" pass="0" class="SimpleLine">
           <prop k="capstyle" v="square"/>
           <prop k="customdash" v="5;2"/>
           <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -27,13 +27,13 @@
           <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <layer enabled="1" locked="0" pass="0" class="MarkerLine">
           <prop k="interval" v="3"/>
           <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="interval_unit" v="MM"/>
@@ -48,13 +48,13 @@
           <prop k="rotate" v="0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
-          <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1" name="@0@1">
-            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <symbol type="marker" name="@0@1" force_rhr="0" alpha="1" clip_to_extent="1">
+            <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
               <prop k="angle" v="0"/>
               <prop k="color" v="255,0,0,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -75,9 +75,9 @@
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" type="QString" name="name"/>
+                  <Option type="QString" name="name" value=""/>
                   <Option name="properties"/>
-                  <Option value="collection" type="QString" name="type"/>
+                  <Option type="QString" name="type" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -97,18 +97,18 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
-    <DiagramCategory opacity="1" lineSizeType="MM" backgroundColor="#ffffff" penColor="#000000" barWidth="5" sizeType="MM" penAlpha="255" minScaleDenominator="0" scaleBasedVisibility="0" diagramOrientation="Up" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" minimumSize="0" height="15" maxScaleDenominator="1e+08" penWidth="0" backgroundAlpha="255" width="15" enabled="0" scaleDependency="Area" rotationOffset="270">
+  <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+    <DiagramCategory scaleBasedVisibility="0" sizeType="MM" lineSizeType="MM" diagramOrientation="Up" barWidth="5" maxScaleDenominator="1e+08" labelPlacementMethod="XHeight" width="15" penAlpha="255" backgroundAlpha="255" penColor="#000000" penWidth="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" minimumSize="0" rotationOffset="270" minScaleDenominator="0" opacity="1" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0" enabled="0" height="15">
       <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
-      <attribute color="#000000" label="" field=""/>
+      <attribute label="" color="#000000" field=""/>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" linePlacementFlags="2" obstacle="0" showAll="1" placement="2" zIndex="0">
+  <DiagramLayerSettings zIndex="0" obstacle="0" showAll="1" priority="0" placement="2" dist="0" linePlacementFlags="2">
     <properties>
       <Option type="Map">
-        <Option value="" type="QString" name="name"/>
+        <Option type="QString" name="name" value=""/>
         <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
+        <Option type="QString" name="type" value="collection"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
@@ -128,8 +128,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -138,8 +138,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -148,8 +148,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -158,8 +158,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -170,10 +170,10 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="3" type="QString" name="3: broad crested"/>
+                <Option type="QString" name="3: broad crested" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4: short crested"/>
+                <Option type="QString" name="4: short crested" value="4"/>
               </Option>
             </Option>
           </Option>
@@ -184,8 +184,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -194,8 +194,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="1" type="QString" name="CheckedState"/>
-            <Option value="0" type="QString" name="UncheckedState"/>
+            <Option type="QString" name="CheckedState" value="1"/>
+            <Option type="QString" name="UncheckedState" value="0"/>
           </Option>
         </config>
       </editWidget>
@@ -204,8 +204,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -214,8 +214,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -224,8 +224,8 @@
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="1" type="QString" name="CheckedState"/>
-            <Option value="0" type="QString" name="UncheckedState"/>
+            <Option type="QString" name="CheckedState" value="1"/>
+            <Option type="QString" name="UncheckedState" value="0"/>
           </Option>
         </config>
       </editWidget>
@@ -236,25 +236,25 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="-1" type="QString" name="-1"/>
+                <Option type="QString" name="-1" value="-1"/>
               </Option>
               <Option type="Map">
-                <Option value="0" type="QString" name="0"/>
+                <Option type="QString" name="0" value="0"/>
               </Option>
               <Option type="Map">
-                <Option value="1" type="QString" name="1"/>
+                <Option type="QString" name="1" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2"/>
+                <Option type="QString" name="2" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3"/>
+                <Option type="QString" name="3" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="4" type="QString" name="4"/>
+                <Option type="QString" name="4" value="4"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5"/>
+                <Option type="QString" name="5" value="5"/>
               </Option>
             </Option>
           </Option>
@@ -265,8 +265,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -277,10 +277,10 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Chèzy"/>
+                <Option type="QString" name="1: Chèzy" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Manning"/>
+                <Option type="QString" name="2: Manning" value="2"/>
               </Option>
             </Option>
           </Option>
@@ -291,8 +291,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -301,8 +301,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -311,8 +311,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -323,19 +323,19 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option value="1" type="QString" name="1: Rectangle"/>
+                <Option type="QString" name="1: Rectangle" value="1"/>
               </Option>
               <Option type="Map">
-                <Option value="2" type="QString" name="2: Circle"/>
+                <Option type="QString" name="2: Circle" value="2"/>
               </Option>
               <Option type="Map">
-                <Option value="3" type="QString" name="3: Egg"/>
+                <Option type="QString" name="3: Egg" value="3"/>
               </Option>
               <Option type="Map">
-                <Option value="5" type="QString" name="5: Tabulated rectangle"/>
+                <Option type="QString" name="5: Tabulated rectangle" value="5"/>
               </Option>
               <Option type="Map">
-                <Option value="6" type="QString" name="6: Tabulated trapezium"/>
+                <Option type="QString" name="6: Tabulated trapezium" value="6"/>
               </Option>
             </Option>
           </Option>
@@ -346,8 +346,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -356,8 +356,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -366,8 +366,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option type="bool" name="IsMultiline" value="false"/>
+            <Option type="bool" name="UseHtml" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -399,102 +399,102 @@
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
   <defaults>
-    <default expression="" applyOnUpdate="0" field="ROWID"/>
-    <default expression="if(maximum(weir_id) is null,1, maximum(weir_id)+1)" applyOnUpdate="0" field="weir_id"/>
-    <default expression="'new'" applyOnUpdate="0" field="weir_display_name"/>
-    <default expression="'new'" applyOnUpdate="0" field="weir_code"/>
-    <default expression="" applyOnUpdate="0" field="weir_crest_level"/>
-    <default expression="4" applyOnUpdate="0" field="weir_crest_type"/>
-    <default expression="" applyOnUpdate="0" field="weir_cross_section_definition_id"/>
-    <default expression="" applyOnUpdate="0" field="weir_sewerage"/>
-    <default expression="0.8" applyOnUpdate="0" field="weir_discharge_coefficient_positive"/>
-    <default expression="0.8" applyOnUpdate="0" field="weir_discharge_coefficient_negative"/>
-    <default expression="1" applyOnUpdate="0" field="weir_external"/>
-    <default expression="2" applyOnUpdate="0" field="weir_zoom_category"/>
-    <default expression="0.02" applyOnUpdate="0" field="weir_friction_value"/>
-    <default expression="2" applyOnUpdate="0" field="weir_friction_type"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="weir_connection_node_start_id"/>
-    <default expression="'filled automatically'" applyOnUpdate="0" field="weir_connection_node_end_id"/>
-    <default expression="" applyOnUpdate="0" field="def_id"/>
-    <default expression="" applyOnUpdate="0" field="def_shape"/>
-    <default expression="" applyOnUpdate="0" field="def_width"/>
-    <default expression="" applyOnUpdate="0" field="def_height"/>
-    <default expression="" applyOnUpdate="0" field="def_code"/>
+    <default field="ROWID" applyOnUpdate="0" expression=""/>
+    <default field="weir_id" applyOnUpdate="0" expression="if(maximum(weir_id) is null,1, maximum(weir_id)+1)"/>
+    <default field="weir_display_name" applyOnUpdate="0" expression="'new'"/>
+    <default field="weir_code" applyOnUpdate="0" expression="'new'"/>
+    <default field="weir_crest_level" applyOnUpdate="0" expression=""/>
+    <default field="weir_crest_type" applyOnUpdate="0" expression="4"/>
+    <default field="weir_cross_section_definition_id" applyOnUpdate="0" expression=""/>
+    <default field="weir_sewerage" applyOnUpdate="0" expression=""/>
+    <default field="weir_discharge_coefficient_positive" applyOnUpdate="0" expression="0.8"/>
+    <default field="weir_discharge_coefficient_negative" applyOnUpdate="0" expression="0.8"/>
+    <default field="weir_external" applyOnUpdate="0" expression="1"/>
+    <default field="weir_zoom_category" applyOnUpdate="0" expression="2"/>
+    <default field="weir_friction_value" applyOnUpdate="0" expression="0.02"/>
+    <default field="weir_friction_type" applyOnUpdate="0" expression="2"/>
+    <default field="weir_connection_node_start_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,start_point(geometry(@parent)))))"/>
+    <default field="weir_connection_node_end_id" applyOnUpdate="0" expression="if(aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))) is null,'Created automatically',aggregate('v2_connection_nodes','min',&quot;id&quot;, intersects($geometry,end_point(geometry(@parent)))))"/>
+    <default field="def_id" applyOnUpdate="0" expression=""/>
+    <default field="def_shape" applyOnUpdate="0" expression=""/>
+    <default field="def_width" applyOnUpdate="0" expression=""/>
+    <default field="def_height" applyOnUpdate="0" expression=""/>
+    <default field="def_code" applyOnUpdate="0" expression=""/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="ROWID"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_display_name"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_code"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_crest_level"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_crest_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_cross_section_definition_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_sewerage"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_discharge_coefficient_positive"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_discharge_coefficient_negative"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_external"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_zoom_category"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_friction_value"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="weir_friction_type"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_connection_node_start_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="weir_connection_node_end_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="2" constraints="1" field="def_id"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_shape"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_width"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_height"/>
-    <constraint exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0" field="def_code"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="ROWID" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_id" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_display_name" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_code" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_crest_level" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_crest_type" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_cross_section_definition_id" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="weir_sewerage" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_discharge_coefficient_positive" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_discharge_coefficient_negative" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="weir_external" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_zoom_category" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_friction_value" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="weir_friction_type" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="weir_connection_node_start_id" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="weir_connection_node_end_id" exp_strength="0"/>
+    <constraint constraints="1" unique_strength="0" notnull_strength="2" field="def_id" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="def_shape" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="def_width" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="def_height" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" notnull_strength="0" field="def_code" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="ROWID"/>
-    <constraint exp="" desc="" field="weir_id"/>
-    <constraint exp="" desc="" field="weir_display_name"/>
-    <constraint exp="" desc="" field="weir_code"/>
-    <constraint exp="" desc="" field="weir_crest_level"/>
-    <constraint exp="" desc="" field="weir_crest_type"/>
-    <constraint exp="" desc="" field="weir_cross_section_definition_id"/>
-    <constraint exp="" desc="" field="weir_sewerage"/>
-    <constraint exp="" desc="" field="weir_discharge_coefficient_positive"/>
-    <constraint exp="" desc="" field="weir_discharge_coefficient_negative"/>
-    <constraint exp="" desc="" field="weir_external"/>
-    <constraint exp="" desc="" field="weir_zoom_category"/>
-    <constraint exp="" desc="" field="weir_friction_value"/>
-    <constraint exp="" desc="" field="weir_friction_type"/>
-    <constraint exp="" desc="" field="weir_connection_node_start_id"/>
-    <constraint exp="" desc="" field="weir_connection_node_end_id"/>
-    <constraint exp="" desc="" field="def_id"/>
-    <constraint exp="" desc="" field="def_shape"/>
-    <constraint exp="" desc="" field="def_width"/>
-    <constraint exp="" desc="" field="def_height"/>
-    <constraint exp="" desc="" field="def_code"/>
+    <constraint exp="" field="ROWID" desc=""/>
+    <constraint exp="" field="weir_id" desc=""/>
+    <constraint exp="" field="weir_display_name" desc=""/>
+    <constraint exp="" field="weir_code" desc=""/>
+    <constraint exp="" field="weir_crest_level" desc=""/>
+    <constraint exp="" field="weir_crest_type" desc=""/>
+    <constraint exp="" field="weir_cross_section_definition_id" desc=""/>
+    <constraint exp="" field="weir_sewerage" desc=""/>
+    <constraint exp="" field="weir_discharge_coefficient_positive" desc=""/>
+    <constraint exp="" field="weir_discharge_coefficient_negative" desc=""/>
+    <constraint exp="" field="weir_external" desc=""/>
+    <constraint exp="" field="weir_zoom_category" desc=""/>
+    <constraint exp="" field="weir_friction_value" desc=""/>
+    <constraint exp="" field="weir_friction_type" desc=""/>
+    <constraint exp="" field="weir_connection_node_start_id" desc=""/>
+    <constraint exp="" field="weir_connection_node_end_id" desc=""/>
+    <constraint exp="" field="def_id" desc=""/>
+    <constraint exp="" field="def_shape" desc=""/>
+    <constraint exp="" field="def_width" desc=""/>
+    <constraint exp="" field="def_height" desc=""/>
+    <constraint exp="" field="def_code" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
     <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
     <columns>
-      <column width="-1" type="field" hidden="0" name="ROWID"/>
-      <column width="-1" type="field" hidden="0" name="weir_id"/>
-      <column width="-1" type="field" hidden="0" name="weir_display_name"/>
-      <column width="-1" type="field" hidden="0" name="weir_code"/>
-      <column width="-1" type="field" hidden="0" name="weir_crest_level"/>
-      <column width="-1" type="field" hidden="0" name="weir_crest_type"/>
-      <column width="185" type="field" hidden="0" name="weir_cross_section_definition_id"/>
-      <column width="-1" type="field" hidden="0" name="weir_sewerage"/>
-      <column width="-1" type="field" hidden="0" name="weir_discharge_coefficient_positive"/>
-      <column width="-1" type="field" hidden="0" name="weir_discharge_coefficient_negative"/>
-      <column width="-1" type="field" hidden="0" name="weir_external"/>
-      <column width="-1" type="field" hidden="0" name="weir_zoom_category"/>
-      <column width="-1" type="field" hidden="0" name="weir_friction_value"/>
-      <column width="-1" type="field" hidden="0" name="weir_friction_type"/>
-      <column width="-1" type="field" hidden="0" name="weir_connection_node_start_id"/>
-      <column width="-1" type="field" hidden="0" name="weir_connection_node_end_id"/>
-      <column width="-1" type="field" hidden="0" name="def_id"/>
-      <column width="-1" type="field" hidden="0" name="def_shape"/>
-      <column width="-1" type="field" hidden="0" name="def_width"/>
-      <column width="-1" type="field" hidden="0" name="def_height"/>
-      <column width="-1" type="field" hidden="0" name="def_code"/>
-      <column width="-1" type="actions" hidden="1"/>
+      <column type="field" name="ROWID" width="-1" hidden="0"/>
+      <column type="field" name="weir_id" width="-1" hidden="0"/>
+      <column type="field" name="weir_display_name" width="-1" hidden="0"/>
+      <column type="field" name="weir_code" width="-1" hidden="0"/>
+      <column type="field" name="weir_crest_level" width="-1" hidden="0"/>
+      <column type="field" name="weir_crest_type" width="-1" hidden="0"/>
+      <column type="field" name="weir_cross_section_definition_id" width="185" hidden="0"/>
+      <column type="field" name="weir_sewerage" width="-1" hidden="0"/>
+      <column type="field" name="weir_discharge_coefficient_positive" width="-1" hidden="0"/>
+      <column type="field" name="weir_discharge_coefficient_negative" width="-1" hidden="0"/>
+      <column type="field" name="weir_external" width="-1" hidden="0"/>
+      <column type="field" name="weir_zoom_category" width="-1" hidden="0"/>
+      <column type="field" name="weir_friction_value" width="-1" hidden="0"/>
+      <column type="field" name="weir_friction_type" width="-1" hidden="0"/>
+      <column type="field" name="weir_connection_node_start_id" width="-1" hidden="0"/>
+      <column type="field" name="weir_connection_node_end_id" width="-1" hidden="0"/>
+      <column type="field" name="def_id" width="-1" hidden="0"/>
+      <column type="field" name="def_shape" width="-1" hidden="0"/>
+      <column type="field" name="def_width" width="-1" hidden="0"/>
+      <column type="field" name="def_height" width="-1" hidden="0"/>
+      <column type="field" name="def_code" width="-1" hidden="0"/>
+      <column type="actions" width="-1" hidden="1"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -525,35 +525,35 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer groupBox="0" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Weir view" columnCount="1">
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="General" columnCount="1">
-        <attributeEditorField showLabel="1" name="weir_id" index="1"/>
-        <attributeEditorField showLabel="1" name="weir_display_name" index="2"/>
-        <attributeEditorField showLabel="1" name="weir_code" index="3"/>
+    <attributeEditorContainer columnCount="1" visibilityExpression="" name="Weir view" groupBox="0" visibilityExpressionEnabled="0" showLabel="1">
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="General" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="weir_id" index="1" showLabel="1"/>
+        <attributeEditorField name="weir_display_name" index="2" showLabel="1"/>
+        <attributeEditorField name="weir_code" index="3" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Characteristics" columnCount="1">
-        <attributeEditorField showLabel="1" name="weir_crest_level" index="4"/>
-        <attributeEditorField showLabel="1" name="weir_crest_type" index="5"/>
-        <attributeEditorField showLabel="1" name="weir_discharge_coefficient_positive" index="8"/>
-        <attributeEditorField showLabel="1" name="weir_discharge_coefficient_negative" index="9"/>
-        <attributeEditorField showLabel="1" name="weir_friction_value" index="12"/>
-        <attributeEditorField showLabel="1" name="weir_friction_type" index="13"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Characteristics" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="weir_crest_level" index="4" showLabel="1"/>
+        <attributeEditorField name="weir_crest_type" index="5" showLabel="1"/>
+        <attributeEditorField name="weir_discharge_coefficient_positive" index="8" showLabel="1"/>
+        <attributeEditorField name="weir_discharge_coefficient_negative" index="9" showLabel="1"/>
+        <attributeEditorField name="weir_friction_value" index="12" showLabel="1"/>
+        <attributeEditorField name="weir_friction_type" index="13" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Cross section" columnCount="1">
-        <attributeEditorField showLabel="1" name="weir_cross_section_definition_id" index="6"/>
-        <attributeEditorField showLabel="1" name="def_code" index="20"/>
-        <attributeEditorField showLabel="1" name="def_shape" index="17"/>
-        <attributeEditorField showLabel="1" name="def_width" index="18"/>
-        <attributeEditorField showLabel="1" name="def_height" index="19"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Cross section" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="weir_cross_section_definition_id" index="6" showLabel="1"/>
+        <attributeEditorField name="def_code" index="20" showLabel="1"/>
+        <attributeEditorField name="def_shape" index="17" showLabel="1"/>
+        <attributeEditorField name="def_width" index="18" showLabel="1"/>
+        <attributeEditorField name="def_height" index="19" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Visualization" columnCount="1">
-        <attributeEditorField showLabel="1" name="weir_sewerage" index="7"/>
-        <attributeEditorField showLabel="1" name="weir_external" index="10"/>
-        <attributeEditorField showLabel="1" name="weir_zoom_category" index="11"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Visualization" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="weir_sewerage" index="7" showLabel="1"/>
+        <attributeEditorField name="weir_external" index="10" showLabel="1"/>
+        <attributeEditorField name="weir_zoom_category" index="11" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer groupBox="1" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0" name="Connection nodes" columnCount="1">
-        <attributeEditorField showLabel="1" name="weir_connection_node_start_id" index="14"/>
-        <attributeEditorField showLabel="1" name="weir_connection_node_end_id" index="15"/>
+      <attributeEditorContainer columnCount="1" visibilityExpression="" name="Connection nodes" groupBox="1" visibilityExpressionEnabled="0" showLabel="1">
+        <attributeEditorField name="weir_connection_node_start_id" index="14" showLabel="1"/>
+        <attributeEditorField name="weir_connection_node_end_id" index="15" showLabel="1"/>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>

--- a/layer_styles/schematisation/v2_windshielding.qml
+++ b/layer_styles/schematisation/v2_windshielding.qml
@@ -1,0 +1,260 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.4.5-Madeira" minScale="1e+08" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <customproperties>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="channel_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="north">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="northeast">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="east">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="southeast">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="south">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="southwest">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="west">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="northwest">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="the_geom">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="id" index="0" name=""/>
+    <alias field="channel_id" index="1" name=""/>
+    <alias field="north" index="2" name=""/>
+    <alias field="northeast" index="3" name=""/>
+    <alias field="east" index="4" name=""/>
+    <alias field="southeast" index="5" name=""/>
+    <alias field="south" index="6" name=""/>
+    <alias field="southwest" index="7" name=""/>
+    <alias field="west" index="8" name=""/>
+    <alias field="northwest" index="9" name=""/>
+    <alias field="the_geom" index="10" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default expression="if(maximum(id) is null,1, maximum(id)+1)" applyOnUpdate="0" field="id"/>
+    <default expression="" applyOnUpdate="0" field="channel_id"/>
+    <default expression="" applyOnUpdate="0" field="north"/>
+    <default expression="" applyOnUpdate="0" field="northeast"/>
+    <default expression="" applyOnUpdate="0" field="east"/>
+    <default expression="" applyOnUpdate="0" field="southeast"/>
+    <default expression="" applyOnUpdate="0" field="south"/>
+    <default expression="" applyOnUpdate="0" field="southwest"/>
+    <default expression="" applyOnUpdate="0" field="west"/>
+    <default expression="" applyOnUpdate="0" field="northwest"/>
+    <default expression="" applyOnUpdate="0" field="the_geom"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" field="id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="channel_id" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="north" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="northeast" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="east" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="southeast" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="south" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="southwest" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="west" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="northwest" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" field="the_geom" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="id" exp=""/>
+    <constraint desc="" field="channel_id" exp=""/>
+    <constraint desc="" field="north" exp=""/>
+    <constraint desc="" field="northeast" exp=""/>
+    <constraint desc="" field="east" exp=""/>
+    <constraint desc="" field="southeast" exp=""/>
+    <constraint desc="" field="south" exp=""/>
+    <constraint desc="" field="southwest" exp=""/>
+    <constraint desc="" field="west" exp=""/>
+    <constraint desc="" field="northwest" exp=""/>
+    <constraint desc="" field="the_geom" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="channel_id"/>
+      <column width="-1" hidden="0" type="field" name="north"/>
+      <column width="-1" hidden="0" type="field" name="northeast"/>
+      <column width="-1" hidden="0" type="field" name="east"/>
+      <column width="-1" hidden="0" type="field" name="southeast"/>
+      <column width="-1" hidden="0" type="field" name="south"/>
+      <column width="-1" hidden="0" type="field" name="southwest"/>
+      <column width="-1" hidden="0" type="field" name="west"/>
+      <column width="-1" hidden="0" type="field" name="northwest"/>
+      <column width="-1" hidden="0" type="field" name="the_geom"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer visibilityExpression="" visibilityExpressionEnabled="0" columnCount="1" name="General" showLabel="1" groupBox="0">
+      <attributeEditorField index="0" name="id" showLabel="1"/>
+      <attributeEditorField index="1" name="channel_id" showLabel="1"/>
+      <attributeEditorField index="2" name="north" showLabel="1"/>
+      <attributeEditorField index="3" name="northeast" showLabel="1"/>
+      <attributeEditorField index="4" name="east" showLabel="1"/>
+      <attributeEditorField index="5" name="southeast" showLabel="1"/>
+      <attributeEditorField index="6" name="south" showLabel="1"/>
+      <attributeEditorField index="7" name="southwest" showLabel="1"/>
+      <attributeEditorField index="8" name="west" showLabel="1"/>
+      <attributeEditorField index="9" name="northwest" showLabel="1"/>
+      <attributeEditorField index="10" name="the_geom" showLabel="1"/>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="channel_id"/>
+    <field editable="1" name="east"/>
+    <field editable="1" name="id"/>
+    <field editable="1" name="north"/>
+    <field editable="1" name="northeast"/>
+    <field editable="1" name="northwest"/>
+    <field editable="1" name="south"/>
+    <field editable="1" name="southeast"/>
+    <field editable="1" name="southwest"/>
+    <field editable="1" name="the_geom"/>
+    <field editable="1" name="west"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="channel_id"/>
+    <field labelOnTop="0" name="east"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="north"/>
+    <field labelOnTop="0" name="northeast"/>
+    <field labelOnTop="0" name="northwest"/>
+    <field labelOnTop="0" name="south"/>
+    <field labelOnTop="0" name="southeast"/>
+    <field labelOnTop="0" name="southwest"/>
+    <field labelOnTop="0" name="the_geom"/>
+    <field labelOnTop="0" name="west"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>id</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -1,3 +1,5 @@
+from ThreeDiToolbox.layer_styles.custom_widgets.mywidget import MyCustomWidgetFactory
+
 from . import styler
 from .threedi_database import ThreediDatabase
 from qgis.core import QgsCoordinateTransform
@@ -392,6 +394,42 @@ class LayerTreeManager(object):
                 styler.apply_style(table_layer, table_name, "schematisation")
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
+
+            if table_name == 'v2_global_settings':
+                print("We have him!")
+                layer = table_layer
+
+                # editFormConfig = layer.editFormConfig()
+                # editFormConfig.setWidgetConfig('id', {'nm-rel': 'other_relation'})
+                # layer.setEditFormConfig(editFormConfig)
+
+
+                # layer.editFormConfig().widgetConfig('')
+                #
+                # [el.name() for el in layer.editFormConfig().tabs()[0].children()]
+                # layer.editFormConfig().tabs()[0].children()[0]
+                # layer.editFormConfig().setWidgetConfig('id2', {'rule': '[A-Z].*'})
+                #
+                # layer.editFormConfig().setWidgetConfig(
+                #
+                # )
+
+
+                # register a new custom widget:
+                from qgis.gui import QgsGui
+                widget_editor_registry = QgsGui.editorWidgetRegistry()
+                widget_editor_registry.registerWidget(
+                    widgetId='mywidget',
+                    widgetFactory=MyCustomWidgetFactory('mywidget123')
+                )
+
+                # self.my_factory = FormAwareValueRelationWidgetFactory(
+                #     'Form Value Relation')
+                # widget_editor_registry.registerWidget(
+                #     'mywidget', self.my_factory)
+
+
+
         QSettings().setValue("/Map/identifyAutoFeatureForm", "true")
 
     def add_results(self, index, start_row, stop_row):

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -386,8 +386,12 @@ class LayerTreeManager(object):
             table_layer = self.create_layer(threedi_spatialite, table_name)
 
             if table_layer.isValid():
+                styler.apply_style(
+                        table_layer, table_name, 'schematisation')
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
+        QSettings().setValue('/Map/identifyAutoFeatureForm','true')
+
 
     def add_results(self, index, start_row, stop_row):
         # unique identifier?

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -391,7 +391,8 @@ class LayerTreeManager(object):
             table_layer = self.create_layer(threedi_spatialite, table_name)
 
             if table_layer.isValid():
-                styler.apply_style(table_layer, table_name, "schematisation")
+                styler.apply_style(
+                        table_layer, table_name, 'schematisation')
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
         QSettings().setValue('/Map/identifyAutoFeatureForm','true')

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -396,15 +396,15 @@ class LayerTreeManager(object):
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
         QSettings().setValue('/Map/identifyAutoFeatureForm','true')
-        my_snap_config = QgsSnappingConfig()
-        my_snap_config.setEnabled(True)
-        my_snap_config.setMode(QgsSnappingConfig.AllLayers)
-        my_snap_config.setType(QgsSnappingConfig.Vertex)
-        my_snap_config.setUnits(QgsTolerance.Pixels)
-        my_snap_config.setTolerance(10)
-        my_snap_config.setIntersectionSnapping(True)
+        # my_snap_config = QgsSnappingConfig()
+        # my_snap_config.setEnabled(True)
+        # my_snap_config.setMode(QgsSnappingConfig.AllLayers)
+        # my_snap_config.setType(QgsSnappingConfig.Vertex)
+        # my_snap_config.setUnits(QgsTolerance.Pixels)
+        # my_snap_config.setTolerance(10)
+        # my_snap_config.setIntersectionSnapping(True)
 
-        QgsProject.instance().setSnappingConfig(my_snap_config)
+        # QgsProject.instance().setSnappingConfig(my_snap_config)
 
     def add_results(self, index, start_row, stop_row):
         # unique identifier?

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -391,8 +391,7 @@ class LayerTreeManager(object):
             table_layer = self.create_layer(threedi_spatialite, table_name)
 
             if table_layer.isValid():
-                styler.apply_style(
-                        table_layer, table_name, 'schematisation')
+                styler.apply_style(table_layer, table_name, "schematisation")
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
         QSettings().setValue('/Map/identifyAutoFeatureForm','true')

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -6,6 +6,8 @@ from qgis.core import QgsLayerTreeNode
 from qgis.core import QgsProject
 from qgis.core import QgsRectangle
 from qgis.core import QgsVectorLayer
+from qgis.core import QgsSnappingConfig
+from qgis.core import QgsTolerance
 from PyQt5.QtCore import QSettings
 
 import os.path
@@ -394,7 +396,15 @@ class LayerTreeManager(object):
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
         QSettings().setValue('/Map/identifyAutoFeatureForm','true')
+        my_snap_config = QgsSnappingConfig()
+        my_snap_config.setEnabled(True)
+        my_snap_config.setMode(QgsSnappingConfig.AllLayers)
+        my_snap_config.setType(QgsSnappingConfig.Vertex)
+        my_snap_config.setUnits(QgsTolerance.Pixels)
+        my_snap_config.setTolerance(10)
+        my_snap_config.setIntersectionSnapping(True)
 
+        QgsProject.instance().setSnappingConfig(my_snap_config)
 
     def add_results(self, index, start_row, stop_row):
         # unique identifier?

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -366,6 +366,7 @@ class LayerTreeManager(object):
             (settings_group, "v2_interflow"),
             (settings_group, "v2_aggregation_settings"),
             (settings_group, "v2_global_settings"),
+            (settings_group, "v2_simple_infiltration"),
             (lateral_group, "v2_1d_lateral"),
             (boundary_group, "v2_1d_boundary_conditions"),
             (additional_oned_group, "v2_cross_section_definition"),

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -6,6 +6,7 @@ from qgis.core import QgsLayerTreeNode
 from qgis.core import QgsProject
 from qgis.core import QgsRectangle
 from qgis.core import QgsVectorLayer
+from PyQt5.QtCore import QSettings
 
 import os.path
 
@@ -278,6 +279,7 @@ class LayerTreeManager(object):
         oned_layers = [
             "v2_connection_nodes",
             "v2_manhole_view",
+            "v2_cross_section_location_view",
             "v2_cross_section_location",
             "v2_pumpstation_view",
             "v2_pumpstation_point_view",

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -1,5 +1,3 @@
-from ThreeDiToolbox.layer_styles.custom_widgets.mywidget import MyCustomWidgetFactory
-
 from . import styler
 from .threedi_database import ThreediDatabase
 from qgis.core import QgsCoordinateTransform
@@ -8,6 +6,8 @@ from qgis.core import QgsLayerTreeNode
 from qgis.core import QgsProject
 from qgis.core import QgsRectangle
 from qgis.core import QgsVectorLayer
+from qgis.core import QgsSnappingConfig
+from qgis.core import QgsTolerance
 from PyQt5.QtCore import QSettings
 
 import os.path
@@ -391,46 +391,20 @@ class LayerTreeManager(object):
             table_layer = self.create_layer(threedi_spatialite, table_name)
 
             if table_layer.isValid():
-                styler.apply_style(table_layer, table_name, "schematisation")
+                styler.apply_style(
+                        table_layer, table_name, 'schematisation')
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
+        QSettings().setValue('/Map/identifyAutoFeatureForm','true')
+        # my_snap_config = QgsSnappingConfig()
+        # my_snap_config.setEnabled(True)
+        # my_snap_config.setMode(QgsSnappingConfig.AllLayers)
+        # my_snap_config.setType(QgsSnappingConfig.Vertex)
+        # my_snap_config.setUnits(QgsTolerance.Pixels)
+        # my_snap_config.setTolerance(10)
+        # my_snap_config.setIntersectionSnapping(True)
 
-            if table_name == 'v2_global_settings':
-                print("We have him!")
-                layer = table_layer
-
-                # editFormConfig = layer.editFormConfig()
-                # editFormConfig.setWidgetConfig('id', {'nm-rel': 'other_relation'})
-                # layer.setEditFormConfig(editFormConfig)
-
-
-                # layer.editFormConfig().widgetConfig('')
-                #
-                # [el.name() for el in layer.editFormConfig().tabs()[0].children()]
-                # layer.editFormConfig().tabs()[0].children()[0]
-                # layer.editFormConfig().setWidgetConfig('id2', {'rule': '[A-Z].*'})
-                #
-                # layer.editFormConfig().setWidgetConfig(
-                #
-                # )
-
-
-                # register a new custom widget:
-                from qgis.gui import QgsGui
-                widget_editor_registry = QgsGui.editorWidgetRegistry()
-                widget_editor_registry.registerWidget(
-                    widgetId='mywidget',
-                    widgetFactory=MyCustomWidgetFactory('mywidget123')
-                )
-
-                # self.my_factory = FormAwareValueRelationWidgetFactory(
-                #     'Form Value Relation')
-                # widget_editor_registry.registerWidget(
-                #     'mywidget', self.my_factory)
-
-
-
-        QSettings().setValue("/Map/identifyAutoFeatureForm", "true")
+        # QgsProject.instance().setSnappingConfig(my_snap_config)
 
     def add_results(self, index, start_row, stop_row):
         # unique identifier?

--- a/utils/layer_tree_manager.py
+++ b/utils/layer_tree_manager.py
@@ -6,8 +6,6 @@ from qgis.core import QgsLayerTreeNode
 from qgis.core import QgsProject
 from qgis.core import QgsRectangle
 from qgis.core import QgsVectorLayer
-from qgis.core import QgsSnappingConfig
-from qgis.core import QgsTolerance
 from PyQt5.QtCore import QSettings
 
 import os.path
@@ -391,20 +389,10 @@ class LayerTreeManager(object):
             table_layer = self.create_layer(threedi_spatialite, table_name)
 
             if table_layer.isValid():
-                styler.apply_style(
-                        table_layer, table_name, 'schematisation')
+                styler.apply_style(table_layer, table_name, "schematisation")
                 QgsProject.instance().addMapLayer(table_layer, False)
                 group.insertLayer(0, table_layer)
-        QSettings().setValue('/Map/identifyAutoFeatureForm','true')
-        # my_snap_config = QgsSnappingConfig()
-        # my_snap_config.setEnabled(True)
-        # my_snap_config.setMode(QgsSnappingConfig.AllLayers)
-        # my_snap_config.setType(QgsSnappingConfig.Vertex)
-        # my_snap_config.setUnits(QgsTolerance.Pixels)
-        # my_snap_config.setTolerance(10)
-        # my_snap_config.setIntersectionSnapping(True)
-
-        # QgsProject.instance().setSnappingConfig(my_snap_config)
+        QSettings().setValue("/Map/identifyAutoFeatureForm", "true")
 
     def add_results(self, index, start_row, stop_row):
         # unique identifier?

--- a/utils/threedi_database.py
+++ b/utils/threedi_database.py
@@ -244,6 +244,34 @@ class ThreediDatabase(object):
         VALUES('v2_1d_boundary_conditions_view', 'the_geom',
         'connection_node_id', 'v2_connection_nodes', 'the_geom');"""
         )
+        conn.execute(
+            """
+        CREATE VIEW IF NOT EXISTS v2_cross_section_location_view 
+        AS SELECT loc.id as loc_id, loc.code as loc_code, 
+        loc.reference_level as loc_reference_level, 
+        loc.bank_level as loc_bank_level, loc.friction_type as 
+        loc_friction_type, loc.friction_value as loc_friction_value, 
+        loc.definition_id as loc_definition_id, loc.channel_id as 
+        loc_channel_id, loc.the_geom as the_geom, def.id as def_id, 
+        def.shape as def_shape, def.width as def_width, def.code as 
+        def_code, def.height as def_height 
+        FROM v2_cross_section_location loc, v2_cross_section_definition def 
+        WHERE loc.definition_id = def.id;"""
+        )
+
+        conn.execute(
+            """
+        DELETE FROM views_geometry_columns
+        WHERE view_name = 'v2_cross_section_location_view';"""
+        )
+
+        conn.execute(
+            """
+        INSERT INTO views_geometry_columns (view_name, view_geometry,
+        view_rowid, f_table_name, f_geometry_column)
+        VALUES('v2_cross_section_location_view', 'the_geom',
+        'ROWID', 'v2_cross_section_location', 'the_geom');"""
+        )
 
         conn.commit()
         conn.close()

--- a/utils/threedi_database.py
+++ b/utils/threedi_database.py
@@ -147,19 +147,19 @@ class ThreediDatabase(object):
 
         conn.execute(
             """
-        CREATE VIEW IF NOT EXISTS v2_manhole_view 
+        CREATE VIEW IF NOT EXISTS v2_manhole_view
         AS SELECT manh.rowid AS ROWID, node.id AS node_id, manh.bottom_level
         AS manh_bottom_level, manh.surface_level AS manh_surface_level,
         manh.display_name AS manh_display_name, manh.shape AS manh_shape,
-        manh.width AS manh_width, manh.length AS manh_length, 
+        manh.width AS manh_width, manh.length AS manh_length,
         manh.manhole_indicator AS manh_manhole_indicator, manh.calculation_type
         AS manh_calculation_type, manh.drain_level AS manh_drain_level,
         manh.zoom_category AS manh_zoom_category, node.initial_waterlevel AS
-        node_initial_waterlevel, manh.id AS manh_id, manh.connection_node_id  AS 
+        node_initial_waterlevel, manh.id AS manh_id, manh.connection_node_id  AS
         manh_connection_node_id, node.storage_area AS node_storage_area,
         manh.code AS manh_code, node.code AS node_code, node.the_geom,
-        node.the_geom_linestring AS node_the_geom_linestring, 
-        manh.sediment_level AS manh_sediment_level 
+        node.the_geom_linestring AS node_the_geom_linestring,
+        manh.sediment_level AS manh_sediment_level
         FROM v2_manhole manh, v2_connection_nodes node
         WHERE manh.connection_node_id = node.id;
         """
@@ -256,16 +256,16 @@ class ThreediDatabase(object):
         )
         conn.execute(
             """
-        CREATE VIEW IF NOT EXISTS v2_cross_section_location_view 
-        AS SELECT loc.ROWID as ROWID, loc.id as loc_id, loc.code as loc_code, 
-        loc.reference_level as loc_reference_level, 
-        loc.bank_level as loc_bank_level, loc.friction_type as 
-        loc_friction_type, loc.friction_value as loc_friction_value, 
-        loc.definition_id as loc_definition_id, loc.channel_id as 
-        loc_channel_id, loc.the_geom as the_geom, def.id as def_id, 
-        def.shape as def_shape, def.width as def_width, def.code as 
-        def_code, def.height as def_height 
-        FROM v2_cross_section_location loc, v2_cross_section_definition def 
+        CREATE VIEW IF NOT EXISTS v2_cross_section_location_view
+        AS SELECT loc.ROWID as ROWID, loc.id as loc_id, loc.code as loc_code,
+        loc.reference_level as loc_reference_level,
+        loc.bank_level as loc_bank_level, loc.friction_type as
+        loc_friction_type, loc.friction_value as loc_friction_value,
+        loc.definition_id as loc_definition_id, loc.channel_id as
+        loc_channel_id, loc.the_geom as the_geom, def.id as def_id,
+        def.shape as def_shape, def.width as def_width, def.code as
+        def_code, def.height as def_height
+        FROM v2_cross_section_location loc, v2_cross_section_definition def
         WHERE loc.definition_id = def.id;"""
         )
 

--- a/utils/threedi_database.py
+++ b/utils/threedi_database.py
@@ -147,19 +147,19 @@ class ThreediDatabase(object):
 
         conn.execute(
             """
-        CREATE VIEW IF NOT EXISTS v2_manhole_view
+        CREATE VIEW IF NOT EXISTS v2_manhole_view 
         AS SELECT manh.rowid AS ROWID, node.id AS node_id, manh.bottom_level
         AS manh_bottom_level, manh.surface_level AS manh_surface_level,
         manh.display_name AS manh_display_name, manh.shape AS manh_shape,
-        manh.width AS manh_width, manh.length AS manh_length,
+        manh.width AS manh_width, manh.length AS manh_length, 
         manh.manhole_indicator AS manh_manhole_indicator, manh.calculation_type
         AS manh_calculation_type, manh.drain_level AS manh_drain_level,
         manh.zoom_category AS manh_zoom_category, node.initial_waterlevel AS
-        node_initial_waterlevel, manh.id AS manh_id, manh.connection_node_id  AS
+        node_initial_waterlevel, manh.id AS manh_id, manh.connection_node_id  AS 
         manh_connection_node_id, node.storage_area AS node_storage_area,
         manh.code AS manh_code, node.code AS node_code, node.the_geom,
-        node.the_geom_linestring AS node_the_geom_linestring,
-        manh.sediment_level AS manh_sediment_level
+        node.the_geom_linestring AS node_the_geom_linestring, 
+        manh.sediment_level AS manh_sediment_level 
         FROM v2_manhole manh, v2_connection_nodes node
         WHERE manh.connection_node_id = node.id;
         """
@@ -256,16 +256,16 @@ class ThreediDatabase(object):
         )
         conn.execute(
             """
-        CREATE VIEW IF NOT EXISTS v2_cross_section_location_view
-        AS SELECT loc.ROWID as ROWID, loc.id as loc_id, loc.code as loc_code,
-        loc.reference_level as loc_reference_level,
-        loc.bank_level as loc_bank_level, loc.friction_type as
-        loc_friction_type, loc.friction_value as loc_friction_value,
-        loc.definition_id as loc_definition_id, loc.channel_id as
-        loc_channel_id, loc.the_geom as the_geom, def.id as def_id,
-        def.shape as def_shape, def.width as def_width, def.code as
-        def_code, def.height as def_height
-        FROM v2_cross_section_location loc, v2_cross_section_definition def
+        CREATE VIEW IF NOT EXISTS v2_cross_section_location_view 
+        AS SELECT loc.ROWID as ROWID, loc.id as loc_id, loc.code as loc_code, 
+        loc.reference_level as loc_reference_level, 
+        loc.bank_level as loc_bank_level, loc.friction_type as 
+        loc_friction_type, loc.friction_value as loc_friction_value, 
+        loc.definition_id as loc_definition_id, loc.channel_id as 
+        loc_channel_id, loc.the_geom as the_geom, def.id as def_id, 
+        def.shape as def_shape, def.width as def_width, def.code as 
+        def_code, def.height as def_height 
+        FROM v2_cross_section_location loc, v2_cross_section_definition def 
         WHERE loc.definition_id = def.id;"""
         )
 

--- a/utils/threedi_database.py
+++ b/utils/threedi_database.py
@@ -165,7 +165,7 @@ class ThreediDatabase(object):
             """
         INSERT INTO views_geometry_columns (view_name, view_geometry,
         view_rowid, f_table_name, f_geometry_column)
-        VALUES('v2_manhole_view', 'the_geom', 'connection_node_id',
+        VALUES('v2_manhole_view', 'the_geom', 'ROWID',
         'v2_connection_nodes', 'the_geom');"""
         )
 
@@ -247,7 +247,7 @@ class ThreediDatabase(object):
         conn.execute(
             """
         CREATE VIEW IF NOT EXISTS v2_cross_section_location_view 
-        AS SELECT loc.id as loc_id, loc.code as loc_code, 
+        AS SELECT loc.ROWID as ROWID, loc.id as loc_id, loc.code as loc_code, 
         loc.reference_level as loc_reference_level, 
         loc.bank_level as loc_bank_level, loc.friction_type as 
         loc_friction_type, loc.friction_value as loc_friction_value, 

--- a/utils/threedi_database.py
+++ b/utils/threedi_database.py
@@ -147,12 +147,22 @@ class ThreediDatabase(object):
 
         conn.execute(
             """
-        CREATE VIEW IF NOT EXISTS v2_manhole_view
-        AS SELECT a.ROWID AS ROWID, a.id AS id, a.connection_node_id AS
-        connection_node_id, b.the_geom
-        FROM v2_manhole a
-        JOIN v2_connection_nodes b
-        ON a.connection_node_id = b.id;"""
+        CREATE VIEW IF NOT EXISTS v2_manhole_view 
+        AS SELECT manh.rowid AS ROWID, node.id AS node_id, manh.bottom_level
+        AS manh_bottom_level, manh.surface_level AS manh_surface_level,
+        manh.display_name AS manh_display_name, manh.shape AS manh_shape,
+        manh.width AS manh_width, manh.length AS manh_length, 
+        manh.manhole_indicator AS manh_manhole_indicator, manh.calculation_type
+        AS manh_calculation_type, manh.drain_level AS manh_drain_level,
+        manh.zoom_category AS manh_zoom_category, node.initial_waterlevel AS
+        node_initial_waterlevel, manh.id AS manh_id, manh.connection_node_id  AS 
+        manh_connection_node_id, node.storage_area AS node_storage_area,
+        manh.code AS manh_code, node.code AS node_code, node.the_geom,
+        node.the_geom_linestring AS node_the_geom_linestring, 
+        manh.sediment_level AS manh_sediment_level 
+        FROM v2_manhole manh, v2_connection_nodes node
+        WHERE manh.connection_node_id = node.id;
+        """
         )
 
         conn.execute(


### PR DESCRIPTION
veranderingen:

- nieuwe qml's voor alle tabellen (styling niet veranderd alleen forms)
- v2_simple infiltration toegevoegd aan de tabellen die automatisch inladen (deze gebruikt eigenlijk iedereen dus was onhandig dat hij niet werd ingeladen)
- Toegevoegd dat tabellen zonder geometrie worden opgemaakt met qml styling
- manhole_view goed gedefinieerd (inclusief geometry columns tabel)
- cross_section_location_view aangemaakt zodat je ook de cross section van channels kan zien. 
- automatisch openen van edit form bij inspect actie aangezet
- nu nog uitgecomment: het activeren van snapping. Het zou heel fijn zijn als snapping automatisch wordt aangezet bij inladen van een model, maar het stukje code dat ik nu heb getypt (in layer_tree_manager) werkt wel maar laat qgis een crash melding geven wanneer je gis afsluit. 