### PR TITLE
Time series plotter: Allow adding groundwater nodes and lines easily

### DIFF
--- a/tool_graph/graph_view.py
+++ b/tool_graph/graph_view.py
@@ -1067,7 +1067,7 @@ class BaseAddMapTool(QgsMapToolIdentify):
             layerList=self.parent().layers(),
         )
         self.widget.add_results(
-            results=results, feature_type=self.feature_type, single_feature_per_layer=True
+            results=results, feature_type=self.feature_type, single_feature_per_layer=False
         )
 
 


### PR DESCRIPTION
In groundwater models, the surface water nodes/lines are at the same location as the groundwater nodes/lines. In the current implementation, only the first feature (i.e. the surface water feature) will be added to the plot. I changed this so that all features within a certain precision from the mouse are added to the plot.

However, if you zoom out very far and click on the map, it will freeze the Modeller Interface for quite a while and add loads of lines to your plot. I propose the following solution:

- If the number of items that are to added to the plot exceeds 10, do not add any and show the following message as a messagebar: "Please zoom in and try again. To add more than 10 items to the plot at once, use the 'Add all selected' option."