### PR TITLE
add migrate algorithm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ ThreeDiToolBox changelog
 
 - Add processing algorithm to migrate sqlite to newest schema
 
+- Add processing algorithm to check schematisation
 
 1.20 (2021-09-02)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,9 @@ ThreeDiToolBox changelog
 - Include info and warning level messages in schematisation checker results csv
 
 - Fix encoding error when reading gridadmin.h5
-  
+
+- Add processing algorithm to migrate sqlite to newest schema
+
 
 1.20 (2021-09-02)
 -----------------

--- a/processing/provider.py
+++ b/processing/provider.py
@@ -3,6 +3,7 @@ from qgis.core import QgsProcessingProvider
 from qgis.PyQt.QtGui import QIcon
 from ThreeDiToolbox.processing.dwf_calculation_algorithm import DWFCalculatorAlgorithm
 from ThreeDiToolbox.processing.threedidepth_algorithm import ThreediDepth
+from ThreeDiToolbox.processing.schematisation_algorithms import MigrateAlgorithm
 
 
 class ThreediProvider(QgsProcessingProvider):
@@ -11,8 +12,7 @@ class ThreediProvider(QgsProcessingProvider):
     def loadAlgorithms(self, *args, **kwargs):
         self.addAlgorithm(ThreediDepth())
         self.addAlgorithm(DWFCalculatorAlgorithm())
-        # add additional algorithms here
-        # self.addAlgorithm(MyOtherAlgorithm())
+        self.addAlgorithm(MigrateAlgorithm())
 
     def id(self, *args, **kwargs):
         """The ID of your plugin, used for identifying the provider.

--- a/processing/provider.py
+++ b/processing/provider.py
@@ -3,7 +3,10 @@ from qgis.core import QgsProcessingProvider
 from qgis.PyQt.QtGui import QIcon
 from ThreeDiToolbox.processing.dwf_calculation_algorithm import DWFCalculatorAlgorithm
 from ThreeDiToolbox.processing.threedidepth_algorithm import ThreediDepth
-from ThreeDiToolbox.processing.schematisation_algorithms import MigrateAlgorithm
+from ThreeDiToolbox.processing.schematisation_algorithms import (
+    CheckSchematisationAlgorithm,
+    MigrateAlgorithm
+)
 
 
 class ThreediProvider(QgsProcessingProvider):
@@ -12,6 +15,7 @@ class ThreediProvider(QgsProcessingProvider):
     def loadAlgorithms(self, *args, **kwargs):
         self.addAlgorithm(ThreediDepth())
         self.addAlgorithm(DWFCalculatorAlgorithm())
+        self.addAlgorithm(CheckSchematisationAlgorithm())
         self.addAlgorithm(MigrateAlgorithm())
 
     def id(self, *args, **kwargs):

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -11,31 +11,47 @@
 ***************************************************************************
 """
 
+import csv
 import os
 import shutil
 from uuid import uuid4
 
-# from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, DatabaseError
 from threedi_modelchecker.threedi_database import ThreediDatabase
-# from threedi_modelchecker.model_checks import ThreediModelChecker
+from threedi_modelchecker.model_checks import ThreediModelChecker
 from threedi_modelchecker.schema import ModelSchema
 from threedi_modelchecker import errors
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
+    QgsProject,
+    QgsVectorLayer,
     QgsProcessingAlgorithm,
-    QgsProcessingParameterFile
+    QgsProcessingParameterBoolean,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterFileDestination
 )
 
 
 def backup_sqlite(filename):
     """Make a backup of the sqlite database."""
-    backup_sqlite_path = None
     backup_folder = os.path.join(os.path.dirname(os.path.dirname(filename)), "_backup")
     os.makedirs(backup_folder, exist_ok=True)
     prefix = str(uuid4())[:8]
     backup_sqlite_path = os.path.join(backup_folder, f"{prefix}_{os.path.basename(filename)}")
     shutil.copyfile(filename, backup_sqlite_path)
     return backup_sqlite_path
+
+
+def get_threedi_database(filename, feedback):
+    try:
+        db_type = "spatialite"
+        db_settings = {"db_path": filename}
+        threedi_db = ThreediDatabase(db_settings, db_type=db_type)
+        threedi_db.check_connection()
+        return threedi_db
+    except (OperationalError, DatabaseError):
+        feedback.pushWarning("Invalid spatialite file")
+        return None
 
 
 class MigrateAlgorithm(QgsProcessingAlgorithm):
