### PR TITLE
Load Waterdepth raster on result add

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -146,3 +146,7 @@ class TestResult(unittest.TestCase):
     def test_parent_should_be_provided(self):
         item = ThreeDiResultItem(self.result_path, "text")
         self.assertFalse(self.model.add_result(item, None))
+
+    def test_result_item_has_waterdepth_layer_id(self):
+        item = ThreeDiResultItem(self.result_path)
+        self.assertIsNone(item.waterdepth_layer_id)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -146,7 +146,3 @@ class TestResult(unittest.TestCase):
     def test_parent_should_be_provided(self):
         item = ThreeDiResultItem(self.result_path, "text")
         self.assertFalse(self.model.add_result(item, None))
-
-    def test_result_item_has_waterdepth_layer_id(self):
-        item = ThreeDiResultItem(self.result_path)
-        self.assertIsNone(item.waterdepth_layer_id)

--- a/threedi_plugin.py
+++ b/threedi_plugin.py
@@ -144,6 +144,7 @@ class ThreeDiPlugin(QObject, ProjectStateMixin):
         self.validator.grid_valid.connect(self.loader.load_grid)
         self.loader.grid_loaded.connect(self.model.add_grid)
         self.loader.result_loaded.connect(self.model.add_result)
+        self.model.result_added.connect(self.loader.load_waterdepth)
 
         self.model.grid_added.connect(self.dockwidget.expand_grid)
 
@@ -232,6 +233,7 @@ class ThreeDiPlugin(QObject, ProjectStateMixin):
 
         self.model.grid_removed.connect(self.loader.unload_grid)
         self.model.result_removed.connect(self.loader.unload_result)
+        self.model.result_removed.connect(self.loader.unload_waterdepth)
 
         self.init_state_sync()
 

--- a/threedi_plugin_layer_manager.py
+++ b/threedi_plugin_layer_manager.py
@@ -216,9 +216,10 @@ class ThreeDiPluginLayerManager(QObject):
         if not tif_path.exists():
             return
 
-        # Skip if this raster is already loaded in the project
+        # Skip if this raster is already loaded in the project (e.g. restored from project file)
         for layer in QgsProject.instance().mapLayers().values():
             if layer.source() == str(tif_path):
+                layer.setFlags(QgsMapLayer.LayerFlag.Searchable | QgsMapLayer.LayerFlag.Identifiable)
                 result_item.waterdepth_layer_id = layer.id()
                 return
 
@@ -237,6 +238,7 @@ class ThreeDiPluginLayerManager(QObject):
             logger.warning(f"Waterdepth raster layer is not valid: {tif_path}")
             return
 
+        raster_layer.setFlags(QgsMapLayer.LayerFlag.Searchable | QgsMapLayer.LayerFlag.Identifiable)
         QgsProject.instance().addMapLayer(raster_layer, addToLegend=False)
 
         waterdepth_group = grid_item.layer_group.findGroup(WATERDEPTH_GROUP_NAME)

--- a/threedi_plugin_layer_manager.py
+++ b/threedi_plugin_layer_manager.py
@@ -8,7 +8,7 @@ import uuid
 from qgis.PyQt.QtCore import Qt
 from threedigrid.admin.exporters.geopackage import GeopackageExporter
 from qgis.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal, QVariant
-from qgis.core import QgsVectorLayer, QgsRasterLayer, QgsProject, QgsMapLayer, QgsField, QgsWkbTypes, QgsLayerTreeNode
+from qgis.core import QgsVectorLayer, QgsRasterLayer, QgsProject, QgsMapLayer, QgsField, QgsWkbTypes, QgsLayerTreeNode, QgsLayerTreeGroup
 from threedi_results_analysis.threedi_plugin_model import ThreeDiGridItem, ThreeDiResultItem
 from threedi_results_analysis.utils.constants import TOOLBOX_QGIS_GROUP_NAME, TOOLBOX_MESSAGE_TITLE
 from threedi_results_analysis.utils.user_messages import StatusProgressBar, messagebar_message, pop_up_critical
