### PR TITLE
Improve error handling schematisation checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 -----------------
 
 - Use randomly generated colour for timeseries plotter when list of colours runs out (#1111)
+- Fix issue where checks on a geometry column could not be processed by the schematisation checker (#1122)
 
 
 3.20 (2025-07-08)

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -301,9 +301,9 @@ class CheckSchematisationAlgorithm(QgsProcessingAlgorithm):
             for error in errors_group:
                 if feature_type != 'Table':
                     try:
-                        geom = wkb.loads(error.geom.data) 
+                        geom = wkb.loads(error.geom.data)
                         geom_wkb = ogr.CreateGeometryFromWkb(geom.wkb)
-                    except Exception (ValueError, TypeError):
+                    except (ValueError, TypeError):
                         # When wkb.loads fails due to malformed WKB data move error to Table errors
                         grouped_errors['Table'].append(error)
                         continue

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -266,7 +266,9 @@ class CheckSchematisationAlgorithm(QgsProcessingAlgorithm):
                 feature_type = geom.geom_type
             grouped_errors[feature_type].append(error)
         group_name_map = {'LineString': 'Line'}
-        for i, (feature_type, errors_group) in enumerate(grouped_errors.items()):
+        ordered_keys = ["Point", "LineString", "Polygon", "Table"]
+        for i, feature_type in enumerate(ordered_keys):
+            errors_group = grouped_errors[feature_type]
             group_name = f'{group_name_map.get(feature_type, feature_type)} features'
             feedback.pushInfo(f"Adding layer '{group_name}' to geopackage...")
             feedback.setProgress(85+5*i)
@@ -297,17 +299,28 @@ class CheckSchematisationAlgorithm(QgsProcessingAlgorithm):
 
             defn = layer.GetLayerDefn()
             for error in errors_group:
+                if feature_type != 'Table':
+                    try:
+                        geom = wkb.loads(error.geom.data) 
+                        geom_wkb = ogr.CreateGeometryFromWkb(geom.wkb)
+                    except Exception (ValueError, TypeError):
+                        # When wkb.loads fails due to malformed WKB data move error to Table errors
+                        grouped_errors['Table'].append(error)
+                        continue
                 feat = ogr.Feature(defn)
                 feat.SetField("level", error.name)
                 feat.SetField("error_code", error.code)
                 feat.SetField("id", error.id)
                 feat.SetField("table", error.table)
                 feat.SetField("column", error.column)
-                feat.SetField("value", error.value)
                 feat.SetField("description", error.description)
+                try:
+                    feat.SetField("value", error.value)
+                except NotImplementedError:
+                    # handle setting value if error.value cannot be processed for any reason
+                    pass
                 if feature_type != 'Table':
-                    geom = wkb.loads(error.geom.data)  # Convert WKB to a Shapely geometry object
-                    feat.SetGeometry(ogr.CreateGeometryFromWkb(geom.wkb))  # Convert back to OGR-compatible WKB
+                    feat.SetGeometry(geom_wkb)
                 layer.CreateFeature(feat)
         feedback.pushInfo("GeoPackage successfully written to file")
         return {self.OUTPUT: self.output_file_path}


### PR DESCRIPTION
Add try and except around handling `geom` and `data` attributes. When processing `geom` fails, the error is moved to the table group and processed later. Because this depends on processing order, I made the loop order explicit. When processing `data` fails the field remains empty.

I considered an generic try and except as well to handle other cases. But I can't imagine a case where the other attributes contain unexpected data.