### PR TITLE
[DONE] modelchecker Click dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ ThreeDiToolBox changelog
 1.13 (unreleased)
 -----------------
 
+- Added Click as external dependency, which is currently required for the
+  threedi-modelchecker.
+
 - Improve raster_checker's 'extreme raster values' check: not rely on meta data,
   but check actual data. Also include number of warnings in pop-up when finished.
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,5 +5,5 @@ lizard-connector==0.6
 pyqtgraph>=0.10.0
 threedigrid==1.0.16
 cached-property
-threedi-modelchecker==0.8
+threedi-modelchecker>=0.8
 click>=7.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,4 +5,5 @@ lizard-connector==0.6
 pyqtgraph>=0.10.0
 threedigrid==1.0.16
 cached-property
-threedi-modelchecker>=0.5
+threedi-modelchecker==0.8
+click>=7.0

--- a/dependencies.py
+++ b/dependencies.py
@@ -43,7 +43,8 @@ DEPENDENCIES = [
     Dependency("pyqtgraph", "pyqtgraph", ">=0.10.0"),
     Dependency("threedigrid", "threedigrid", "==1.0.16"),
     Dependency("cached-property", "cached_property", ""),
-    Dependency("threedi-modelchecker", "threedi_modelchecker", ">=0.5"),
+    Dependency("threedi-modelchecker", "threedi_modelchecker", ">=0.8"),
+    Dependency("click", "click", ">=7.0")
 ]
 
 # Dependencies that contain compiled extensions for windows platform

--- a/external-dependencies/populate.sh
+++ b/external-dependencies/populate.sh
@@ -6,7 +6,7 @@ rm -rf SQLAlchemy*
 rm -rf build
 
 # Download pure python dependencies and convert them to wheels.
-pip3 wheel --constraint ../constraints.txt --no-deps GeoAlchemy2 lizard-connector pyqtgraph threedigrid cached-property threedi-modelchecker
+pip3 wheel --constraint ../constraints.txt --no-deps GeoAlchemy2 lizard-connector pyqtgraph threedigrid cached-property threedi-modelchecker click
 
 # Start a build/ directory for easier later cleanup.
 mkdir build


### PR DESCRIPTION
Adds `click` as an additional external-dependency. 

Click is currently required to successfully install threedi-modelchecker. Without installing Click, the plugin tries to install the threedi-modelchecker each time on startup, see also #441.

Click might be removed in the future from the threedi-modelchecker or added as an optional dependency, but for now it is required. Click is fortunately a very small package (80 KB) and a pure python package.