### PR TITLE
Require exact version of threedi-modelchecker instead of minimum version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -5,7 +5,7 @@ lizard-connector==0.7.3
 pyqtgraph>=0.11.1,<0.12
 threedigrid>=1.2.3
 cached-property
-threedi-modelchecker>=0.28
+threedi-modelchecker==0.31
 threedidepth==0.4
 click>=8.0
 alembic==1.6.5

--- a/dependencies.py
+++ b/dependencies.py
@@ -48,7 +48,7 @@ DEPENDENCIES = [
     Dependency("pyqtgraph", "pyqtgraph", ">=0.11.1,<0.12"),
     Dependency("threedigrid", "threedigrid", ">=1.2.3"),
     Dependency("cached-property", "cached_property", ""),
-    Dependency("threedi-modelchecker", "threedi_modelchecker", ">=0.31"),
+    Dependency("threedi-modelchecker", "threedi_modelchecker", "==0.31"),
     Dependency("threedidepth", "threedidepth", "==0.4"),
     Dependency("click", "click", ">=8.0"),
     Dependency("alembic", "alembic", "==1.6.5"),


### PR DESCRIPTION
We do not want 3Di Toolbox to user higher versions of `threedi-modelchecker` than what we use during development, because newer versions may involve sqlite schema changes, which will often break stuff.

@benvanbasten-ns could you please check if this change is sufficient or should anything else be changed as well?