### PR TITLE
Revert "fetch column key instead of name when running the modelchecker"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ ThreeDiToolBox changelog
 2.5.6 (unreleased)
 ------------------
 
-- Fetch check.column.key when running the modelchecker so checks don't fail on models.Pumpstation.type.
+- Nothing changed yet.
 
 
 2.5.5 (2023-09-21)

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -211,7 +211,7 @@ class CheckSchematisationAlgorithm(QgsProcessingAlgorithm):
                                 error_row.id,
                                 check.table.name,
                                 check.column.name,
-                                getattr(error_row, check.column.key),
+                                getattr(error_row, check.column.name),
                                 check.description(),
                             ]
                         )


### PR DESCRIPTION
Reverts nens/ThreeDiToolbox#969
The code should be merged to refactor instead of master.