### PR TITLE
Disable dialog without trouble on linux.

### DIFF
--- a/threedi_plugin.py
+++ b/threedi_plugin.py
@@ -188,14 +188,6 @@ class ThreeDiPlugin(QObject, ProjectStateMixin):
         self.model.grid_removed.connect(self.loader.unload_grid)
         self.model.result_removed.connect(self.loader.unload_result)
 
-        # When a grid or result is loaded (or was invalid), the grid/result dialog can be enabled again
-        self.model.grid_added.connect(self.dockwidget.dialog.enable)
-        self.model.result_added.connect(self.dockwidget.dialog.enable)
-        self.loader.result_not_loaded.connect(self.dockwidget.dialog.enable)
-        self.loader.grid_not_loaded.connect(self.dockwidget.dialog.enable)
-        self.validator.grid_invalid.connect(self.dockwidget.dialog.enable)
-        self.validator.result_invalid.connect(self.dockwidget.dialog.enable)
-
         self.init_state_sync()
 
         # Disable warning that scratch layer data will be lost


### PR DESCRIPTION
Hey, this works for me in linux, without the need for signals to re-enable the dialog after calling the func. But how does it work on windows?