### PR TITLE
Make error handling of error values generic to prevent crashes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 3.22 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Make handling of errors in processing values in the schematisation checker generic to prevent crashes on checks with unexpected values
 
 
 3.21 (2025-07-16)

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -316,9 +316,10 @@ class CheckSchematisationAlgorithm(QgsProcessingAlgorithm):
                 feat.SetField("description", error.description)
                 try:
                     feat.SetField("value", error.value)
-                except Exception:
-                    # handle setting value if error.value cannot be processed for any reason
+                except (NotImplementedError, TypeError):
                     pass
+                except Exception:
+                    feedback.pushWarning(f"Could not set value for check with code {error.code}")
                 if feature_type != 'Table':
                     feat.SetGeometry(geom_wkb)
                 layer.CreateFeature(feat)

--- a/processing/schematisation_algorithms.py
+++ b/processing/schematisation_algorithms.py
@@ -316,7 +316,7 @@ class CheckSchematisationAlgorithm(QgsProcessingAlgorithm):
                 feat.SetField("description", error.description)
                 try:
                     feat.SetField("value", error.value)
-                except NotImplementedError:
+                except Exception:
                     # handle setting value if error.value cannot be processed for any reason
                     pass
                 if feature_type != 'Table':


### PR DESCRIPTION
Note that when an error is raised, it is passed silently and the value field will not get an error. This prevents the crash and actually makes it easier to trace back the issue.