### PR TITLE
[DONE] Bugfix pumplines coords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ ThreeDiToolBox changelog
 1.14 (unreleased)
 -----------------
 
+- Bug fix pumplines coords not using the projected coordinates.
+
 - Small fix in predict_calc_points command.
 
 - Update v2_pumpstation action_type from 'set_capacity' to 'set_pump_capacity'.

--- a/utils/gridadmin.py
+++ b/utils/gridadmin.py
@@ -447,16 +447,16 @@ class QgisPumpsOgrExporter(BaseOgrExporter):
                 if node_id == -9999:
                     try:
                         line.AddPoint_2D(
-                            self.node_data["coordinates"][0][node1_id] + 5,
-                            self.node_data["coordinates"][1][node1_id] + 5,
+                            pump_data['coordinates'][0][i] + 0.00002,
+                            pump_data['coordinates'][1][i] + 0.00002,
                         )
                     except IndexError:
                         logger.exception("Invalid node id: %s", node_id)
                 else:
                     try:
                         line.AddPoint_2D(
-                            self.node_data["coordinates"][0][node_id],
-                            self.node_data["coordinates"][1][node_id],
+                            pump_data['coordinates'][0][i],
+                            pump_data['coordinates'][1][i],
                         )
                     except IndexError:
                         logger.exception("Invalid node id: %s", node_id)


### PR DESCRIPTION
Since we now reproject the nodes/lines/pumplines into epsg4326, we need to make sure we use these projected coords and not the original data.