@@ -120,6 +120,8 @@ class ThreeDiPluginLayerManager(QObject):
             pop_up_critical("Failed adding the layers to the project.")
             self.grid_not_loaded.emit(grid_item)
             return False
+
+        grid_item.project = project
 
         messagebar_message(TOOLBOX_MESSAGE_TITLE, "Added layers to the project", duration=2)
 
@@ -256,12 +258,14 @@ class ThreeDiPluginLayerManager(QObject):
             return
 
         layer = QgsProject.instance().mapLayer(result_item.waterdepth_layer_id)
-        if layer is not None:
-            QgsProject.instance().removeMapLayer(result_item.waterdepth_layer_id)
-
         result_item.waterdepth_layer_id = None
 
-        # Clean up the Waterdepth group if it is now empty
+        if layer is None:
+            return
+
+        # Remove via the layer tree node directly. This both removes the node
+        # from the group and unregisters the layer from the project synchronously,
+        # avoiding timing issues with QgsLayerTreeRegistryBridge.
         grid_item = result_item.parent()
         if not isinstance(grid_item, ThreeDiGridItem):
             return
@@ -269,8 +273,11 @@ class ThreeDiPluginLayerManager(QObject):
             return
 
         waterdepth_group = grid_item.layer_group.findGroup(WATERDEPTH_GROUP_NAME)
-        if waterdepth_group and len(waterdepth_group.children()) == 0:
-            grid_item.layer_group.removeChildNode(waterdepth_group)
+        if waterdepth_group:
+            layer.setFlags(layer.flags() | QgsMapLayer.LayerFlag.Removable)
+            waterdepth_group.removeLayer(layer)
+            if len(waterdepth_group.children()) == 0:
+                grid_item.layer_group.removeChildNode(waterdepth_group)
 
         iface.mapCanvas().refresh()
 
@@ -485,8 +492,14 @@ class ThreeDiPluginLayerManager(QObject):
     @staticmethod
     def _get_or_create_group(group_name: str):
         root = QgsProject.instance().layerTreeRoot()
-        root_group = root.findGroup(TOOLBOX_QGIS_GROUP_NAME)
-        if not root_group or root_group not in root.children():
+        # Use a direct children search (not recursive) to avoid accidentally matching
+        # a same-named group that is nested under a project folder (e.g. from rana-qgis-plugin).
+        root_group = next(
+            (child for child in root.children()
+             if isinstance(child, QgsLayerTreeGroup) and child.name() == TOOLBOX_QGIS_GROUP_NAME),
+            None
+        )
+        if not root_group:
             root_group = root.insertGroup(0, TOOLBOX_QGIS_GROUP_NAME)
 
         layer_group = root_group.findGroup(group_name)

--- a/threedi_plugin_layer_manager.py
+++ b/threedi_plugin_layer_manager.py
@@ -212,6 +212,9 @@ class ThreeDiPluginLayerManager(QObject):
     def load_waterdepth(self, result_item: ThreeDiResultItem) -> None:
         """If max_waterdepth.tif exists in the result folder, load it into a
         'Waterdepth' group inside the grid's layer group."""
+        if result_item.waterdepth_layer_id:
+            return
+
         tif_path = result_item.path.parent / "max_waterdepth.tif"
         if not tif_path.exists():
             return

--- a/threedi_plugin_layer_manager.py
+++ b/threedi_plugin_layer_manager.py
@@ -208,12 +208,17 @@ class ThreeDiPluginLayerManager(QObject):
         self.result_loaded.emit(threedi_result_item, grid_item)
         return True
 
-    @pyqtSlot(ThreeDiResultItem, ThreeDiGridItem)
-    def load_waterdepth(self, result_item: ThreeDiResultItem, grid_item: ThreeDiGridItem) -> None:
+    @pyqtSlot(ThreeDiResultItem)
+    def load_waterdepth(self, result_item: ThreeDiResultItem) -> None:
         """If max_waterdepth.tif exists in the result folder, load it into a
         'Waterdepth' group inside the grid's layer group."""
         tif_path = result_item.path.parent / "max_waterdepth.tif"
         if not tif_path.exists():
