### PR TITLE
Fix for issue 1163

### DIFF
--- a/tool_watershed/watershed_analysis_dockwidget_base.ui
+++ b/tool_watershed/watershed_analysis_dockwidget_base.ui
@@ -334,10 +334,10 @@
            <string>Outputs</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
-           <item row="4" column="0" colspan="2">
-            <widget class="QPushButton" name="pushButtonClearResults">
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="checkBoxDownstream">
              <property name="text">
-              <string>Clear results</string>
+              <string>Downstream</string>
              </property>
             </widget>
            </item>
@@ -351,7 +351,24 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
+           <item row="5" column="0" colspan="2">
+            <widget class="QPushButton" name="pushButtonClearResults">
+             <property name="text">
+              <string>Clear results</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QCheckBox" name="checkBoxBrowseResultSets">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Browse result sets:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
             <widget class="QSpinBox" name="spinBoxBrowseResultSets">
              <property name="enabled">
               <bool>false</bool>
@@ -364,27 +381,20 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
-            <widget class="QCheckBox" name="checkBoxDownstream">
-             <property name="text">
-              <string>Downstream</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QCheckBox" name="checkBoxBrowseResultSets">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>Browse result sets:</string>
-             </property>
-            </widget>
-           </item>
            <item row="2" column="0">
             <widget class="QCheckBox" name="checkBoxSmoothing">
              <property name="text">
               <string>Smooth result watersheds</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QCheckBox" name="checkBoxShowMarkers">
+             <property name="text">
+              <string>Highlight analysed target nodes</string>
              </property>
              <property name="checked">
               <bool>true</bool>


### PR DESCRIPTION
- Bugfix: if multiple target nodes are used to create a result set, all of them are managed in self._result_markers. The bug was that only the last one of them was included, and therefore the others were not removed.
- Add a "Highlight analysed target nodes" option using `checkBoxShowMarkers` so users can switch the markers on and off