### PR TITLE
Snap results

### DIFF
--- a/threedi_plugin.py
+++ b/threedi_plugin.py
@@ -148,16 +148,14 @@ class ThreeDiPlugin(QObject, ProjectStateMixin):
 
         self.initProcessing()
 
+        # mapping anim tool
         self.map_animator = MapAnimator(self.dockwidget.get_tools_widget(), self.model)
-
         self.model.result_checked.connect(self.map_animator.results_changed)
         self.model.result_unchecked.connect(self.map_animator.results_changed)
+        iface.mapCanvas().temporalController().updateTemporalRange.connect(self.map_animator.update_results)
 
-        # start animating
-        tc = iface.mapCanvas().temporalController()
-        tc.updateTemporalRange.connect(self.map_animator.update_results)
-
-        self.model.result_added.connect(self.graph_tool.result_added)
+        # mapping graph tool
+        self.validator.result_validated.connect(self.graph_tool.result_added)
         self.model.result_removed.connect(self.graph_tool.result_removed)
         self.model.result_changed.connect(self.graph_tool.result_changed)
         self.model.grid_changed.connect(self.graph_tool.grid_changed)

--- a/threedi_plugin_model.py
+++ b/threedi_plugin_model.py
@@ -197,7 +197,7 @@ class ThreeDiPluginModel(QStandardItemModel):
         # Remove the actual grid
         return self.removeRows(self.indexFromItem(item).row(), 1)
 
-    def _remove_result(self, item: ThreeDiResultItem) -> bool:
+    def remove_result(self, item: ThreeDiResultItem) -> bool:
         """Removes a result from the model, emits result_removed"""
         grid_item = item.parent()
         assert isinstance(grid_item, ThreeDiGridItem)
@@ -215,7 +215,7 @@ class ThreeDiPluginModel(QStandardItemModel):
         if isinstance(item, ThreeDiGridItem):
             return self._remove_grid(item)
         if isinstance(item, ThreeDiResultItem):
-            return self._remove_result(item)
+            return self.remove_result(item)
 
     def get_results(self, checked_only: bool) -> List[ThreeDiResultItem]:
         """Returns the list of selected results (traversal)"""

--- a/threedi_plugin_model_validation.py
+++ b/threedi_plugin_model_validation.py
@@ -2,7 +2,7 @@ from qgis.PyQt.QtCore import QObject, pyqtSignal, pyqtSlot
 from qgis.PyQt.QtGui import QIcon
 from qgis.core import Qgis
 from ThreeDiToolbox.threedi_plugin_model import ThreeDiGridItem, ThreeDiResultItem
-from ThreeDiToolbox.utils.user_messages import messagebar_message
+from ThreeDiToolbox.utils.user_messages import messagebar_message, pop_up_critical
 from ThreeDiToolbox.utils.constants import TOOLBOX_MESSAGE_TITLE
 import h5py
 from osgeo import ogr
