### PR TITLE
Switch order emptying calc/conn points

### DIFF
--- a/tool_commands/predict_calc_points/command.py
+++ b/tool_commands/predict_calc_points/command.py
@@ -128,7 +128,7 @@ class CustomCommand(CustomCommandBase):
             )
 
             if pop_up_question(question, "Warning"):
-                predictor.threedi_db.delete_from(constants.TABLE_NAME_CALC_PNT)
                 predictor.threedi_db.delete_from(constants.TABLE_NAME_CONN_PNT)
+                predictor.threedi_db.delete_from(constants.TABLE_NAME_CALC_PNT)
                 fresh = True
         return fresh


### PR DESCRIPTION
Switched order of emptying tables of calculation points and connected points.
Connected points refer to calculation points so should be removed before removing calculation points.