+            return
+
+        grid_item = result_item.parent()
+        if not isinstance(grid_item, ThreeDiGridItem):
+            logger.warning("Cannot load waterdepth: result item has no grid parent")
             return
 
         if not grid_item.layer_group:

--- a/threedi_plugin_layer_manager.py
+++ b/threedi_plugin_layer_manager.py
@@ -212,12 +212,15 @@ class ThreeDiPluginLayerManager(QObject):
     def load_waterdepth(self, result_item: ThreeDiResultItem) -> None:
         """If max_waterdepth.tif exists in the result folder, load it into a
         'Waterdepth' group inside the grid's layer group."""
-        if result_item.waterdepth_layer_id:
-            return
-
         tif_path = result_item.path.parent / "max_waterdepth.tif"
         if not tif_path.exists():
             return
+
+        # Skip if this raster is already loaded in the project
+        for layer in QgsProject.instance().mapLayers().values():
+            if layer.source() == str(tif_path):
+                result_item.waterdepth_layer_id = layer.id()
+                return
 
         grid_item = result_item.parent()
         if not isinstance(grid_item, ThreeDiGridItem):

--- a/threedi_plugin_layer_manager.py
+++ b/threedi_plugin_layer_manager.py
@@ -8,7 +8,7 @@ import uuid
 from qgis.PyQt.QtCore import Qt
 from threedigrid.admin.exporters.geopackage import GeopackageExporter
 from qgis.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal, QVariant
-from qgis.core import QgsVectorLayer, QgsProject, QgsMapLayer, QgsField, QgsWkbTypes, QgsLayerTreeNode
+from qgis.core import QgsVectorLayer, QgsRasterLayer, QgsProject, QgsMapLayer, QgsField, QgsWkbTypes, QgsLayerTreeNode
 from threedi_results_analysis.threedi_plugin_model import ThreeDiGridItem, ThreeDiResultItem
 from threedi_results_analysis.utils.constants import TOOLBOX_QGIS_GROUP_NAME, TOOLBOX_MESSAGE_TITLE
 from threedi_results_analysis.utils.user_messages import StatusProgressBar, messagebar_message, pop_up_critical
@@ -21,6 +21,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 GRID_GROUP_NAME = "Computational grid"
+WATERDEPTH_GROUP_NAME = "Waterdepth"
 
 
 def dirty(func):
@@ -206,6 +207,58 @@ class ThreeDiPluginLayerManager(QObject):
 
         self.result_loaded.emit(threedi_result_item, grid_item)
         return True
+
+    @pyqtSlot(ThreeDiResultItem, ThreeDiGridItem)
+    def load_waterdepth(self, result_item: ThreeDiResultItem, grid_item: ThreeDiGridItem) -> None:
+        """If max_waterdepth.tif exists in the result folder, load it into a
+        'Waterdepth' group inside the grid's layer group."""
+        tif_path = result_item.path.parent / "max_waterdepth.tif"
+        if not tif_path.exists():
+            return
+
+        if not grid_item.layer_group:
+            logger.warning("Cannot load waterdepth: grid has no layer group")
+            return
+
+        raster_layer = QgsRasterLayer(str(tif_path), tif_path.stem)
+        if not raster_layer.isValid():
+            logger.warning(f"Waterdepth raster layer is not valid: {tif_path}")
+            return
+
+        QgsProject.instance().addMapLayer(raster_layer, addToLegend=False)
+
+        waterdepth_group = grid_item.layer_group.findGroup(WATERDEPTH_GROUP_NAME)
+        if not waterdepth_group:
+            waterdepth_group = grid_item.layer_group.insertGroup(1, WATERDEPTH_GROUP_NAME)
+
+        waterdepth_group.addLayer(raster_layer)
+        result_item.waterdepth_layer_id = raster_layer.id()
+        logger.info(f"Loaded waterdepth layer: {tif_path}")
+
+    @pyqtSlot(ThreeDiResultItem)
+    def unload_waterdepth(self, result_item: ThreeDiResultItem) -> None:
+        """Remove the waterdepth raster layer (if any) for this result."""
+        if not result_item.waterdepth_layer_id:
+            return
+
+        layer = QgsProject.instance().mapLayer(result_item.waterdepth_layer_id)
+        if layer is not None:
+            QgsProject.instance().removeMapLayer(result_item.waterdepth_layer_id)
+
+        result_item.waterdepth_layer_id = None
+
+        # Clean up the Waterdepth group if it is now empty
+        grid_item = result_item.parent()
+        if not isinstance(grid_item, ThreeDiGridItem):
+            return
+        if not grid_item.layer_group:
+            return
+
+        waterdepth_group = grid_item.layer_group.findGroup(WATERDEPTH_GROUP_NAME)
+        if waterdepth_group and len(waterdepth_group.children()) == 0:
+            grid_item.layer_group.removeChildNode(waterdepth_group)
+
+        iface.mapCanvas().refresh()
 
     @pyqtSlot(ThreeDiResultItem)
     def unload_result(self, threedi_result_item: ThreeDiResultItem) -> bool:

