### PR TITLE
Update gridadmin.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ ThreeDiToolBox changelog
 
 - Schematisation checker compatible with threedi-modelchecker 0.25.2
 
-- Include info and warning level messages in schematisation checker results csv  
+- Include info and warning level messages in schematisation checker results csv
+
+- Fix encoding error when reading gridadmin.h5
   
 
 1.20 (2021-09-02)

--- a/utils/gridadmin.py
+++ b/utils/gridadmin.py
@@ -358,12 +358,7 @@ class QgisLinesOgrExporter(BaseOgrExporter):
                         cont_type_raw_value = None
 
                     if cont_type_raw_value:
-                        if field_type == 'str':
-                            value = TYPE_FUNC_MAP[field_type](
-                                cont_type_raw_value, encoding="utf-8"
-                            )
-                        else:
-                            value = TYPE_FUNC_MAP[field_type](cont_type_raw_value)
+                        value = TYPE_FUNC_MAP[field_type](cont_type_raw_value)
                     else:
                         try:
                             value = str(kcu_dict[int(line_data["kcu"][i])])
@@ -378,12 +373,7 @@ class QgisLinesOgrExporter(BaseOgrExporter):
                 else:
                     try:
                         raw_value = line_data[fname][i]
-                        if field_type == 'str':
-                            value = TYPE_FUNC_MAP[field_type](
-                                raw_value, encoding="utf-8"
-                            )
-                        else:
-                            value = TYPE_FUNC_MAP[field_type](raw_value)
+                        value = TYPE_FUNC_MAP[field_type](raw_value)
                     except IndexError:
                         logger.debug("Error getting index %s from %s array", i, fname)
                         value = None

--- a/utils/gridadmin.py
+++ b/utils/gridadmin.py
@@ -358,7 +358,7 @@ class QgisLinesOgrExporter(BaseOgrExporter):
                         cont_type_raw_value = None
 
                     if cont_type_raw_value:
-                        if type(cont_type_raw_value) is np.bytes_:
+                        if field_type == 'str':
                             value = TYPE_FUNC_MAP[field_type](
                                 cont_type_raw_value, encoding="utf-8"
                             )
@@ -378,7 +378,7 @@ class QgisLinesOgrExporter(BaseOgrExporter):
                 else:
                     try:
                         raw_value = line_data[fname][i]
-                        if type(raw_value) is np.bytes_:
+                        if field_type == 'str':
                             value = TYPE_FUNC_MAP[field_type](
                                 raw_value, encoding="utf-8"
                             )


### PR DESCRIPTION
Resolves the error that results from opening 3Di Testbank simulation results:

`An error has occurred while executing Python code:

TypeError: to_string() got an unexpected keyword argument 'encoding' 

Traceback (most recent call last):
  File "C:/Users/leendert.vanwolfswin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ThreeDiToolbox\utils\layer_tree_manager.py", line 414, in add_results
    line, node, cell, pumpline = result.get_result_layers()
  File "C:/Users/leendert.vanwolfswin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ThreeDiToolbox\tool_result_selection\models.py", line 213, in get_result_layers
    progress_bar=progress_bar
  File "C:/Users/leendert.vanwolfswin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ThreeDiToolbox\tool_result_selection\models.py", line 130, in get_result_layers
    self.threedi_result, self.sqlite_gridadmin_filepath
  File "C:/Users/leendert.vanwolfswin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ThreeDiToolbox\datasource\spatialite.py", line 55, in wrapper
    retval = func(*args, **kwargs)
  File "C:/Users/leendert.vanwolfswin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ThreeDiToolbox\utils\layer_from_netCDF.py", line 56, in get_or_create_flowline_layer
    exporter.save(output_path, FLOWLINES_LAYER_NAME, sliced.data, 4326)
  File "C:/Users/leendert.vanwolfswin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ThreeDiToolbox\utils\gridadmin.py", line 383, in save
    raw_value, encoding="utf-8"
TypeError: to_string() got an unexpected keyword argument 'encoding'`