### PR TITLE
Catch all gridbuilder errors

### DIFF
--- a/processing/grid_creation_algorithm.py
+++ b/processing/grid_creation_algorithm.py
@@ -109,8 +109,12 @@ class ThreeDiGenerateCompGridAlgorithm(QgsProcessingAlgorithm):
         logger.addHandler(ch)
         try:
             make_gridadmin(input_schematisation, set_dem_path, gridadmin_file, progress_callback=progress_rep)
-        except SchematisationError as e:
-            err = f"Creating grid file failed with the following error: {repr(e)}"
+        except Exception as e:
+            err = (
+                f"Creating grid file failed with the following error: {repr(e)}\n"
+                "This error is likely caused by errors in the schematisation.\n"
+                "Run the schematisation checker, correct any errors that are reported, and try again."
+            )
             raise QgsProcessingException(err)
         finally:
             # Pull the contents back into a string and close the stream


### PR DESCRIPTION
and report them to the user with instructions what to do about it

In processing algorithm "computational grid from schematisation"