### PR TITLE
Fix inp_id

### DIFF
--- a/utils/gridadmin.py
+++ b/utils/gridadmin.py
@@ -49,7 +49,7 @@ class QgisNodesOgrExporter(BaseOgrExporter):
 
     QGIS_NODE_FIELD_NAME_MAP = OrderedDict(
         [
-            ("inp_id", "seq_id"),
+            ("inp_id", "id"),
             ("spatialite_id", "content_pk"),
             ("feature_type", "node_type"),
             ("type", "node_type"),
@@ -263,7 +263,7 @@ class QgisLinesOgrExporter(BaseOgrExporter):
             ("type", "does not matter"),
             ("start_node_idx", "does not matter"),
             ("end_node_idx", "does not matter"),
-            ("inp_id", "lik"),
+            ("inp_id", "id"),
             ("content_type", "content_type"),
             ("spatialite_id", "content_pk"),
         ]


### PR DESCRIPTION
When loading the results_3di.nc, a large number of critical errors are raised (not shown directly to the user, but mentioned in the message log):
```
Error getting index 1716 from seq_id array
Traceback (most recent call last):
File "C:\Users/leendert.vanwolfswin/AppData/Roaming/QGIS/QGIS3\profiles\test 3Di Toolbox 20220523/python/plugins\ThreeDiToolbox\utils\gridadmin.py", line 165, in save
raw_value = node_data[fname][i]
IndexError: index 1716 is out of bounds for axis 0 with size 0
```

The inp_id field is a legacy thing (there used to be two different id systems in the stack). I left the field in there because I think removing it might cause some problems, and this part of the 3Di Toolbox will be deprecated soon anyway.

@ldebek please merge PR when convenient