### PR TITLE
Progress bars colors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Rana Results Analysis changelog
 3.26.16 (unreleased)
 --------------------
 
-- Add progress bar colors: blue while running, green on completion (nens/rana#294)
+- Add progress bar colors: blue while running, green on completion (nens/rana-qgis-plugin#294)
 
 
 3.26.15 (2026-05-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Rana Results Analysis changelog
 3.26.16 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add progress bar colors: blue while running, green on completion (nens/rana#294)
 
 
 3.26.15 (2026-05-20)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ ENV PYTHONPATH=/usr/share/qgis/python/:/usr/share/qgis/python/plugins:/usr/lib/p
  
 # Install the test dependencies in a folder in python path
 # Retrieve constraints from dependency loader
-# TODO: change back to main!
-ADD https://raw.githubusercontent.com/nens/nens-dependency-loader/refs/heads/bump_deps/dependencies.py /root/dependencies.py
+ADD https://raw.githubusercontent.com/nens/nens-dependency-loader/refs/heads/main/dependencies.py /root/dependencies.py
 
 RUN python3 /root/dependencies.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ ENV PYTHONPATH=/usr/share/qgis/python/:/usr/share/qgis/python/plugins:/usr/lib/p
  
 # Install the test dependencies in a folder in python path
 # Retrieve constraints from dependency loader
-ADD https://raw.githubusercontent.com/nens/nens-dependency-loader/refs/heads/main/dependencies.py /root/dependencies.py
+# TODO: change back to main!
+ADD https://raw.githubusercontent.com/nens/nens-dependency-loader/refs/heads/bump_deps/dependencies.py /root/dependencies.py
+
 RUN python3 /root/dependencies.py
 
 RUN pip3 install -r /root/requirements-test.txt -c /root/constraints.txt --no-deps --upgrade --target /usr/share/qgis/python/plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV PYTHONPATH=/usr/share/qgis/python/:/usr/share/qgis/python/plugins:/usr/lib/p
 # Install the test dependencies in a folder in python path
 # Retrieve constraints from dependency loader
 ADD https://raw.githubusercontent.com/nens/nens-dependency-loader/refs/heads/main/dependencies.py /root/dependencies.py
-
 RUN python3 /root/dependencies.py
 
 RUN pip3 install -r /root/requirements-test.txt -c /root/constraints.txt --no-deps --upgrade --target /usr/share/qgis/python/plugins

--- a/tool_watershed/watershed_analysis_dockwidget.py
+++ b/tool_watershed/watershed_analysis_dockwidget.py
@@ -43,7 +43,7 @@ from threedi_results_analysis.utils.qprojects import set_read_only
 from threedi_results_analysis.utils.threedi_result_aggregation.threedigrid_ogr import (
     threedigrid_to_ogr,
 )
-from threedi_results_analysis.utils.user_messages import ColoredProgressBar
+from threedi_mi_utils.ui import ColoredProgressBar
 from threedi_schema import errors
 from threedi_schema import ThreediDatabase
 from threedigrid.admin.gridresultadmin import GridH5ResultAdmin

--- a/tool_watershed/watershed_analysis_dockwidget.py
+++ b/tool_watershed/watershed_analysis_dockwidget.py
@@ -43,6 +43,7 @@ from threedi_results_analysis.utils.qprojects import set_read_only
 from threedi_results_analysis.utils.threedi_result_aggregation.threedigrid_ogr import (
     threedigrid_to_ogr,
 )
+from threedi_results_analysis.utils.user_messages import ColoredProgressBar
 from threedi_schema import errors
 from threedi_schema import ThreediDatabase
 from threedigrid.admin.gridresultadmin import GridH5ResultAdmin
@@ -749,7 +750,7 @@ class Graph3DiQgsConnector:
 
     def upstream_downstream_analysis(self, target_node_ids: Iterable, upstream: bool, downstream: bool, smoothing: bool):
         progress_message_bar = self.iface.messageBar().createMessage("Watershed analysis is being performed...")
-        progress = QtWidgets.QProgressBar()
+        progress = ColoredProgressBar()
         current_progress = 0
         max_progress = 2
         if upstream:

--- a/utils/user_messages.py
+++ b/utils/user_messages.py
@@ -8,6 +8,46 @@ from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.PyQt.QtWidgets import QProgressBar
 from qgis.utils import iface
 
+from threedi_mi_utils.constants import (
+    PROGRESS_COLOR_FAILED,
+    PROGRESS_COLOR_FINISHED,
+    PROGRESS_COLOR_RUNNING,
+)
+
+
+class ColoredProgressBar(QProgressBar):
+    """QProgressBar that auto-colors based on progress: blue while running, green when complete."""
+
+    COLOR_RUNNING = PROGRESS_COLOR_RUNNING
+    COLOR_FINISHED = PROGRESS_COLOR_FINISHED
+    COLOR_FAILED = PROGRESS_COLOR_FAILED
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._update_color()
+
+    def setValue(self, value):
+        super().setValue(value)
+        self._update_color()
+
+    def setMaximum(self, maximum):
+        super().setMaximum(maximum)
+        self._update_color()
+
+    def set_failed(self):
+        """Set progress bar to failed (red) state."""
+        self.setStyleSheet(
+            f"QProgressBar::chunk {{ background-color: {self.COLOR_FAILED}; }}"
+            f"QProgressBar {{ background-color: {self.COLOR_FAILED}; }}"
+        )
+
+    def _update_color(self):
+        if self.maximum() > 0 and self.value() >= self.maximum():
+            color = self.COLOR_FINISHED
+        else:
+            color = self.COLOR_RUNNING
+        self.setStyleSheet(f"QProgressBar::chunk {{ background-color: {color}; }}")
+
 
 def pop_up_info(msg: str = "", title: str = "Information", parent=None):
     """Display an info message via Qt box"""
@@ -73,7 +113,7 @@ class StatusProgressBar(object):
         self.maximum = maximum
         self.message_bar = iface.messageBar().createMessage(message_title, "")
 
-        self.progress_bar = QProgressBar()
+        self.progress_bar = ColoredProgressBar()
         self.progress_bar.setMaximum(maximum)
         self.progress_bar.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
 
@@ -123,7 +163,7 @@ def progress_bar(iface, min_value=1, max_value=100):
     try:
         progressMessageBar = iface.messageBar()
 
-        _progress_bar = QProgressBar()
+        _progress_bar = ColoredProgressBar()
         # Maximum is set to 100, making it easy to work with
         # percentage of completion
         _progress_bar.setMinimum(min_value)

--- a/utils/user_messages.py
+++ b/utils/user_messages.py
@@ -5,7 +5,6 @@ from qgis.core import Qgis
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QApplication
 from qgis.PyQt.QtWidgets import QMessageBox
-from qgis.PyQt.QtWidgets import QProgressBar
 from qgis.utils import iface
 from threedi_mi_utils.ui import ColoredProgressBar
 

--- a/utils/user_messages.py
+++ b/utils/user_messages.py
@@ -7,46 +7,7 @@ from qgis.PyQt.QtWidgets import QApplication
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.PyQt.QtWidgets import QProgressBar
 from qgis.utils import iface
-
-from threedi_mi_utils.constants import (
-    PROGRESS_COLOR_FAILED,
-    PROGRESS_COLOR_FINISHED,
-    PROGRESS_COLOR_RUNNING,
-)
-
-
-class ColoredProgressBar(QProgressBar):
-    """QProgressBar that auto-colors based on progress: blue while running, green when complete."""
-
-    COLOR_RUNNING = PROGRESS_COLOR_RUNNING
-    COLOR_FINISHED = PROGRESS_COLOR_FINISHED
-    COLOR_FAILED = PROGRESS_COLOR_FAILED
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._update_color()
-
-    def setValue(self, value):
-        super().setValue(value)
-        self._update_color()
-
-    def setMaximum(self, maximum):
-        super().setMaximum(maximum)
-        self._update_color()
-
-    def set_failed(self):
-        """Set progress bar to failed (red) state."""
-        self.setStyleSheet(
-            f"QProgressBar::chunk {{ background-color: {self.COLOR_FAILED}; }}"
-            f"QProgressBar {{ background-color: {self.COLOR_FAILED}; }}"
-        )
-
-    def _update_color(self):
-        if self.maximum() > 0 and self.value() >= self.maximum():
-            color = self.COLOR_FINISHED
-        else:
-            color = self.COLOR_RUNNING
-        self.setStyleSheet(f"QProgressBar::chunk {{ background-color: {color}; }}")
+from threedi_mi_utils.ui import ColoredProgressBar
 
 
 def pop_up_info(msg: str = "", title: str = "Information", parent=None):


### PR DESCRIPTION
Add colored progress bars using shared constants from threedi-mi-utils

- Blue (#69A0C9) while running
- Green (#4BDC7E) on completion

Adds `ColoredProgressBar` class to `utils/user_messages.py` (same pattern as rana-qgis-plugin and threedi-schematisation-editor). Applied to:
- `StatusProgressBar` class (used in 5 locations: GPKG generation, layer loading, layer styling, water balance)
- `progress_bar` context manager
- Watershed analysis manual progress bar

All progress bars now consistently show blue while running and turn green when complete.