@@ -55,11 +71,10 @@ class MigrateAlgorithm(QgsProcessingAlgorithm):
         )
 
     def processAlgorithm(self, parameters, context, feedback):
-        success = False
         filename = self.parameterAsFile(parameters, self.INPUT, context)
-        db_type = "spatialite"
-        db_settings = {"db_path": filename}
-        threedi_db = ThreediDatabase(db_settings, db_type=db_type)
+        threedi_db = get_threedi_database(filename=filename, feedback=feedback)
+        if not threedi_db:
+            return {self.OUTPUT: None}
         schema = ModelSchema(threedi_db)
         try:
             schema.validate_schema()
@@ -109,3 +124,141 @@ class MigrateAlgorithm(QgsProcessingAlgorithm):
 
     def createInstance(self):
         return MigrateAlgorithm()
+
+
+class CheckSchematisationAlgorithm(QgsProcessingAlgorithm):
+    """
+    Run the schematisation checker
+    """
+    INPUT = 'INPUT'
+    OUTPUT = 'OUTPUT'
+    ADD_TO_PROJECT = 'ADD_TO_PROJECT'
+
+    def initAlgorithm(self, config):
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.INPUT,
+                self.tr('3Di Spatialite'),
+                extension="sqlite"
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                self.tr('Output'),
+                fileFilter="csv"
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.ADD_TO_PROJECT,
+                self.tr('Add result to project'),
+                defaultValue=True
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        self.add_to_project = self.parameterAsBoolean(parameters, self.ADD_TO_PROJECT, context)
+        self.output_file_path = None
+        input_filename = self.parameterAsFile(parameters, self.INPUT, context)
+        threedi_db = get_threedi_database(filename=input_filename, feedback=feedback)
+        if not threedi_db:
+            return {self.OUTPUT: None}
+        try:
+            model_checker = ThreediModelChecker(threedi_db)
+        except errors.MigrationMissingError:
+            feedback.pushWarning(
+                "The selected 3Di model does not have the latest migration. Please "
+                "migrate your model to the latest version."
+            )
+            return {self.OUTPUT: None}
+
+        generated_output_file_path = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
+        self.output_file_path = f"{os.path.splitext(generated_output_file_path)[0]}.csv"
+        session = model_checker.db.get_session()
+        total_checks = len(model_checker.config.checks)
+        progress_per_check = 100.0 / total_checks
+        checks_passed = 0
+        try:
+            with open(self.output_file_path, "w", newline="") as output_file:
+                writer = csv.writer(output_file)
+                writer.writerow(
+                    ["level", "error_code", "id", "table", "column", "value", "description"]
+                )
+                for i, check in enumerate(model_checker.checks(level="info")):
+                    model_errors = check.get_invalid(session)
+                    for error_row in model_errors:
+                        writer.writerow(
+                            [
+                                check.level.name,
+                                check.error_code,
+                                error_row.id,
+                                check.table.name,
+                                check.column.name,
+                                getattr(error_row, check.column.name),
+                                check.description(),
+                            ]
+                        )
+                    checks_passed += 1
+                    feedback.setProgress(int(checks_passed * progress_per_check))
+        except PermissionError:
+            # PermissionError happens for example when a user has the file already open
+            # with Excel on Windows, which locks the file.
+            feedback.pushWarning(
+                f"Not enough permissions to write the file '{self.output_file_path}'.\n\n"
+                "The file may be used by another program. Please close all "
+                "other programs using the file or select another output "
+                "file."
+            )
+            return {self.OUTPUT: None}
+
+        return {self.OUTPUT: self.output_file_path}
+
+    def postProcessAlgorithm(self, context, feedback):
+        if self.add_to_project:
+            if self.output_file_path:
+                result_layer = QgsVectorLayer(self.output_file_path, '3Di schematisation errors')
+                QgsProject.instance().addMapLayer(result_layer)
+        return {self.OUTPUT: self.output_file_path}
+
+    def name(self):
+        """
+        Returns the algorithm name, used for identifying the algorithm. This
+        string should be fixed for the algorithm, and must not be localised.
+        The name should be unique within each provider. Names should contain
+        lowercase alphanumeric characters only and no spaces or other
+        formatting characters.
+        """
+        return 'check_schematisation'
+
+    def displayName(self):
+        """
+        Returns the translated algorithm name, which should be used for any
+        user-visible display of the algorithm name.
+        """
+        return self.tr('Check Schematisation')
+
+    def group(self):
+        """
+        Returns the name of the group this algorithm belongs to. This string
+        should be localised.
+        """
+        return self.tr(self.groupId())
+
+    def groupId(self):
+        """
+        Returns the unique ID of the group this algorithm belongs to. This
+        string should be fixed for the algorithm, and must not be localised.
+        The group id should be unique within each provider. Group id should
+        contain lowercase alphanumeric characters only and no spaces or other
+        formatting characters.
+        """
+        return 'Schematisation'
+
+    def tr(self, string):
+        return QCoreApplication.translate('Processing', string)
+
+    def createInstance(self):
+        return CheckSchematisationAlgorithm()

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+import os
+import shutil
+from uuid import uuid4
+
+# from sqlalchemy.exc import OperationalError
+from threedi_modelchecker.threedi_database import ThreediDatabase
+# from threedi_modelchecker.model_checks import ThreediModelChecker
+from threedi_modelchecker.schema import ModelSchema
+from threedi_modelchecker import errors
+from qgis.PyQt.QtCore import QCoreApplication
+from qgis.core import (
+    QgsProcessingAlgorithm,
+    QgsProcessingParameterFile
+)
+
+
+def backup_sqlite(filename):
+    """Make a backup of the sqlite database."""
+    backup_sqlite_path = None
+    backup_folder = os.path.join(os.path.dirname(os.path.dirname(filename)), "_backup")
+    os.makedirs(backup_folder, exist_ok=True)
+    prefix = str(uuid4())[:8]
+    backup_sqlite_path = os.path.join(backup_folder, f"{prefix}_{os.path.basename(filename)}")
+    shutil.copyfile(filename, backup_sqlite_path)
+    return backup_sqlite_path
+
+
+class MigrateAlgorithm(QgsProcessingAlgorithm):
+    """
+    Migrate 3Di model schema to the current version
+    """
+    INPUT = 'INPUT'
+    OUTPUT = 'OUTPUT'
+
+    def initAlgorithm(self, config):
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.INPUT,
+                self.tr('3Di Spatialite'),
+                extension="sqlite"
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        success = False
+        filename = self.parameterAsFile(parameters, self.INPUT, context)
+        db_type = "spatialite"
+        db_settings = {"db_path": filename}
+        threedi_db = ThreediDatabase(db_settings, db_type=db_type)
+        schema = ModelSchema(threedi_db)
+        try:
+            schema.validate_schema()
+        except errors.MigrationMissingError:
+            backup_filepath = backup_sqlite(filename)
+            schema.upgrade(backup=False)
+            shutil.rmtree(os.path.dirname(backup_filepath))
+        success = True
+        return {self.OUTPUT: success}
+
+    def name(self):
+        """
+        Returns the algorithm name, used for identifying the algorithm. This
+        string should be fixed for the algorithm, and must not be localised.
+        The name should be unique within each provider. Names should contain
+        lowercase alphanumeric characters only and no spaces or other
+        formatting characters.
+        """
+        return 'migrate'
+
+    def displayName(self):
+        """
+        Returns the translated algorithm name, which should be used for any
+        user-visible display of the algorithm name.
+        """
+        return self.tr('Migrate Spatialite')
+
+    def group(self):
+        """
+        Returns the name of the group this algorithm belongs to. This string
+        should be localised.
+        """
+        return self.tr(self.groupId())
+
+    def groupId(self):
+        """
+        Returns the unique ID of the group this algorithm belongs to. This
+        string should be fixed for the algorithm, and must not be localised.
+        The group id should be unique within each provider. Group id should
+        contain lowercase alphanumeric characters only and no spaces or other
+        formatting characters.
+        """
+        return 'Schematisation'
+
+    def tr(self, string):
+        return QCoreApplication.translate('Processing', string)
+
+    def createInstance(self):
+        return MigrateAlgorithm()


### PR DESCRIPTION
If users do not have the ability to migrate their sqlites, they cannot use the schematisation checker anymore, so this PR adds an algorithm to the Processing toolbox to migrate spatialite to the newest schema. 

The algorithm can be found under 3Di > Schematisation > Migrate Spatialite
![image](https://user-images.githubusercontent.com/26224299/153402341-e0c6c236-ad40-4cd6-aa6e-c04c297a6585.png)