@@ -18,8 +18,8 @@ class ThreeDiPluginModelValidator(QObject):
     validation is completed, a signal with the validation result is emited
     so listeners can handle accordingly.
     """
-    grid_validated = pyqtSignal(ThreeDiGridItem, bool)
-    result_validated = pyqtSignal(ThreeDiResultItem, bool)
+    grid_validated = pyqtSignal(ThreeDiGridItem)
+    result_validated = pyqtSignal(ThreeDiResultItem)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -27,19 +27,17 @@ class ThreeDiPluginModelValidator(QObject):
     @pyqtSlot(ThreeDiGridItem)
     def validate_grid(self, item: ThreeDiGridItem):
         item.setIcon(QIcon(":images/themes/default/mIconSuccess.svg"))
-        self.grid_validated.emit(item, True)
+        self.grid_validated.emit(item)
 
     @pyqtSlot(ThreeDiResultItem)
-    def validate_result(self, item: ThreeDiResultItem):
-        item.setIcon(QIcon(":images/themes/default/mIndicatorBadLayer.svg"))
+    def validate_result(self, result_item: ThreeDiResultItem):
+        result_item.setIcon(QIcon(":images/themes/default/mIndicatorBadLayer.svg"))
 
         def fail(msg):
-            # logger.error(msg)
             messagebar_message(TOOLBOX_MESSAGE_TITLE, msg, Qgis.Warning, 5.0)
-            self.result_validated.emit(item, False)
 
         # Check correct file name
-        results_path = item.path
+        results_path = result_item.path
 
         if not results_path.name == "results_3di.nc":
             return fail("Unexpected file name for results file")
@@ -55,25 +53,8 @@ class ThreeDiPluginModelValidator(QObject):
                 )
             return fail("Results file cannot be opened.")
 
-        # Any modern enough calc core adds a 'threedicore_version' atribute
-        if "threedicore_version" not in results_h5.attrs:
-            return fail("Result file is too old, please recalculate.")
-
-        # Check whether corresponding grid item belongs to same model
-        result_model_slug = results_h5.attrs['model_slug'].decode()
-        grid_item = item.parent()
-        assert isinstance(grid_item, ThreeDiGridItem)
-        driver = ogr.GetDriverByName('GPKG')
-        package = driver.Open(str(grid_item.path), True)
-        grid_model_slug = package.GetMetadataItem('model_slug')
-
-        if grid_model_slug is None:
-            logger.warning("No model meta information in grid layer, skipping model validation.")
-        elif result_model_slug != grid_model_slug:
-            return fail("Result corresponds to different model than grid")
-
         # Try to open accompanying aggregate results file
-        aggregate_results_path = item.path.with_name("aggregate_results_3di.nc")
+        aggregate_results_path = result_item.path.with_name("aggregate_results_3di.nc")
         if aggregate_results_path.exists():
             try:
                 h5py.File(aggregate_results_path, "r")
@@ -86,5 +67,45 @@ class ThreeDiPluginModelValidator(QObject):
                     )
                 return fail("Aggregate results file cannot be opened.")
 
-        item.setIcon(QIcon(":images/themes/default/mIconSuccess.svg"))
-        self.result_validated.emit(item, True)
+        # Any modern enough calc core adds a 'threedicore_version' atribute
+        if "threedicore_version" not in results_h5.attrs:
+            return fail("Result file is too old, please recalculate.")
+
+        # Check whether corresponding grid item belongs to same model
+        result_model_slug = results_h5.attrs['model_slug'].decode()
+        grid_item = result_item.parent()
+        assert isinstance(grid_item, ThreeDiGridItem)
+        driver = ogr.GetDriverByName('GPKG')
+        package = driver.Open(str(grid_item.path), True)
+        grid_model_slug = package.GetMetadataItem('model_slug')
+
+        logger.info(f"Comparing grid slug {grid_model_slug} to result slug {result_model_slug}")
+
+        if result_model_slug is None or grid_model_slug is None:
+            msg = "No model meta information in result or grid, skipping slug validation."
+            messagebar_message(TOOLBOX_MESSAGE_TITLE, msg, Qgis.Warning, 5)
+        elif result_model_slug != grid_model_slug:
+
+            # Really wrong grid, find a grid with the right slug, if not available, abort with pop-up
+            root_node = result_item.model().invisibleRootItem()
+            for i in range(root_node.rowCount()):
+                other_grid_item = root_node.child(i)
+
+                package = ogr.GetDriverByName('GPKG').Open(str(other_grid_item.path), True)
+                other_grid_model_slug = package.GetMetadataItem('model_slug')
+
+                if result_model_slug == other_grid_model_slug:
+                    logger.info("Found other corresponding grid with slug {other_grid_model_slug}, moving result to that grid.")
+
+                    # Remove the result from the model and start the processing sequence all over
+                    new_results_args = {"input_result_nc": result_item.path, "parent_item": other_grid_item, "text": result_item.text()}
+                    result_item.model().remove_result(result_item)
+                    return other_grid_item.model().add_result(**new_results_args)
+
+            msg = "Result corresponds to different model than loaded grids, removed from Results Manager"
+            result_item.model().remove_result(result_item)
+            pop_up_critical(msg)
+            return fail(msg)
+
+        result_item.setIcon(QIcon(":images/themes/default/mIconSuccess.svg"))
+        self.result_validated.emit(result_item)


### PR DESCRIPTION
In case the slug of an added result doesn't match the slug of the selected grid (and both slugs are non-None), it checks for a grid whose slug does match. If so, it removes the result and readds it to the other grid.

In case no other grid is found, a messagebar appears and the result is removed from the model.

