### PR TITLE
Change set_capacity to set_pump_capacity in control constants

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -62,6 +62,6 @@ DICT_TABLE_ID = {
 DICT_ACTION_TYPES = {
     "culvert": ["set_discharge_coefficients"],
     "orifice": ["set_crest_level", "set_discharge_coefficients"],
-    "pumpstation": ["set_capacity"],
+    "pumpstation": ["set_pump_capacity"],
     "weir": ["set_crest_level", "set_discharge_coefficients"],
 }


### PR DESCRIPTION
The action type for a v2_pumpstation is set_pump_capacity, not set_capacity. Hereby fixed.