--- a/threedi_plugin_layer_manager.py
+++ b/threedi_plugin_layer_manager.py
@@ -231,7 +231,8 @@ class ThreeDiPluginLayerManager(QObject):
             logger.warning("Cannot load waterdepth: grid has no layer group")
             return
 
-        raster_layer = QgsRasterLayer(str(tif_path), tif_path.stem)
+        sim_name = result_item.text() or tif_path.parent.stem
+        raster_layer = QgsRasterLayer(str(tif_path), f"max wd {sim_name}")
         if not raster_layer.isValid():
             logger.warning(f"Waterdepth raster layer is not valid: {tif_path}")
             return

--- a/threedi_plugin_model.py
+++ b/threedi_plugin_model.py
@@ -94,6 +94,9 @@ class ThreeDiResultItem(ThreeDiModelItem):
 
         self._timedelta = None
 
+        # Layer ID of the optional max_waterdepth.tif raster layer
+        self.waterdepth_layer_id = None
+
     @cached_property
     def threedi_result(self):
         # ThreediResult is a wrapper around a theedigrid's

--- a/threedi_plugin_model.py
+++ b/threedi_plugin_model.py
@@ -8,7 +8,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QStandardItem
 from qgis.PyQt.QtGui import QStandardItemModel
 from threedi_results_analysis.datasource.threedi_results import ThreediResult
-from typing import List
+from typing import List, Optional
 
 import logging
 import uuid
@@ -64,6 +64,9 @@ class ThreeDiGridItem(ThreeDiModelItem):
 
         # layer info
         self.layer_group = None
+
+        # project name used when the grid was loaded via an external plugin (e.g. rana-qgis-plugin)
+        self.project: Optional[str] = None
 
 
 class ThreeDiResultItem(ThreeDiModelItem):

--- a/threedi_plugin_model_serialization.py
+++ b/threedi_plugin_model_serialization.py
@@ -77,7 +77,8 @@ class ThreeDiPluginModelSerializer:
                         label_node = layer_nodes.at(i).toElement()
                         model_node.layer_ids[label_node.attribute("table_name")] = label_node.attribute("id")
 
-                    if not loader.load_grid(model_node):
+                    project = xml_element_node.attribute("project") or None
+                    if not loader.load_grid(model_node, project):
                         return False
 
                 elif tag_name == "result":
@@ -161,6 +162,8 @@ class ThreeDiPluginModelSerializer:
                     xml_node.setAttribute("path", resolver.writePath(str(model_node.path)))
                     xml_node.setAttribute("text", model_node.text())
                     xml_node.setAttribute("id", model_node.id)
+                    if model_node.project:
+                        xml_node.setAttribute("project", model_node.project)
 
                     # Write corresponding layer id's
                     for table_name, layer_id in model_node.layer_ids.items():


### PR DESCRIPTION
Loads max_waterdepth.tif into a 'Waterdepth' layer group when a result is added. Implemented by connecting model.result_added → loader.load_waterdepth; the loader creates a QgsRasterLayer for max_waterdepth.tif, places it in a 'Waterdepth' group next to 'Computational grid', and records the layer id on the result item for cleanup. On result removal the raster is removed and empty group cleaned up.

Closes nens/rana#4349