### PR TITLE
add upgrade progess

### DIFF
--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -49,7 +49,6 @@ def feedback_callback_factory(feedback):
     def feedback_callback(progres_value, message):
         feedback.setProgress(progres_value)
         feedback.setProgressText(message)
-        QCoreApplication.processEvents()
 
     return feedback_callback
 
@@ -99,9 +98,6 @@ class MigrateAlgorithm(QgsProcessingAlgorithm):
                 feedback_callback = feedback_callback_factory(feedback)
                 schema.upgrade(backup=False, upgrade_spatialite_version=True, epsg_code_override=srid,
                                progress_func=feedback_callback)
-                # TODO: somehow this is version 230 and not 300 which causes set_spatial_indexes to fail
-                print(schema.get_version())
-                print(schema.db.path)
                 schema.set_spatial_indexes()
                 shutil.rmtree(os.path.dirname(backup_filepath))
             except errors.UpgradeFailedError:

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -66,7 +66,7 @@ class MigrateAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.INPUT,
                 "3Di schematisation database",
-                fileFilter="Geopackage (*.gpkg);;Spatialite (*.sqlite)"
+                fileFilter="3Di schematisation database (*.gpkg *.sqlite)"
             )
         )
 


### PR DESCRIPTION
After the upgrade step the schema version is 230 instead of 300 which causes problems downstream.

```
QGIS version: 3.40.4-Bratislava
QGIS code revision: 4dd7d7e9691
Qt version: 5.15.3
Python version: 3.10.12
GDAL version: 3.4.1
GEOS version: 3.10.2-CAPI-1.16.0
PROJ version: Rel. 8.2.1, January 1st, 2022
PDAL version: 2.3.0 (git-version: Release)
Algorithm started at: 2025-03-27T07:35:44
Algorithm 'Migrate schematisation database' starting…
Input parameters:
{ 'INPUT' : '/testing/oosten.sqlite' }

Running upgrade 0219 -> 0220, rename vegetation columns
Running upgrade 0220 -> 0221, remove vegetation_drag_coeficients column
Running upgrade 0221 -> 0222, Upgrade settings in schema
Running upgrade 0222 -> 0223, Upgrade inflow settings
Running upgrade 0223 -> 0224, Upgrade structure control
Running upgrade 0224 -> 0225, Migrate 1d and 2d lateral and boundary condition tables to new schema
Running upgrade 0225 -> 0226, Upgrade 1d and 1d2d settings
Running upgrade 0226 -> 0227, Fixups for structure control upgrade
Running upgrade 0227 -> 0228, Upgrade 1d settings
Running upgrade 0228 -> 0229, Clean up some issues from migrations 222 to 228
Running upgrade 0229 -> 0230, Reproject geometries to model CRS
Running upgrade 0230 -> 0300, Convert to geopackage
Traceback (most recent call last):
File "/root/.local/share/QGIS/QGIS3/profiles/default/python/plugins/threedi_results_analysis/processing/schematisation_algorithms.py", line 80, in processAlgorithm
schema.validate_schema()
File "/root/.local/share/QGIS/QGIS3/profiles/default/python/plugins/threedi_schematisation_editor/deps/threedi_schema/application/schema.py", line 368, in validate_schema
raise MigrationMissingError(
threedi_schema.application.errors.MigrationMissingError: This tool requires at least schema version 300. Current version: 219.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/root/.local/share/QGIS/QGIS3/profiles/default/python/plugins/threedi_results_analysis/processing/schematisation_algorithms.py", line 104, in processAlgorithm
schema.set_spatial_indexes()
File "/root/.local/share/QGIS/QGIS3/profiles/default/python/plugins/threedi_schematisation_editor/deps/threedi_schema/application/schema.py", line 386, in set_spatial_indexes
raise MigrationMissingError(
threedi_schema.application.errors.MigrationMissingError: Setting views requires schema version 300. Current version: 230.

Execution failed after 15.06 seconds

Loading resulting layers
Algorithm 'Migrate schematisation database' finished
```

This problem is resolved by fixing https://github.com/nens/threedi-schema/issues/221; this needs a threedi-schema upgrade to get here.